### PR TITLE
Simplified removal of noterefs and removed code handling these

### DIFF
--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -68,7 +68,7 @@ class LandmarkItem:
 	title = ""
 	file_link = ""
 	epub_type = ""
-	place: Position = Position.FRONT
+	place = Position.FRONT
 
 	def output(self, work_type: str = "fiction", work_title: str = "WORK_TITLE"):
 		"""

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -398,8 +398,8 @@ def process_heading_contents(heading, toc_item):
 				try:
 					epub_type = child["epub:type"]
 				except KeyError:
-					# It's a tag without epub:type, such as <abbr>.
-					accumulator += extract_strings(child)
+					# It's a tag without epub:type, such as <abbr>, take whole thing, tags and all.
+					accumulator += str(child)
 					continue  # Skip following and go to next child.
 
 				if "z3998:roman" in epub_type:

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -68,7 +68,7 @@ class LandmarkItem:
 	title = ""
 	file_link = ""
 	epub_type = ""
-	place = Position.FRONT
+	place: Position = Position.FRONT
 
 	def output(self, work_type: str = "fiction", work_title: str = "WORK_TITLE"):
 		"""


### PR DESCRIPTION
I'm now removing noterefs as soon as I've read in the html for each file. This has enabled a considerable simplification of code further downstream (see extract_strings, for example).