### PR TITLE
Lint tries to process .DS_Store on macOS

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -276,6 +276,9 @@ class SeEpub:
 		# Add XHTML files
 		for root, _, filenames in os.walk(os.path.join(self.directory, "src", "epub", "text")):
 			for filename in filenames:
+				if filename.startswith("."):
+					continue
+
 				properties = ""
 
 				with open(os.path.join(root, filename), "r", encoding="utf-8") as file:


### PR DESCRIPTION
I got an error running lint under macOS 10.12.:

```
Traceback (most recent call last):
  File "../tools/lint", line 61, in <module>
    main()
  File "../tools/lint", line 25, in main
    messages = se_epub.lint()
  File "/Users/steve/Documents/StandardEbooks/tools/se/se_epub.py", line 451, in lint
    expected_manifest = regex.sub(r"[\n\t]", "", self.generate_manifest())
  File "/Users/steve/Documents/StandardEbooks/tools/se/se_epub.py", line 282, in generate_manifest
    file_contents = file.read()
  File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 3131: invalid start byte
```

It was trying to process .DS_Store. It should skip all hidden files, right? I added a test for that.