### PR TITLE
Add waggon -> wagon

### DIFF
--- a/modernize-spelling
+++ b/modernize-spelling
@@ -160,6 +160,7 @@ def modernize_spelling(xhtml, language):
 	xhtml = regex.sub(r"\bIncase", r"Encase", xhtml)				# incase -> encase
 	xhtml = regex.sub(r"\bincase", r"encase", xhtml)				# incase -> encase
 	xhtml = regex.sub(r"\b([Cc])ocoanut", r"\1oconut", xhtml)			# cocoanut -> coconut
+	xhtml = regex.sub(r"\b([Ww])aggon", r"\1agon", xhtml)			# waggon -> wagon
 
 	if language == "en-US":
 		xhtml = regex.sub(r"\b([Cc])osey", r"\1ozy", xhtml)


### PR DESCRIPTION
‘waggon’ [listed as ‘dated’ on wiktionary](https://en.wiktionary.org/wiki/waggon), and feels wrong to me. Came up a couple of times in Gogol’s Dead Souls.