### PR TITLE
Make titlecase linting aware of embedded titles

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -41,6 +41,9 @@ def titlecase(text):
 	# Lowercase "from", "with", as long as they're not the first word and not preceded by a parenthesis
 	text = regex.sub(r"(?<!^)(?<!\()\b(From|With)\b", lambda result: result.group(1).lower(), text)
 
+	# Capitalise the first word after an opening quote or italicisation that signifies a work
+	text = regex.sub(r"(‘|“|<i.*?epub:type=\".*?se:.*?\".*?>)([a-z])", lambda result: result.group(1) + result.group(2).upper(), text)
+
 	# Lowercase "the" if preceded by "vs."
 	text = regex.sub(r"(?:vs\.) The\b", "vs. the", text)
 

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -638,11 +638,11 @@ class SeEpub:
 								subtitle_matches = regex.findall(r"(.*?)<span epub:type=\"subtitle\">(.*?)</span>(.*?)", title, flags=regex.DOTALL)
 								if subtitle_matches:
 									for title_header, subtitle, title_footer in subtitle_matches:
-										title_header = se.formatting.remove_tags(title_header).strip()
-										subtitle = se.formatting.remove_tags(subtitle).strip()
-										title_footer = se.formatting.remove_tags(title_footer).strip()
+										title_header = se.formatting.remove_tags(se.formatting.titlecase(title_header)).strip()
+										subtitle = se.formatting.remove_tags(se.formatting.titlecase(subtitle)).strip()
+										title_footer = se.formatting.remove_tags(se.formatting.titlecase(title_footer)).strip()
 
-										titlecased_title = se.formatting.titlecase(title_header) + " " + se.formatting.titlecase(subtitle) + " " + se.formatting.titlecase(title_footer)
+										titlecased_title = title_header + " " + subtitle + " " + title_footer
 										titlecased_title = titlecased_title.strip()
 
 										title = se.formatting.remove_tags(title).strip()
@@ -651,8 +651,8 @@ class SeEpub:
 
 								# No subtitle? Much more straightforward
 								else:
+									titlecased_title = se.formatting.remove_tags(se.formatting.titlecase(title))
 									title = se.formatting.remove_tags(title)
-									titlecased_title = se.formatting.titlecase(title)
 									if title != titlecased_title:
 										messages.append(LintMessage("Title \"{}\" not correctly titlecased. Expected: {}".format(title, titlecased_title), se.MESSAGE_TYPE_WARNING, filename))
 


### PR DESCRIPTION
This does two things:

1. Teaches `titlecase` that a letter immediately following a `‘`, `“` or an `<i>` with an attribute that starts `se:` shoud be uppercase.
2. Adjusts the linting to apply `titlecase` first before stripping tags to make sure there’s no disparity between the linter and the real world.

Fixes https://github.com/standardebooks/tools/issues/50. I think this works OK, been testing with Keats and it seems to, although I’ve been down a couple of blind alleys on the way to this solution.