### PR TITLE
Lint for headings in text that aren’t in the ToC

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -815,7 +815,8 @@ class SeEpub:
 			toc_entries = BeautifulSoup(toc.read(), "lxml").find_all('a')
 			# ToC headers have a ‘:’ after the chapter number that main headings don’t
 			for index, entry in enumerate(toc_entries):
-				toc_entries[index] = ' '.join(entry.get_text().replace(":", "").split())
+				entry_text = regex.sub(r"([IVXLCM].*?):", r"\1", entry.get_text())
+				toc_entries[index] = ' '.join(entry_text.split())
 			for heading in headings:
 				if heading[0] not in toc_entries:
 					messages.append(LintMessage("Heading ‘{}’ found, but not present in the ToC".format(heading[0]), se.MESSAGE_TYPE_ERROR, heading[1]))

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -470,7 +470,7 @@ class SeEpub:
 							for match in matches:
 
 								# Remove any links to the endnotes
-								endnote_ref = match.find('a')
+								endnote_ref = match.find('a', attrs={"epub:type": regex.compile("^.*noteref.*$")})
 								if endnote_ref:
 									endnote_ref.extract()
 

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -480,6 +480,15 @@ class SeEpub:
 									if halftitle_subtitle:
 										halftitle_subtitle.extract()
 
+								# Remove any subtitles from headings that don’t have a preceding roman number)
+								heading_first_child = match.find('span',recursive=False)
+								if heading_first_child:
+									epub_type = heading_first_child.get('epub:type')
+									if epub_type is None or len(regex.findall(r"z3998:roman", epub_type)) == 0:
+										unnumbered_subtitle = match.find(attrs={"epub:type": regex.compile("^.*subtitle.*$")})
+										if unnumbered_subtitle:
+											unnumbered_subtitle.extract()
+
 								normalised_text = ' '.join(match.get_text().split())
 								headings = headings + [(normalised_text, filename)]
 

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -474,6 +474,12 @@ class SeEpub:
 								if endnote_ref:
 									endnote_ref.extract()
 
+								# Remove any subtitles on halftitle pages
+								if match.find_parent(attrs={"epub:type": regex.compile("^.*halftitlepage.*$")}):
+									halftitle_subtitle = match.find(attrs={"epub:type": regex.compile("^.*subtitle.*$")})
+									if halftitle_subtitle:
+										halftitle_subtitle.extract()
+
 								normalised_text = ' '.join(match.get_text().split())
 								headings = headings + [(normalised_text, filename)]
 


### PR DESCRIPTION
This collects text from the headings that has had the tags stripped and whitespace normalised. It then checks them off against the ToC entries to see if any are present that don’t have an entry.

The only amend we do to the ToC entries is to strip out the `:` that the style guide suggests for after the chapter number.

Problems found so far:

- Missing entries! Nice to see it works. E.g. [missing chapter 5 entry](https://github.com/standardebooks/arthur-machen_short-fiction/blob/6d14f29a42dbb41ca4fe7c58ab26aacdec5eb9d9/src/epub/toc.xhtml#L60) from [`the-inmost-light.xhtml`](https://github.com/standardebooks/arthur-machen_short-fiction/blob/6d14f29a42dbb41ca4fe7c58ab26aacdec5eb9d9/src/epub/text/the-inmost-light.xhtml#L126) in Arthur Machen, missing [endnotes](https://github.com/standardebooks/erskine-childers_the-riddle-of-the-sands/blob/3443922da0d43eed6095709c5a97f46f54fa4c76/src/epub/text/endnotes.xhtml) from The Riddle of the Sands [ToC](https://github.com/standardebooks/erskine-childers_the-riddle-of-the-sands/blob/3443922da0d43eed6095709c5a97f46f54fa4c76/src/epub/toc.xhtml).
- Simple small fixes, for example [extra accidental whitespace](https://github.com/standardebooks/abraham-merritt_the-moon-pool/blob/502873c89f15fb0d7604365b136a84bb17e75a45/src/epub/toc.xhtml#L113) in the ToC entry, [spelling mistakes](https://github.com/standardebooks/david-lindsay_a-voyage-to-arcturus/blob/42c547b0460e7d0c7ee5c4880815d740cfe956a2/src/epub/toc.xhtml#L67) in the chapter title, or [misnumbered chapter titles](https://github.com/standardebooks/edgar-rice-burroughs_a-princess-of-mars_frank-e-schoonover/blob/82c531a50443a31a084765f91e4205f71280560d/src/epub/toc.xhtml#L98) in the ToC.
- Simplified titles in the ToC (e.g. [missing ‘(Continue)’s in multiple places](https://github.com/standardebooks/apsley-cherry-garrard_the-worst-journey-in-the-world/blob/4bfd63876a46ec3402c971a4b081d8f70618a92f/src/epub/toc.xhtml#L66) in The Worst Journey in the World, or [omitting the subtitle](https://github.com/standardebooks/c-j-cutcliffe-hyne_the-lost-continent/blob/3a279022714ce8bc0b815d04f56abf2db8c791a5/src/epub/toc.xhtml#L20) on the [halftitle of The Lost Continent](https://github.com/standardebooks/c-j-cutcliffe-hyne_the-lost-continent/blob/3a279022714ce8bc0b815d04f56abf2db8c791a5/src/epub/text/halftitle.xhtml)).
- Headings in letters / diary entries not reflected in the ToC (e.g. in [Dracula](https://github.com/standardebooks/bram-stoker_dracula/blob/05964e212fae6b7e20c7c543953c687e4c63e7b4/src/epub/text/chapter-7.xhtml#L13) or in [The Worst Journey in the World](https://github.com/standardebooks/apsley-cherry-garrard_the-worst-journey-in-the-world/blob/3c8cb3337b53f2c14742bb475ce22def68398ef2/src/epub/text/chapter-11.xhtml#L54) again, this I guess should be fixed at source).
- ‘Chapter’ in ToC but not in headings. This is different in different books, e.g. not a problem in [Alice Adams](https://github.com/standardebooks/booth-tarkington_alice-adams/blob/b1d82b6e7c1dad8a2cfa486e110c168779525fc1/src/epub/toc.xhtml), but flagged in [The Magnificent Ambersons](https://github.com/standardebooks/booth-tarkington_the-magnificent-ambersons/blob/7047a52c36236fcc7679962bcd11ed68fa641a98/src/epub/toc.xhtml).

I went through about half of the corpus, but the set of errors had settled down to pretty much the above. I didn’t want to start submitting PRs until we’d discussed the above, but I’m happy to send some time doing that afterwards if that’d help.

Will fix https://github.com/standardebooks/tools/issues/47