### PR TITLE
ebook-convert failed message

### DIFF
--- a/build
+++ b/build
@@ -379,5 +379,10 @@ do
 				printf " OK\n"
 			fi
 		fi
+		else
+			if [ "${verbose}" = "true" ]; then
+				printf " ebook-convert failed\n"
+			fi
+		fi
 	fi
 done


### PR DESCRIPTION
Show a message if `ebook-convert` fails in verbose mode. Otherwise, the command prompt is appended to the end of the *Building %s ..." "${kindleOutputFilename}"* line.