### PR TITLE
New algorithm for subtitle inclusion in the ToC

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -479,7 +479,7 @@ class SeEpub:
 									endnote_ref.extract()
 
 								# Decide whether to remove subheadings based on the following logic:
-								# If the closest parent <section> is a part ordivision, then keep subtitle
+								# If the closest parent <section> is a part or division, then keep subtitle
 								# Else, if the closest parent <section> is a halftitlepage, then discard subtitle
 								# Else, if the first child of the heading is not z3998:roman, then also discard subtitle
 								# Else, keep the subtitle.
@@ -487,13 +487,13 @@ class SeEpub:
 
 								if heading_subtitle:
 									closest_section_epub_type = match.find_parents('section')[0].get('epub:type') or ''
-									heading_first_child_epub_type = match.find('span',recursive=False).get('epub:type') or ''
+									heading_first_child_epub_type = match.find('span', recursive=False).get('epub:type') or ''
 
-									if len(regex.findall(r"^.*(part|division).*$", closest_section_epub_type)) > 0:
+									if regex.findall(r"^.*(part|division).*$", closest_section_epub_type):
 										remove_subtitle = False
-									elif len(regex.findall(r"^.*halftitlepage.*$", closest_section_epub_type)) > 0:
+									elif regex.findall(r"^.*halftitlepage.*$", closest_section_epub_type):
 										remove_subtitle = True
-									elif len(regex.findall(r"^.*z3998:roman.*$", heading_first_child_epub_type)) == 0:
+									elif not regex.findall(r"^.*z3998:roman.*$", heading_first_child_epub_type):
 										remove_subtitle = True
 									else:
 										remove_subtitle = False

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -825,9 +825,9 @@ class SeEpub:
 		headings = list(set(headings))
 		with open(os.path.join(self.directory, "src", "epub", "toc.xhtml"), "r", encoding="utf-8") as toc:
 			toc_entries = BeautifulSoup(toc.read(), "lxml").find_all('a')
-			# ToC headers have a ‘:’ after the chapter number that main headings don’t
+			# Unlike main headings, ToC entries have a ‘:’ before the subheading
 			for index, entry in enumerate(toc_entries):
-				entry_text = ' '.join(regex.sub(r"([IVXLCM].*?):", r"\1", entry.get_text()).split())
+				entry_text = ' '.join(regex.sub(r"^(.*?):", r"\1", entry.get_text()).split())
 				entry_file = regex.sub(r"^text\/(.*?\.xhtml).*$", r"\1", entry.get('href'))
 				toc_entries[index] = (entry_text, entry_file)
 			for heading in headings:

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -486,8 +486,8 @@ class SeEpub:
 								heading_subtitle = match.find(attrs={"epub:type": regex.compile("^.*subtitle.*$")})
 
 								if heading_subtitle:
-									closest_section_epub_type = match.find_parents('section')[0].get('epub:type')
-									heading_first_child_epub_type = match.find('span',recursive=False).get('epub:type')
+									closest_section_epub_type = match.find_parents('section')[0].get('epub:type') or ''
+									heading_first_child_epub_type = match.find('span',recursive=False).get('epub:type') or ''
 
 									if len(regex.findall(r"^.*(part|division).*$", closest_section_epub_type)) > 0:
 										remove_subtitle = False


### PR DESCRIPTION
This is based on the algorithm suggested in https://github.com/standardebooks/tools/pull/48#issuecomment-346490298. It has the added bonus of simplifying the code a bit, although it’s still complex enough that I detailed the process in a comment above.

I’ve tested this manually with a few different configurations and it seems to work, but I haven’t run it over the full corpus.