### PR TITLE
brew install libmagic

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ These instructions were tested on macOS 10.12 and 10.13. Your mileage may vary. 
 
 	```shell
 	# Install some pre-flight dependencies
-	brew install python epubcheck imagemagick librsvg exiftool git
+	brew install python epubcheck imagemagick libmagic librsvg exiftool git
 
 	# Clone the tools repo
 	git clone https://github.com/standardebooks/tools.git


### PR DESCRIPTION
without this, you get the following error:

```
$ tools/extract-ebook --help
Traceback (most recent call last):
  File "tools/extract-ebook", line 8, in <module>
    import magic
  File "/Users/alsuren/envs/standardebooks/lib/python3.7/site-packages/magic.py", line 176, in <module>
    raise ImportError('failed to find libmagic.  Check your installation')
ImportError: failed to find libmagic.  Check your installation
```