### PR TITLE
Fix META-INF directory creation

### DIFF
--- a/create-draft
+++ b/create-draft
@@ -120,7 +120,7 @@ mkdir -p "${repoName}/src/epub/css"
 mkdir -p "${repoName}/src/epub/images"
 mkdir -p "${repoName}/src/epub/text"
 
-cp -r "${scriptDir}/templates/META-INF/" "${repoName}/src/"
+cp -r "${scriptDir}/templates/META-INF" "${repoName}/src/"
 cp "${scriptDir}/templates/mimetype" "${repoName}/src/"
 cp "${scriptDir}/templates/onix.xml" "${repoName}/src/epub/"
 cp "${scriptDir}/templates/toc.xhtml" "${repoName}/src/epub/"


### PR DESCRIPTION
On macOS at least leaving the trailing slash on the `META-INF` directory causes it to not be created; `container.xml` is then dropped into the parent. Removing the trailing slash fixes it.

Not tested on Linux, so will need double-checking before a merge.