### PR TITLE
Package updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "cssselect==1.0.1",
         "ftfy==5.3.0",
         "gitpython==2.1.5",
-        "lxml==4.2.3",
+        "lxml==4.4.0",
         "psutil==5.5.0",
         "pyhyphen==3.0.1",
         # "pyopenssl>=19.0.0",  # Required to allows the `requests` package to use https on Mac OSX, but segfaults when installed on Ubuntu

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,8 @@ setup(
     python_requires=">=3.5", # The latest version installed by default on Ubuntu 16.04 is 3.5.2
     install_requires=[
         "beautifulsoup4==4.6.0",
-        "cssselect==1.0.1",
-        "ftfy==5.3.0",
+        "cssselect==1.0.3",
+        "ftfy==5.5.1",
         "gitpython==2.1.5",
         "lxml==4.4.0",
         "psutil==5.5.0",
@@ -55,8 +55,8 @@ setup(
         "python-magic==0.4.13",
         "regex==2017.7.26",
         "requests>=2.20.0",
-        "roman==2.0.0",
-        "smartypants==2.0.0",
+        "roman==3.2.0",
+        "smartypants==2.0.1",
         "titlecase==0.11.0",
         "termcolor==1.1.0",
         "terminaltables==3.1.0"

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_packages(),
     python_requires=">=3.5", # The latest version installed by default on Ubuntu 16.04 is 3.5.2
     install_requires=[
-        "beautifulsoup4==4.6.0",
+        "beautifulsoup4==4.8.0",
         "cssselect==1.0.3",
         "ftfy==5.5.1",
         "gitpython==2.1.5",


### PR DESCRIPTION
This gets us up to the latest on a bunch of packages. Rebuilding the entire corpus and MD5ing the `.epub` shows that pretty much all have changed, but checking specific packages (I tested with Wittgenstein, Babbage, and Johnson’s The Alchemist) shows that it’s the order of the generated pseudoclass classes versus the generated epub classes that’s causing the difference. No other differences were found.

Generally, the common themes for the updates were increased speed and dropping of Python 2 / 3.3. `ftfy` also claims that it should better detect mojibake in small words.