### PR TITLE
Force utf-8 when creating a draft

### DIFF
--- a/create-draft
+++ b/create-draft
@@ -329,6 +329,7 @@ def main():
 		# Get the actual ebook URL
 		try:
 			response = requests.get(pg_ebook_url)
+			response.encoding = 'utf-8'
 			pg_ebook_html = response.text
 		except Exception as ex:
 			se.print_error("Couldn't download Project Gutenberg ebook HTML. Error: {}".format(ex))

--- a/create-draft
+++ b/create-draft
@@ -8,10 +8,11 @@ import requests
 import git
 import regex
 import unicodedata
+from ftfy import fix_text
 import se
 import se.formatting
 import se.epub
-from bs4 import BeautifulSoup, UnicodeDammit
+from bs4 import BeautifulSoup
 
 
 def get_word_widths(str, target_height):
@@ -329,15 +330,14 @@ def main():
 		# Get the actual ebook URL
 		try:
 			response = requests.get(pg_ebook_url)
-			response.encoding = 'utf-8'
 			pg_ebook_html = response.text
 		except Exception as ex:
 			se.print_error("Couldn't download Project Gutenberg ebook HTML. Error: {}".format(ex))
 			exit(1)
 
 		try:
-			dammit = UnicodeDammit(pg_ebook_html)
-			pg_ebook_html = se.epub.strip_bom(dammit.unicode_markup)
+			fixed_pg_ebook_html = fix_text(pg_ebook_html)
+			pg_ebook_html = se.epub.strip_bom(fixed_pg_ebook_html)
 		except Exception as ex:
 			se.print_error("Couldn't determine text encoding of Project Gutenberg HTML file. Error: {}".format(ex))
 			exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 beautifulsoup4==4.6.0
 cssselect==1.0.1
+ftfy==5.3.0
 gitpython==2.1.5
 lxml==3.8.0
 pyhyphen==2.0.8


### PR DESCRIPTION
I’ve noticed on a couple of recent books that `create-draft`’s automatic Gutenberg pull fails to properly encode characters in the HTML. For example, this command:

`~/tools/create-draft --author="Selma Lagerlöf" --title="The Story of Gösta Berling" --translator="Pauline Bancroft Flach" --gutenberg-ebook-url="https://www.gutenberg.org/ebooks/56158"`

will produce a body.xhtml with a title of `The Story of GÃ¶sta Berling`, not `The Story of Gösta Berling` due to requests assuming the file is ISO-8859-1 encoded. requests will try to guess an appropriate encoding but this particular file (and others I’ve tried) don’t supply an encoding value in the headers. As we always want UTF-8 anyway we can just tell requests to use the correct encoding.

It’s possible this will break some files, but files are being broken already and this will work directly with ISO-8859-1 (well, theoretically - UTF-8 is effectively a superset).