### PR TITLE
modernize-spelling: Add intrust -> entrust

### DIFF
--- a/modernize-spelling
+++ b/modernize-spelling
@@ -49,6 +49,8 @@ def modernize_spelling(xhtml, language):
 	xhtml = regex.sub(r"\bquoiff", r"coif", xhtml)					# quoiff -> coif
 	xhtml = regex.sub(r"\bIndorse", r"Endorse", xhtml)				# indorse -> endorse
 	xhtml = regex.sub(r"\bindorse", r"endorse", xhtml)				# indorse -> endorse
+	xhtml = regex.sub(r"\bIntrust", r"Entrust", xhtml)				# Intrust -> Entrust
+	xhtml = regex.sub(r"\bintrust", r"entrust", xhtml)				# intrust -> entrust
 	xhtml = regex.sub(r"\bPhantas(y|ie)", r"Fantasy", xhtml)			# phantasie -> fantasy
 	xhtml = regex.sub(r"\bphantas(y|ie)", r"fantasy", xhtml)			# phantasie -> fantasy
 	xhtml = regex.sub(r"\bPhantastic", r"Fantastic", xhtml)				# phantastic -> fantastic


### PR DESCRIPTION
Seems equivalent to indorse -> endorse