### PR TITLE
Flip b+w illustrations in Apple Books grey theme

### DIFF
--- a/se/data/templates/compatibility.css
+++ b/se/data/templates/compatibility.css
@@ -27,13 +27,14 @@ img[epub|type~="se:image.color-depth.black-on-transparent"][epub|type~="z3998:pu
 	background: transparent !important;
 }
 
-/* And except in iBooks, where we can target night mode specifically */
+/* And except in Apple Books, where we can target night mode specifically */
 :root[__ibooks_internal_theme] img[epub|type~="se:image.color-depth.black-on-transparent"]{
 	background: transparent !important;
 }
 
-/* Enable night mode in iBooks */
-:root[__ibooks_internal_theme*="Night"] img[epub|type~="se:image.color-depth.black-on-transparent"]{
+/* Enable night mode in Apple Books */
+:root[__ibooks_internal_theme*="Night"] img[epub|type~="se:image.color-depth.black-on-transparent"],
+:root[__ibooks_internal_theme*="Gray"] img[epub|type~="se:image.color-depth.black-on-transparent"]{
 	filter: invert(100%);
 }
 


### PR DESCRIPTION
I’m not sure if this is a new theme, but if you put macOS into ‘dark mode’ Apple Books (née iBooks) defaults to a grey theme. The illustrations also need to be flipped here. Screenshots:

Before:
![Screenshot from Flatland showing black on grey image.](https://user-images.githubusercontent.com/7414/53298455-c0742900-382e-11e9-8e50-1755ab12745c.png)

After:
![Screenshot from Flatland showing new white on grey image.](https://user-images.githubusercontent.com/7414/53298454-c0742900-382e-11e9-8310-a0fdd71346e7.png)

Incidentally, Apple has added an experimental [`prefers-color-scheme: dark`](https://blog.iconfactory.com/2018/10/dark-mode-and-css/) media query to Safari which I imagine will come to Books at some point and could replace these app specific selections. That’s a future thing though.