### PR TITLE
Have lint ignore .DS_Store files when running under macOS

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -486,6 +486,10 @@ class SeEpub:
 				if ".git/" in os.path.join(root, filename) or filename.endswith(tuple(se.BINARY_EXTENSIONS)):
 					continue
 
+				# Ignore .DS_Store files when running under macOS
+				if filename == ".DS_Store":
+					continue
+
 				if filename.startswith(".") or filename.startswith("README"):
 					messages.append(LintMessage("Illegal {} file detected in {}".format(filename, root), se.MESSAGE_TYPE_ERROR))
 					continue


### PR DESCRIPTION
macOS litters .DS_Store files in every directory and they then clog up the lint output. This change will make lint silently ignore .DS_Store files. macOS users will rejoice.