### PR TITLE
Update brew instructions for inkscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ These instructions were tested on Mac OS X 10.12. Your mileage may vary.
 3. Install [Java JDK 1.7 or later](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 4. Install the required homebrew packages
 
-       brew install python3 gnu-sed xmlstarlet imagemagick librsvg epubcheck inkscape
+       brew tap caskroom/cask
+       brew cask install xquartz inkscape
+       brew install python3 gnu-sed xmlstarlet imagemagick librsvg epubcheck
 
 5. Install the required python packages:
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ These instructions were tested on Mac OS X 10.12. Your mileage may vary.
 3. Install [Java JDK 1.7 or later](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 4. Install the required homebrew packages
 
-       brew tap caskroom/cask
-       brew cask install xquartz inkscape
-       brew install python3 gnu-sed xmlstarlet imagemagick librsvg epubcheck
+       brew install python3 gnu-sed xmlstarlet imagemagick librsvg epubcheck caskformula/caskformula/inkscape
 
 5. Install the required python packages:
 


### PR DESCRIPTION
In order to use brew to install inkscape, I had to do `brew tap caskroom/cask` and `brew cask install xquartz inkscape`. This was under macOS 10.12.5.