### PR TITLE
Remove unused imports

### DIFF
--- a/se/executables_create_draft.py
+++ b/se/executables_create_draft.py
@@ -6,7 +6,6 @@ It *could* be inlined in executables.py, but it's broken out into its own file f
 and maintainability.
 """
 
-import os
 import shutil
 from pathlib import Path
 from subprocess import call

--- a/se/mobi.py
+++ b/se/mobi.py
@@ -14,12 +14,7 @@ https://www.mobileread.com/forums/showpost.php?p=3165291
 from __future__ import unicode_literals, division, absolute_import, print_function
 
 import sys
-import os
-import getopt
 import struct
-import locale
-import codecs
-import traceback
 
 text_type = str
 binary_type = bytes

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -7,7 +7,6 @@ Standard Ebooks epub3 files.
 import os
 import html
 import tempfile
-import errno
 import shutil
 import fnmatch
 import datetime


### PR DESCRIPTION
I've been playing around with running pylint on the standardebooks code and found these unused imports.