### PR TITLE
Lint was choking on .DS_Store file (created by macOS Finder) and .epu…

### DIFF
--- a/se/__init__.py
+++ b/se/__init__.py
@@ -12,7 +12,7 @@ IGNORED_FILENAMES = ["colophon.xhtml", "titlepage.xhtml", "imprint.xhtml", "unco
 XHTML_NAMESPACES = {"xhtml": "http://www.w3.org/1999/xhtml", "epub": "http://www.idpf.org/2007/ops", "z3998": "http://www.daisy.org/z3998/2012/vocab/structure/", "se": "https://standardebooks.org/vocab/1.0", "dc": "http://purl.org/dc/elements/1.1/", "opf": "http://www.idpf.org/2007/opf"}
 FRONTMATTER_FILENAMES = ["dedication.xhtml", "introduction.xhtml", "preface.xhtml", "prologue.xhtml", "foreword.xhtml", "preamble.xhtml", "titlepage.xhtml", "halftitlepage.xhtml", "imprint.xhtml"]
 BACKMATTER_FILENAMES = ["endnotes.xhtml", "loi.xhtml", "epilogue.xhtml", "afterword.xhtml", "appendix.xhtml", "colophon.xhtml", "uncopyright.xhtml"]
-BINARY_EXTENSIONS = [".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".png"]
+BINARY_EXTENSIONS = [".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".png", ".epub", ".epub3", ".DS_Store"]
 
 
 def print_error(message, verbose=False):

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -169,7 +169,12 @@ class SeEpub:
 					continue
 
 				with open(os.path.join(root, filename), "r", encoding="utf-8") as file:
-					file_contents = file.read()
+					try:
+						file_contents = file.read()
+					except UnicodeDecodeError as e:
+						# This is more to help developers find weird files that might choke 'lint', hopefully unnecessary for end users
+						print('Problem decoding file as utf-8: ', filename)
+						raise e
 
 					if "UTF-8" in file_contents:
 						messages.append("String \"UTF-8\" must always be lowercase. File: {}".format(filename))


### PR DESCRIPTION
Lint was crashing when it could not decode certain binary files as UTF-8. Catch this exception and print the filename (in case we find more such files). Skip .epub, .epub3, and .DS_Store files so lint can do its work, unhindered by common files.