### PR TITLE
Changed ebook-convert error message to be a bit clearer

### DIFF
--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -60,7 +60,7 @@ def build(self, metadata_xhtml: str, metadata_tree: se.easy_xml.EasyXmlTree, run
 			# Look for default Mac calibre app path if none found in path
 			ebook_convert_path = Path("/Applications/calibre.app/Contents/MacOS/ebook-convert")
 			if not ebook_convert_path.exists():
-				raise se.MissingDependencyException("Couldn’t locate epubcheck. Is it installed?")
+				raise se.MissingDependencyException("Couldn’t locate ebook-convert. Is Calibre installed?")
 
 	if run_epubcheck:
 		try:


### PR DESCRIPTION
While trying to generate a `.azw3` file for Kindle, I got the output `Error: Couldn’t locate epubcheck. Is it installed?`

I felt this was a bit misleading as I did have `epubcheck` installed. The step was actually looking for `ebook-convert`, which ships as part of Calibre. I had forgot to install Calibre but spent a little bit of time scratching myself over why `se` couldn't find my `epubcheck` install.

I think you can possibly install `ebook-convert` as a standalone item but seeing as the docs recommend/require Calibre as an install step, it didn't seem that much of a stretch to have the error message just ask `Is Calibre installed?` rather than a potentially less informative `Is ebook-convert installed?`