### PR TITLE
Update search URL for Wikipedia

### DIFF
--- a/se/executables_create_draft.py
+++ b/se/executables_create_draft.py
@@ -298,13 +298,17 @@ def _get_wikipedia_url(string: str, get_nacoaf_url: bool) -> (str, str):
 	# returns HTTP 200, then we didn't find a direct match and return nothing.
 
 	try:
-		response = requests.get("https://en.wikipedia.org/wiki/Special:Search", params={"search": string, "go": "Go"}, allow_redirects=False)
+		response = requests.get("https://en.wikipedia.org/wiki/Special:Search",
+								params={"search": string, "go": "Go", "ns0": 1}, allow_redirects=False)
 	except Exception as ex:
 		se.print_error("Couldn’t contact Wikipedia. Error: {}".format(ex))
 
 	if response.status_code == 302:
 		nacoaf_url = None
 		wiki_url = response.headers["Location"]
+		if urllib.parse.urlparse(wiki_url).path == "/wiki/Special:Search":
+			# Redirected back to search URL, no match
+			return None, None
 
 		if get_nacoaf_url:
 			try:


### PR DESCRIPTION
I was finding that the clean command was failing on the content.opf file. The root cause was an invalid (unescaped) URL for Wikipedia.

The URL "https://en.wikipedia.org/wiki/Special:Search?search=unknown_search_term&go=Go" was redirecting to "https://en.wikipedia.org/wiki/Special:Search?search=unknown_search_term&go=Go&ns0=1" (note extra ns0=1 term) which was then returned as a successful article match. The unescaped ampersands cause the clean on content.opf to fail.

I've updated the code with the new Wikipedia search URL. I also added a check to see if the URL path has actually updated to protect from future Wikipedia search parameter changes.

It might also be a good idea to html.escape() the URL? I can add that too if you think it's a good idea.
