### PR TITLE
Move version specification out of __init__.py.

### DIFF
--- a/se/__init__.py
+++ b/se/__init__.py
@@ -11,9 +11,15 @@ from textwrap import wrap
 from termcolor import colored
 import terminaltables
 import regex
+import pkg_resources
 
 
-VERSION = "1.0.6"
+try:
+    VERSION = pkg_resources.get_distribution('standardebooks').version
+except:
+    # we get in this branch when the package hasn't been installed via pip or
+    # the setup script.
+    VERSION = 'unknown'
 MESSAGE_INDENT = "    "
 UNICODE_BOM = "\ufeff"
 NO_BREAK_SPACE = "\u00a0"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ pip3 install twine
 
 from os import path
 from setuptools import setup, find_packages
-import se
 
 # Get the long description from the README file
 def _get_file_contents(filename):
@@ -26,8 +25,8 @@ def _get_file_contents(filename):
         return file.read()
 
 setup(
+    version="1.0.6",
     name="standardebooks",
-    version=se.VERSION,
     description="The toolset used to produce Standard Ebooks epub ebooks.",
     long_description=_get_file_contents(path.join(path.abspath(path.dirname(__file__)), "README.md")),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This enables the tools to be installed without needing to install
dependencies in a separate step.  It follows the same pattern as the
popular trio Python library.