### PR TITLE
Cap GitHub repo name to 100 characters

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -175,10 +175,10 @@ class SeEpub:
 		None
 
 		OUTPUTS
-		A string representing the GitHub repository URL.
+		A string representing the GitHub repository URL (capped at maximum 100 characters).
 		"""
 
-		return "https://github.com/standardebooks/" + self.generated_identifier.replace("url:https://standardebooks.org/ebooks/", "").replace("/", "_")
+		return "https://github.com/standardebooks/" + self.generated_identifier.replace("url:https://standardebooks.org/ebooks/", "").replace("/", "_")[0:100]
 
 	def _generate_identifier(self) -> str:
 		"""

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -281,7 +281,7 @@ def lint(self, metadata_xhtml) -> list:
 		messages.append(LintMessage("<dc:identifier> does not match expected: {}".format(self.generated_identifier), se.MESSAGE_TYPE_ERROR, "content.opf"))
 
 	# Check that the GitHub repo URL is as expected
-	if self.generated_github_repo_url not in metadata_xhtml:
+	if ("<meta property=\"se:url.vcs.github\">" + self.generated_github_repo_url + "</meta>") not in metadata_xhtml:
 		messages.append(LintMessage("GitHub repo URL does not match expected: {}".format(self.generated_github_repo_url), se.MESSAGE_TYPE_ERROR, "content.opf"))
 
 	# Check if se:name.person.full-name matches their titlepage name

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ To build the project, enter the project's root directory and do:
 python3 setup.py bdist_wheel
 
 To install the project locally, build it and do:
-pip3 install dist/se-*.whl
+pip3 install dist/standardebooks-*.whl
 
 To upload to pypi, twine is required:
 pip3 install twine


### PR DESCRIPTION
Fixes https://github.com/standardebooks/tools/issues/125. Also fixes a hangover from an earler version in the README I found while testing this.