### PR TITLE
Fixes to issues found when running print-toc over corpus

### DIFF
--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -119,13 +119,17 @@ def get_work_type(xhtml) -> str:
 	Returns either "fiction" or "non-fiction"
 	"""
 
+	worktype = "fiction"
 	for match in regex.findall(r"<meta property=\"se:subject\">([^<]+?)</meta>", xhtml):
-		# The se:subjects MUST include Nonfiction for the work to be deemed non-fiction.
-		# Otherwise it's impossible to be sure. Some works of fantasy are tagged "Philosophy" for example.
+		# Unfortunately, some works are tagged "Philosophy" but are nevertheless fiction.
 		if "Nonfiction" in match:
 			return "non-fiction"
+		if match in ["Adventure", "Autobiography", "Memoir", "Philosophy", "Spirituality", "Travel"]:
+			worktype = "non-fiction"  # This may change below!
+		if match in ["Fantasy", "Fiction", "Horror", "Mystery", "Science Fiction"]:
+			worktype = "fiction"
 
-	return "fiction"
+	return worktype
 
 def get_work_title(opf: BeautifulSoup) -> str:
 	"""

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -445,7 +445,7 @@ def strip_notes(text: str) -> str:
 	"""
 	Returns html text stripped of noterefs.
 	"""
-	return regex.sub(r'<a.*?epub:type="noteref".*?>\d+<\/a>', "", text)
+	return regex.sub(r'<a .*?epub:type="noteref".*?>\d+<\/a>', "", text)
 
 
 def process_heading_contents(heading, toc_item):

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -374,7 +374,8 @@ def process_heading(heading, is_toplevel, textf) -> Toc_item:
 	toc_item.division = get_book_division(heading)
 
 	# This stops the first heading in a file getting an anchor id, we don't want that.
-	if is_toplevel:
+	# The exceptions are things like poems within single-file volume, usually tagged as articles.
+	if is_toplevel and toc_item.division != BookDivision.ARTICLE:
 		toc_item.id = ""
 		toc_item.file_link = textf
 	else:


### PR DESCRIPTION
I think this is now as close as I can get it to completion. Mismatches found when running over the entire corpus are either:

1. Inclusion of subtitles for Parts and Divisions
2. Inclusion of `<abbr>` or `<i>` tags in Toc
3. Files with unique structures like Keat's poetry

Just as a note: the routine to apply print-toc over the entire corpus and check for mismatches runs in just over 2 minutes, which I reckon is pretty good.