### PR TITLE
Fix lxml 3.8.0 failing to compile on default 10.13 macOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.6.0
 cssselect==1.0.1
 ftfy==5.3.0
 gitpython==2.1.5
-lxml==3.8.0
+lxml==4.2.3
 pyhyphen==2.0.8
 pyopenssl==17.2.0	# Required to allows the `requests` package to use https on Mac OSX
 python-magic==0.4.13


### PR DESCRIPTION
clang 9.1.0 throws a bunch of errors around nulls when trying to compile lxml 3.8.0. lxml 4.2.3 (current at time of patch) doesn’t seem to fundamentally change any functionality we’re relying on, promises speed ups, and more importantly compiles fine.