### PR TITLE
Fix endnote reordering

### DIFF
--- a/reorder-endnotes
+++ b/reorder-endnotes
@@ -50,7 +50,7 @@ def main():
 
 			for endnote_number in note_range:
 				xhtml = xhtml.replace("id=\"note-{}\"".format(endnote_number), "id=\"note-{}\"".format(endnote_number + step))
-				xhtml = xhtml.replace("#note-{}\"".format(endnote_number), "#note-{}\"".format(endnote_number + step))
+				xhtml = xhtml.replace("#noteref-{}\"".format(endnote_number), "#noteref-{}\"".format(endnote_number + step))
 
 			file.seek(0)
 			file.write(xhtml)
@@ -72,7 +72,7 @@ def main():
 
 				for endnote_number in note_range:
 					processed_xhtml = regex.sub(r"(<a[^>]*?>){}</a>".format(endnote_number), "\g<1>{}</a>".format(endnote_number + step), processed_xhtml, flags=regex.MULTILINE | regex.DOTALL)
-					processed_xhtml = processed_xhtml.replace("id=\"note-{}\"".format(endnote_number), "id=\"note-{}\"".format(endnote_number + step))
+					processed_xhtml = processed_xhtml.replace("id=\"noteref-{}\"".format(endnote_number), "id=\"noteref-{}\"".format(endnote_number + step))
 					processed_xhtml = processed_xhtml.replace("#note-{}\"".format(endnote_number), "#note-{}\"".format(endnote_number + step))
 
 				if processed_xhtml != xhtml:


### PR DESCRIPTION
In the new endnote style the links to the notes have an `id` attribute starting with `noteref-`, but the existing code is still looking for `note-`.

Obviously this commit will break reordering endnotes in the old style, so if older books have endnotes added they’ll need to be updated to the new style first.