### PR TITLE
Update semanticate

### DIFF
--- a/semanticate
+++ b/semanticate
@@ -56,6 +56,7 @@ def main():
 				processed_xhtml = regex.sub(r"(?<!\<abbr\>)Messrs\.", r"<abbr>Messrs.</abbr>", processed_xhtml)
 				processed_xhtml = regex.sub(r"(?<!\<abbr\>)Messers\.", r"<abbr>Messers.</abbr>", processed_xhtml)
 				processed_xhtml = regex.sub(r"(?<!\<abbr\>)P\.S\.", r"<abbr>P.S.</abbr>", processed_xhtml)
+				processed_xhtml = regex.sub(r"(?<!\<abbr\>)(?<!.)[Oo]p\.\s{1,2}[Cc]it\.", r"<abbr>Op. Cit.</abbr>", processed_xhtml)
 				processed_xhtml = regex.sub(r"(?<!\<abbr\>)Co\.", r"<abbr>Co.</abbr>", processed_xhtml)
 				processed_xhtml = regex.sub(r"(?<!\<abbr\>)Inc\.", r"<abbr>Inc.</abbr>", processed_xhtml)
 				processed_xhtml = regex.sub(r"(?<!\<abbr\>)Ltd\.", r"<abbr>Ltd.</abbr>", processed_xhtml)


### PR DESCRIPTION
This is abbreviation regex for "Op. Cit"  - opere citato - 'in the work cited'.

This captures the following possible permutations - I also included both one and two spaces-after-a-full-point varieties:

Op. Cit.
Op. cit.
op. Cit.
op. cit.
Op.  Cit.
Op.  cit.
op.  Cit.
op.  cit.

The regex ignores the following:
<abbr>Op. Cit.</abbr>
<abbr>Op. cit.</abbr>
<abbr>op. Cit.</abbr>
<abbr>op. cit.</abbr>
<abbr>Op.</abbr>
<abbr>op.</abbr>
Op.
op.
scoop. tacit.
scoop.  tacit.
scoop. cit.
scoop.  cit.

Tested using https://regex101.com/ (thanks Mr Cabal).