### PR TITLE
Expanded lint message about ToC not matching spine order.

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -1112,7 +1112,7 @@ def lint(self, metadata_xhtml) -> list:
 			spine_entries = BeautifulSoup(content_opf.read(), "lxml").find("spine").find_all("itemref")
 			for index, entry in enumerate(spine_entries):
 				if toc_files[index] != entry.attrs["idref"]:
-					messages.append(LintMessage("The spine order does not match the order of the ToC and landmarks", se.MESSAGE_TYPE_ERROR, "content.opf"))
+					messages.append(LintMessage("The spine order does not match the order of the ToC and landmarks. Expected " + entry.attrs["idref"] + ", found " + toc_files[index], se.MESSAGE_TYPE_ERROR, "content.opf"))
 					break
 
 	for element in abbr_elements:


### PR DESCRIPTION
Suggested improvement: tell the producer what doesn't match in the spine order.

Now outputs, as example:

Error: content.opf The spine order does not match the order of the ToC and landmarks. Expected part-1.xhtml, found chapter-1-1.xhtml