### PR TITLE
Remove a11y prefix compatibility additon

### DIFF
--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -348,7 +348,6 @@ def build(self, metadata_xhtml, metadata_tree, run_epubcheck, build_kobo, build_
 
 		# Google Play Books chokes on https XML namespace identifiers (as of at least 2017-07)
 		metadata_xhtml = metadata_xhtml.replace("https://standardebooks.org/vocab/1.0", "http://standardebooks.org/vocab/1.0")
-		metadata_xhtml = metadata_xhtml.replace("https://www.idpf.org/epub/vocab/package/a11y/", "http://www.idpf.org/epub/vocab/package/a11y/")
 
 		# Output the modified content.opf so that we can build the kobo book before making more epub2 compatibility hacks
 		with open(os.path.join(work_epub_root_directory, "epub", "content.opf"), "w", encoding="utf-8") as file:

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -346,10 +346,6 @@ def build(self, metadata_xhtml, metadata_tree, run_epubcheck, build_kobo, build_
 		metadata_xhtml = metadata_xhtml.replace("image/svg+xml", "image/png")
 		metadata_xhtml = regex.sub(r"properties=\"([^\"]*?)svg([^\"]*?)\"", "properties=\"\\1\\2\"", metadata_xhtml) # We may also have the `mathml` property
 
-		# NOTE: even though the a11y namespace is reserved by the epub spec, we must declare it because epubcheck doesn't know that yet.
-		# Once epubcheck understands the a11y namespace is reserved, we can remove it from the namespace declarations.
-		metadata_xhtml = metadata_xhtml.replace(" prefix=\"se: https://standardebooks.org/vocab/1.0\"", " prefix=\"se: https://standardebooks.org/vocab/1.0, a11y: https://www.idpf.org/epub/vocab/package/a11y/\"")
-
 		# Google Play Books chokes on https XML namespace identifiers (as of at least 2017-07)
 		metadata_xhtml = metadata_xhtml.replace("https://standardebooks.org/vocab/1.0", "http://standardebooks.org/vocab/1.0")
 		metadata_xhtml = metadata_xhtml.replace("https://www.idpf.org/epub/vocab/package/a11y/", "http://www.idpf.org/epub/vocab/package/a11y/")


### PR DESCRIPTION
epubcheck now marks the a11y prefix wrong as it now understands it is a reserved prefix so this piece of code is no longer needed.