### PR TITLE
Add lacquey -> lackey

### DIFF
--- a/modernize-spelling
+++ b/modernize-spelling
@@ -162,6 +162,7 @@ def modernize_spelling(xhtml, language):
 	xhtml = regex.sub(r"\bincase", r"encase", xhtml)				# incase -> encase
 	xhtml = regex.sub(r"\b([Cc])ocoanut", r"\1oconut", xhtml)			# cocoanut -> coconut
 	xhtml = regex.sub(r"\b([Ww])aggon", r"\1agon", xhtml)			# waggon -> wagon
+	xhtml = regex.sub(r"\b([Ll])acquey", r"\1ackey", xhtml)			# lacquey -> lackey
 
 	if language == "en-US":
 		xhtml = regex.sub(r"\b([Cc])osey", r"\1ozy", xhtml)


### PR DESCRIPTION
Google ngram shows this as pretty much dead: https://books.google.com/ngrams/graph?content=lackey%2Clacquey&year_start=1800&year_end=2000&corpus=6&smoothing=3&share=&direct_url=t1%3B%2Clackey%3B%2Cc0%3B.t1%3B%2Clacquey%3B%2Cc0 . There’s a few uses throughout the current corpus: https://github.com/search?q=org%3Astandardebooks+lacquey&type=Code