### PR TITLE
Speed up endnote reordering again, and make it more correct

### DIFF
--- a/reorder-endnotes
+++ b/reorder-endnotes
@@ -58,6 +58,16 @@ def main():
 				xhtml = xhtml.replace("id=\"note-{}\"".format(endnote_number), "id=\"note-{}\"".format(endnote_number + step), 1)
 				xhtml = xhtml.replace("#noteref-{}\"".format(endnote_number), "#noteref-{}\"".format(endnote_number + step), 1)
 
+			# There may be some links within the notes that refer to other endnotes.
+			# These potentially need incrementing / decrementing too. This code assumes
+			# a link that looks something like <a href="#note-1">note 1</a>.
+			endnote_links = regex.findall(r"href=\"#note-(\d+)\"(.*?) (\d+)</a>", xhtml)
+			for link in endnote_links:
+				link_number = int(link[0])
+				if (link_number < target_endnote_number and args.increment) or (link_number > target_endnote_number and not args.increment):
+					continue
+				xhtml = xhtml.replace("href=\"#note-{0}\"{1} {0}</a>".format(link[0], link[1]), "href=\"#note-{0}\"{1} {0}</a>".format(link_number + step, link[1]))
+
 			file.seek(0)
 			file.write(xhtml)
 			file.truncate()

--- a/reorder-endnotes
+++ b/reorder-endnotes
@@ -85,9 +85,9 @@ def process_endnotes_in_file(filename: str, root: str, note_range: range, step: 
 			# If we’ve already changed some notes and can’t find the next then we don’t need to continue searching
 			if not "id=\"noteref-{}\"".format(endnote_number) in processed_xhtml and processed_xhtml_is_modified:
 				break
-			processed_xhtml = regex.sub(r"(<a[^>]*?>){}</a>".format(endnote_number), r"\g<1>{}</a>".format(endnote_number + step), processed_xhtml, flags=regex.DOTALL)
 			processed_xhtml = processed_xhtml.replace("id=\"noteref-{}\"".format(endnote_number), "id=\"noteref-{}\"".format(endnote_number + step), 1)
 			processed_xhtml = processed_xhtml.replace("#note-{}\"".format(endnote_number), "#note-{}\"".format(endnote_number + step), 1)
+			processed_xhtml = processed_xhtml.replace(">{}</a>".format(endnote_number), ">{}</a>".format(endnote_number + step), 1)
 			processed_xhtml_is_modified = processed_xhtml_is_modified or (processed_xhtml != xhtml)
 
 		if processed_xhtml_is_modified:


### PR DESCRIPTION
This PR drops endnote reordering (increment all endnotes from 1, against current Pepys with 1595 endnotes) from ~23.5s to 5s on my laptop, and adds in the ability to reorder links inside `endnotes.xhtml` to other endnotes assuming they are of the form `<a href="#note-x">note x</a>` or close.

The speed-up comes from reworking the existing regex sub inside the loop to be a straight text replacement. Python should cache regular expressions as they’re first evaluated, but it turns out that generating and caching ~1600 of them is pretty slow.