### PR TITLE
Don’t replace &gt; and &lt;

### DIFF
--- a/clean
+++ b/clean
@@ -3,10 +3,45 @@
 import argparse
 import os
 import html
+import re
 import shutil
 import subprocess
 import regex
 import se
+
+
+def replace_inessential_references(xml_text):
+	"""Replace most XML character references with literal characters.
+
+	This function excludes &, >, and < (&amp;, &lt;, and &gt;), since
+	un-escaping them would create an invalid document.
+	"""
+	def helper(match_object):
+		entity = match_object.group(0).lower()
+		# Explicitly whitelist the three (nine) essential character references
+		if entity in ["&gt;", "&lt;",   "&amp;",
+					"&#62;",  "&#60;",  "&#38;",
+					"&#x3e;", "&#x3c;", "&#x26;"]:
+			return entity
+		# Convert base 16 references
+		elif entity.startswith("&#x"):
+			try:
+				return chr(int(entity[3:-1], 16))
+			except ValueError:
+				return entity
+		# Convert base 10 references
+		elif entity.startswith("&#"):
+			try:
+				return chr(int(entity[2:-1]))
+			except ValueError:
+				return entity
+		# Convert named references
+		else:
+			try:
+				return html.entities.html5[entity[1:]]
+			except KeyError:
+				return entity
+	return re.sub("&#?\w+;", helper, xml_text)
 
 
 def main():
@@ -59,7 +94,7 @@ def main():
 				# Epub3 doesn't allow named entities, so convert them to their unicode equivalents
 				# But, don't unescape the content.opf long-description accidentally
 				if not filename.endswith("content.opf"):
-					processed_xhtml = html.unescape(processed_xhtml).replace("&", "&amp;")
+					processed_xhtml = replace_inessential_references(processed_xhtml)
 
 				# Remove unnecessary doctypes which can cause xmllint to hang
 				processed_xhtml = regex.sub(r"<!DOCTYPE[^>]+?>", "", processed_xhtml, flags=regex.MULTILINE | regex.DOTALL)


### PR DESCRIPTION
This PR fixes #107. I tested with valid and invalid references of all three types, and the code works as intended — with one exception. If you give it a really huge (which implies invalid) numerical character reference, it will throw an `OverflowError`. I can handle that too, but I'm not sure if it's necessary.