### PR TITLE
Convert Path to string before printing

### DIFF
--- a/se/executables.py
+++ b/se/executables.py
@@ -100,7 +100,7 @@ def british2american() -> int:
 					convert = False
 					if args.verbose:
 					 	print("")
-					se.print_warning("File appears to already use American quote style, ignoring. Use --force to convert anyway.{}".format(" File: " + filename if not args.verbose else ""), args.verbose)
+					se.print_warning("File appears to already use American quote style, ignoring. Use --force to convert anyway.{}".format(" File: " + str(filename) if not args.verbose else ""), args.verbose)
 
 			if convert:
 				new_xhtml = se.typography.convert_british_to_american(xhtml)


### PR DESCRIPTION
The british2american command crashes if the text already uses american-style quotes. The crash is because the warning message is trying to print a Path object without converting it to a string.

$ se british2american .
Traceback (most recent call last):
  File "/home/dave/work/se-tools/venv/bin/se", line 11, in <module>
    load_entry_point('standardebooks', 'console_scripts', 'se')()
  File "/home/dave/work/se-tools/se/executables.py", line 76, in main
    return globals()[args.command.replace("-", "_")]()
  File "/home/dave/work/se-tools/se/executables.py", line 103, in british2american
    se.print_warning("File appears to already use American quote style, ignoring. Use --force to convert anyway.{}".format(" File: " + filename if not args.verbose else ""), args.verbose)
TypeError: must be str, not PosixPath


