### PR TITLE
Removed raising error if epub:type not found when adding landmarks.

### DIFF
--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -324,10 +324,14 @@ def process_headings(soup: BeautifulSoup, textf: str, toc_list: list, nest_under
 
 	if not heads:  # May be a dedication or an epigraph, with no heading tag.
 		special_item = Toc_item()
-		sections = soup.find_all("section")  # Count the sections within this file.
-		special_item.level = len(sections)
-		if special_item.level == 0:
-			special_item.level = 1
+		# Need to determine level depth.
+		# We don't have a heading, so get the first content item.
+		content_item = soup.find(["p", "header", "img"])
+		if content_item is not None:
+			parents = content_item.find_parents(["section", "article"])
+			special_item.level = len(parents)
+			if special_item.level == 0:
+				special_item.level = 1
 		if nest_under_halftitle:
 			special_item.level += 1
 		title_tag = soup.find("title")  # Use the page title as the ToC entry title.

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -185,9 +185,6 @@ def add_landmark(soup: BeautifulSoup, textf: str, landmarks: list):
 		else:
 			landmark.title = landmark.epub_type.capitalize
 		landmarks.append(landmark)
-	else:
-		raise se.InvalidInputException("Failed to get epub:type from file: " + textf)
-
 
 def process_landmarks(landmarks_list: list, work_type: str, work_title: str):
 	"""


### PR DESCRIPTION
Addresses #144. On reflection, the appropriate action here is not to raise an exception but simply not to add the file as a landmark.