### PR TITLE
Minimise default clean fixes

### DIFF
--- a/create-draft
+++ b/create-draft
@@ -140,7 +140,7 @@ def generate_titlepage_svg(title, authors, contributors, title_string, templates
 
 	y += se.TITLEPAGE_VERTICAL_PADDING
 
-	svg = svg.replace("</svg>", "\n" + text_elements + "</svg>").replace("TITLESTRING", title_string)
+	svg = svg.replace("</svg>", "\n" + text_elements + "</svg>\n").replace("TITLESTRING", title_string)
 	svg = regex.sub(r"viewBox=\".+?\"", "viewBox=\"0 0 1400 {:.0f}\"".format(y), svg)
 
 	return svg
@@ -218,7 +218,7 @@ def generate_cover_svg(title, authors, title_string, templates_path):
 	if title_class != "title-xsmall":
 		svg = regex.sub(r"\n\n\t\t\.title-xsmall\{.+?\}", "", svg, flags=regex.DOTALL)
 
-	svg = svg.replace("</svg>", "\n" + text_elements + "</svg>").replace("TITLESTRING", title_string)
+	svg = svg.replace("</svg>", "\n" + text_elements + "</svg>\n").replace("TITLESTRING", title_string)
 
 	return svg
 

--- a/templates/content.opf
+++ b/templates/content.opf
@@ -16,7 +16,7 @@
 		<meta property="file-as" refines="#type-designer">League of Moveable Type, The</meta>
 		<meta property="se:url.homepage" refines="#type-designer">https://www.theleagueofmoveabletype.com</meta>
 		<meta property="role" refines="#type-designer" scheme="marc:relators">tyd</meta>
- 		<link href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa" rel="dcterms:conformsTo"/>
+		<link href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa" rel="dcterms:conformsTo"/>
 		<meta property="a11y:certifiedBy">Standard Ebooks</meta>
 		<meta property="schema:accessMode">textual</meta>
 		<meta property="schema:accessModeSufficient">textual</meta>


### PR DESCRIPTION
- Fix an extra space in `content.opf`
- Insert a blank newline at the end of `cover.svg` and `titlepage.svg` (via method given at https://stackoverflow.com/a/31906126/453783)

After this the only error `clean` fixes on a newly created SE repo is removing the `CDATA` blocks around the long description. I assume this is expected so have left it as is.