### PR TITLE
Fixed incorrect method of determining fiction/non-fiction status

### DIFF
--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -97,26 +97,32 @@ def get_content_files(opf: BeautifulSoup) -> list:
 
 	return ret_list
 
-def get_work_title_and_type(opf: BeautifulSoup) -> (str, str):
+def get_se_subjects(xhtml: str) -> list:
+	matches = regex.findall(r"<meta property=\"se:subject\">([^<]+?)</meta>", xhtml)
+	subjects = []
+	if matches:
+		for match in matches:
+			subjects.append(match)
+	return subjects
+
+def get_work_type(xhtml) -> str:
+	subject_list = get_se_subjects(xhtml)
+	for subject in subject_list:
+		if "Nonfiction" in subject:
+			return "non-fiction"
+	return "fiction"
+
+def get_work_title(opf: BeautifulSoup) -> str:
 	"""
 	From content.opf, which we assume has been correctly completed,
-	pulls out the title and determines if the type is fiction or nonfiction.
-	Returns this information as a tuple.
+	pulls out the title.
 	"""
 
-	# First, set up the defaults if we can"t find the info.
-	work_type = "fiction"
-	work_title = "WORK_TITLE"
 	dc_title = opf.find("dc:title")
 	if dc_title is not None:
-		work_title = dc_title.string
-	subjects = opf.find_all("se:subject")
-	for subject in subjects:
-		if "Nonfiction" in subject:
-			work_type = "non-fiction"
-			break
-
-	return work_title, work_type
+		return dc_title.string
+	else:
+		return "WORK_TITLE"
 
 def get_epub_type(soup: BeautifulSoup) -> str:
 	"""

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -462,7 +462,9 @@ def generate_toc(self) -> str:
 
 	soup = BeautifulSoup(self.metadata_xhtml, "html.parser")
 	file_list = get_content_files(soup)
-	work_title, work_type = get_work_title_and_type(soup)
+
+	work_title = get_work_title(soup)
+	work_type = get_work_type(self.metadata_xhtml)
 
 	landmarks, toc_list = process_all_content(file_list, os.path.join(self.directory, "src", "epub", "text"))
 


### PR DESCRIPTION
Addresses issue #142.

My bad. I didn't test my previous method of obtaining the se:subject values, which was way wrong. Copied your approach in lint.