### PR TITLE
Make sure LoI text / image title / figure alt text are consistent

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -1049,22 +1049,26 @@ class SeEpub:
 						if filename == "loi.xhtml":
 							illustrations = dom.select('li > a')
 							for illustration in illustrations:
+								figure_ref = illustration["href"].split("#")[1]
+								image_ref = ''
+								chapter_ref = regex.findall(r".*\/(.*?)#.*", illustration["href"])[0]
 								alt_text = ''
 								title_text = ''
 								loi_text = illustration.get_text()
-								image_ref = illustration["href"].split('#')[1]
-								chapter_ref = regex.findall(r".*\/(.*?)#.*", illustration["href"])[0]
 
-								with open(os.path.join(self.directory, "src", "epub", "images", image_ref + ".svg"), "r", encoding="utf-8") as image:
-									title_text = BeautifulSoup(image, "lxml").title.get_text()
 								with open(os.path.join(self.directory, "src", "epub", "text", chapter_ref), "r", encoding="utf-8") as chapter:
-									alt_text = BeautifulSoup(chapter, "lxml").select("#"+image_ref)[0].img["alt"]
+									figure_image = BeautifulSoup(chapter, "lxml").select("#"+figure_ref)[0].img
+									image_ref = figure_image["src"].split("/").pop()
+									alt_text = figure_image["alt"]
+								if image_ref.endswith(".svg"):
+									with open(os.path.join(self.directory, "src", "epub", "images", image_ref), "r", encoding="utf-8") as image:
+										title_text = BeautifulSoup(image, "lxml").title.get_text()
 
 								if alt_text != '' and title_text != '':
 									if title_text != alt_text:
-										messages.append(LintMessage("The title of {}.svg doesn’t match the alt text in {}".format(image_ref, chapter_ref), se.MESSAGE_TYPE_ERROR, chapter_ref))
+										messages.append(LintMessage("The title of {} doesn’t match the alt text in {}".format(image_ref, chapter_ref), se.MESSAGE_TYPE_ERROR, chapter_ref))
 									if title_text != loi_text:
-										messages.append(LintMessage("The title of {}.svg doesn’t match the text in its LoI entry".format(image_ref), se.MESSAGE_TYPE_WARNING, filename))
+										messages.append(LintMessage("The title of {} doesn’t match the text in its LoI entry".format(image_ref), se.MESSAGE_TYPE_WARNING, filename))
 
 					# Check for missing MARC relators
 					if filename == "introduction.xhtml" and ">aui<" not in metadata_xhtml and ">win<" not in metadata_xhtml:


### PR DESCRIPTION
The title text in the SVG should always match the alt text in the associated figure, so that’s easy to lint and error on (if there’s no title, eg a PNG we can bail). As well as that, the title text should mostly match the text in the LoI but there are cases where this doesn’t work (eg Just So Stories), so if it doesn’t we emit a manual review warning.