### PR TITLE
Add empale -> impale to modernize-spelling

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -203,6 +203,8 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b([Ss])ha’n’t", r"\1han’t", xhtml)				# sha'n't -> shan't (see https://english.stackexchange.com/questions/71414/apostrophes-in-contractions-shant-shant-or-shant)
 	xhtml = regex.sub(r"\b([Ss])[uû]ret[eé]", r"\1ûreté", xhtml)			# Surete -> Sûreté
 	xhtml = regex.sub(r"\b([Ss])eance", r"\1éance", xhtml)				# seance -> séance
+	xhtml = regex.sub(r"\bEmpale", r"Impale", xhtml)				# empale -> impale
+	xhtml = regex.sub(r"\bempale", r"impale", xhtml)				# empale -> impale
 
 	# Normalize some names
 	xhtml = regex.sub(r"Moliere", r"Molière", xhtml)				# Moliere -> Molière


### PR DESCRIPTION
Google Ngrams: https://books.google.com/ngrams/graph?content=impale%2Cempale&year_start=1800&year_end=2000&corpus=15&smoothing=3&share=&direct_url=t1%3B%2Cimpale%3B%2Cc0%3B.t1%3B%2Cempale%3B%2Cc0

"empaled" was used in *Commentaries on the Gallic War*, and we're changing it to "impaled".