### PR TITLE
Now including subtitles for Volume divisions

### DIFF
--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -26,6 +26,7 @@ class BookDivision(Enum):
 	CHAPTER = 3
 	DIVISION = 4
 	PART = 5
+	VOLUME = 6
 
 class Position(Enum):
 	"""
@@ -69,8 +70,8 @@ class TocItem:
 				out_string += "<a href=\"text/{}\" epub:type=\"z3998:roman\">{}</a>\n".format(self.file_link, self.roman)
 			else:
 				out_string += "<a href=\"text/{}\">{}: {}</a>\n".format(self.file_link, self.title, self.subtitle)
-		else:  # Use the subtitle only if we're a Part or Division
-			if self.subtitle != "" and ((self.division == BookDivision.PART) or (self.division == BookDivision.DIVISION)):
+		else:  # Use the subtitle only if we're a Part or Division or Volume
+			if self.subtitle != "" and (self.division in [BookDivision.PART, BookDivision.DIVISION, BookDivision.VOLUME]):
 				out_string += "<a href=\"text/{}\">{}: {}</a>\n".format(self.file_link, self.title, self.subtitle)
 			else:
 				out_string += "<a href=\"text/{}\">{}</a>\n".format(self.file_link, self.title)
@@ -423,6 +424,8 @@ def get_book_division(tag: BeautifulSoup) -> BookDivision:
 		return BookDivision.PART
 	elif "division" in section_epub_type:
 		return BookDivision.DIVISION
+	elif ("volume" in section_epub_type) and (not "se:short-story" in section_epub_type):
+		return BookDivision.VOLUME
 	elif "subchapter" in section_epub_type:
 		return BookDivision.SUBCHAPTER
 	elif "chapter" in section_epub_type:


### PR DESCRIPTION
Addresses issue #155 . However, it's not quite as simple a fix as it looks. In short fiction collections sections are given an epub:type of  "volume se:short-story". I've never quite understood that, tbh. Anyway, I'm filtering out such epub:types as it could give us subtitles to short stories in the ToC, which I presume we don't want.