### PR TITLE
Calibre path mac

### DIFF
--- a/build
+++ b/build
@@ -47,8 +47,14 @@ def main():
 	args = parser.parse_args()
 
 	script_directory = os.path.dirname(os.path.realpath(__file__))
+	calibre_app_mac_path = "/Applications/calibre.app/Contents/MacOS/"
 	epubcheck_path = shutil.which("epubcheck")
 	ebook_convert_path = shutil.which("ebook-convert")
+	# look for default Mac calibre app path if none found in path
+	if ebook_convert_path is None and os.path.exists(calibre_app_mac_path):
+		ebook_convert_path = os.path.join(
+				calibre_app_mac_path,
+				'ebook-convert')
 	rsvg_convert_path = shutil.which("rsvg-convert")
 	convert_path = shutil.which("convert")
 	simplify_tags_path = os.path.join(script_directory, "simplify-tags")

--- a/build
+++ b/build
@@ -526,3 +526,6 @@ def main():
 
 if __name__ == "__main__":
 	main()
+
+# Sets Standard ebook tab settings for vim users:
+# vim: noexpandtab tabstop=8 shiftwidth=0 softtabstop=0


### PR DESCRIPTION
This pull request is to allow more flexibility with Calibre, if 'build' cannot find 'ebook-convert' it checks to see if the default Calibre path on a Mac exists, and if so, uses that to find 'ebook-convert'.

Additionally, I added a modeline at the bottom (in a python comment) for vim, that automatically sets the tabbing in vim for the Standard Ebooks preferred tab mode (actual tabs indents)

I already had Calibre installed without using brew cask.  brew cask adds symlinks in /usr/local/bin to the binaries inside the Calibre app, but installing it from the Calibre website does not.  This code modification in 'build' finds the Calibre binary for 'ebook-convert' no matter how you installed it on a Mac.
