### PR TITLE
Upgrade Pyhyphen

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ sudo fc-cache -fv
 
 # Install python dependencies
 pip3 install -r ./tools/requirements.txt
-
-# Install hyphenation dictionaries for the pyhyphen library
-python3 -c "exec(\"from hyphen import dictools\\ndictools.install('en_GB')\\ndictools.install('en_US')\")"
 ```
 
 ## macOS users
@@ -60,8 +57,6 @@ These instructions were tested on macOS 10.12 and 10.13. Your mileage may vary. 
 	curl -s -o ~/Library/Fonts/OFLGoudyStM-Italic.otf "https://raw.githubusercontent.com/theleagueof/sorts-mill-goudy/master/OFLGoudyStM-Italic.otf"
 
 	# Install python dependencies
-	# *********IMPORTANT NOTE*********: PyHyphen currently fails to install on Mac OS when you run this command.
-	# Don't worry, you can safely ignore PyHyphen's failure, as long as all the other pip packages install correctly.
 	pip3 install -r ./tools/requirements.txt
 	```
 

--- a/build
+++ b/build
@@ -895,11 +895,7 @@ def main():
 					core_css_file.write(compatibility_css_file.read())
 
 			# Add soft hyphens
-			# pyhyphen is currently broken on Mac, so skip this on Macs
-			if platform.system() == "Darwin":
-				print("{}Warning: pyhyphen is currently unstable on Macs, so hyphenation has been disabled.  The resulting Kindle file will not have soft hyphenation.".format("\t" if args.verbose else ""))
-			else:
-				subprocess.run([hyphenate_path, "--ignore-h-tags", work_epub_root_directory])
+			subprocess.run([hyphenate_path, "--ignore-h-tags", work_epub_root_directory])
 
 			# Build an epub file we can send to Calibre
 			se.epub.write_epub(work_epub_root_directory, os.path.join(work_directory, epub_output_filename))

--- a/hyphenate
+++ b/hyphenate
@@ -5,7 +5,8 @@ import sys
 import os
 import fnmatch
 import regex
-from hyphen import Hyphenator, dict_info
+from hyphen import Hyphenator
+from hyphen.dictools import list_installed
 from bs4 import BeautifulSoup
 
 
@@ -58,7 +59,7 @@ def main():
 							hyphenators[language] = Hyphenator(language)
 					except Exception:
 						print("Error: Hyphenator for language \"{}\" not available.".format(language), file=sys.stderr)
-						print("Installed hyphenators: {}".format(str(list(dict_info.keys()))), file=sys.stderr)
+						print("Installed hyphenators: {}".format(list_installed()), file=sys.stderr)
 						exit(1)
 
 					text = str(soup.body)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cssselect==1.0.1
 ftfy==5.3.0
 gitpython==2.1.5
 lxml==4.2.3
-pyhyphen==2.0.8
+pyhyphen==3.0.1
 pyopenssl==17.2.0	# Required to allows the `requests` package to use https on Mac OSX
 python-magic==0.4.13
 regex==2017.7.26


### PR DESCRIPTION
This fixes installation problems on macOS (tested on 10.13), and changes the way dict_info is accessed to match the new 3.0 way.

Installation succeeds, and en-GB libraries are downloaded automatically where needed. Running hyphenate manually against a chapter produces a soft-hyphenated file, and build --kindle produces an azw3 file without complaint.

Untested on Linux or older macOS. The changelog between the old 2.0.8 and the new 3.0.1 is at https://pypi.org/project/PyHyphen/#changelog.