### PR TITLE
check if lengths of spine and ToC match before comparing them

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -1129,10 +1129,13 @@ def lint(self, metadata_xhtml) -> list:
 			[unique_toc_files.append(i) for i in toc_files if not unique_toc_files.count(i)]
 			toc_files = unique_toc_files
 			spine_entries = BeautifulSoup(content_opf.read(), "lxml").find("spine").find_all("itemref")
-			for index, entry in enumerate(spine_entries):
-				if toc_files[index] != entry.attrs["idref"]:
-					messages.append(LintMessage("The spine order does not match the order of the ToC and landmarks. Expected {}, found {}.".format(entry.attrs["idref"], toc_files[index]), se.MESSAGE_TYPE_ERROR, "content.opf"))
-					break
+			if len(toc_files) == len(spine_entries):
+				for index, entry in enumerate(spine_entries):
+					if toc_files[index] != entry.attrs["idref"]:
+						messages.append(LintMessage("The spine order does not match the order of the ToC and landmarks. Expected {}, found {}.".format(entry.attrs["idref"], toc_files[index]), se.MESSAGE_TYPE_ERROR, "content.opf"))
+						break
+			else:
+				messages.append(LintMessage("Number of elements in spine does not match the number of elements of the ToC and landmarks.", se.MESSAGE_TYPE_ERROR, "content.opf"))
 
 	for element in abbr_elements:
 		try:


### PR DESCRIPTION
Don't know how I managed but I had different lengths in spine and ToC and so lint died with a IndexError.

This is how spine and ToC looked like, note the double `copyright.xhtml`.

```
['titlepage.xhtml', 'imprint.xhtml', 'body.xhtml', 'copyright.xhtml', 'endnotes.xhtml', 'loi.xhtml', 'colophon.xhtml']
<itemref idref="titlepage.xhtml"></itemref>
<itemref idref="imprint.xhtml"></itemref>
<itemref idref="body.xhtml"></itemref>
<itemref idref="copyright.xhtml"></itemref>
<itemref idref="endnotes.xhtml"></itemref>
<itemref idref="loi.xhtml"></itemref>
<itemref idref="colophon.xhtml"></itemref>
<itemref idref="copyright.xhtml"></itemref>
```

Please note that this happened on a modified version. To my knowledge none of the modifications should cause this. I think it doesn't hurt to check the lengths, but if you think that this is impossible to happen with the vanilla version then please discard this PR.