### PR TITLE
Warn on >> at the end of a tag

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -837,6 +837,11 @@ class SeEpub:
 						if matches:
 							messages.append(LintMessage("Illegal numeric entity (like &#913;) in file.", se.MESSAGE_TYPE_ERROR, filename))
 
+						# Check for double greater-than at the end of a tag
+						matches = regex.findall(r"(>>|>&gt;)", file_contents)
+						if matches:
+							messages.append(LintMessage("Tags should end with a single >.", se.MESSAGE_TYPE_WARNING, filename))
+
 						# Check for nbsp before times
 						matches = regex.findall(r"[0-9]+[^{}]<abbr class=\"time".format(se.NO_BREAK_SPACE), file_contents)
 						if matches:


### PR DESCRIPTION
Seen this a few times, so it’s worth linting for. We also need to check for `>&gt;` as `clean` will ‘fix’ the second `>` if run before lint, and it isn’t caught in a manual review.

We don’t need to check for double opening `<` as that throws a parse error in our tooling.