### PR TITLE
Make sure alt text / image title match checking is run against all images

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -928,7 +928,7 @@ class SeEpub:
 						if filename not in se.IGNORED_FILENAMES:
 							matches = regex.findall(r"alt=\"[^\"]*?[a-zA-Z]\"", file_contents)
 							if matches:
-								messages.append(LintMessage("Alt attribute doesn't appear to end with puncutation. Alt attributes must be composed of complete sentences ending in appropriate punctuation.", se.MESSAGE_TYPE_ERROR, filename))
+								messages.append(LintMessage("Alt attribute doesn't appear to end with punctuation. Alt attributes must be composed of complete sentences ending in appropriate punctuation.", se.MESSAGE_TYPE_ERROR, filename))
 
 						# Check for punctuation after endnotes
 						regex_string = r"<a[^>]*?epub:type=\"noteref\"[^>]*?>[0-9]+</a>[^\s<–\]\)—{}]".format(se.WORD_JOINER)


### PR DESCRIPTION
The removes the alt / title match checking from the LoI section and applies it to every referenced .svg.

Unfortunately though this has exposed a problem: the title tag in titlepage.svg (default `The titlepage for the Standard Ebooks edition of TITLESTRING`) doesn’t match the alt text in titlepage.xhtml (default `TITLESTRING`). The obvious two fixes that spring to mind are to normalise the title / alt strings in this case and republish every book, or to ignore the titlepage in another commit to this PR before merging. I’d be happy with either, but I’ll leave it up to you to make the decision.