### PR TITLE
Replace lxml with html.parser when fetching ebook html

### DIFF
--- a/create-draft
+++ b/create-draft
@@ -419,7 +419,7 @@ def main():
 
 	# Write PG data if we have it
 	if args.pg_url and pg_ebook_html:
-		soup = BeautifulSoup(pg_ebook_html, "lxml")
+		soup = BeautifulSoup(pg_ebook_html, "html.parser")
 
 		# Try to get the PG producers.  We only try this if there's a <pre> block with the header info (which is not always the case)
 		for element in soup(text=regex.compile(r"\*\*\*\s*Produced by.+$", flags=regex.DOTALL)):


### PR DESCRIPTION
This pull request addresses the strange formatting issue [reported on the mailing list](https://groups.google.com/forum/#!topic/standardebooks/VkRe8FA9tl0):

> Not sure what the problem is, but after running `create-draft` with
> 
>  `   ~/tools/create-draft --author="William Beckford" --title="Vathek: An Arabian Tale" --gutenberg-ebook-url="https://www.gutenberg.org/ebooks/42401"`
> 
> src/epub/text/body.xhtml looks like this -
> 
> `    ...
    <p>The last years of his life were passed at Bath—where he united two houses in Lansdown Crescent, by an arch thrown across the street, and containing his library, which was well selected, and very extensive. Not far off, he again erected a tower, 180 feet high, of which the following d e s c r i p t i o n w a s g i v e n a t t h e t i m e o f h i s d e c e a s e , b y a c o r r e s p o n d e n t o f t h e A t h e n &amp;a e l i g ; u m : &amp;m d a s h ; / p &gt; p &gt; &amp;l d q u o ; M r . B e c k f o r d , a t a n e a r l y p e r i o d o f h i s r e s i d e n c e t h e r e , e r e c t e d a l o f t y t o w e r , i n t h e a p a r t m e n t s o f w h i c h w e r e p l a c e d m a n y o f h i s c h o i c e s t p a i n t i n g s a n
`
> 
> i.e. each letter has 3 spaces after it for the rest of the file. 

This problem appears to be related to the lxml parser that BeautifulSoup uses. Changing this to html.parser solves the problem.

The BeautifulSoup documentation warns that the output between the lxml and html.parser may not be identical. I compared the output for both parsers on the Vathek ebook and the only difference (prior to the catastrophic divergence reported above) was one new-line character. Since this is only used to create the initial file (which is then reviewed and further manipulated by SE users), I don't think that any differences between the two parsers would cause any problems. lxml appears to be preferred because it's faster than html.parser, but for processing a single ebook, any difference is probably negligible.

BeautifulSoup is used with lxml elsewhere in the tools scripts, but I don't think it's necessary to change it everywhere. Once the file has been parsed and saved with html.parser, lxml has no trouble parsing it normally. (This suggests to me that the real problem is some kind of encoding issue, but I haven't been able to pin it down yet. I'll report it upstream to the appropriate project if I manage to figure it out.)