### PR TITLE
add support for page-list in ToC and pagebreak tags in the text

### DIFF
--- a/se/data/navdoc2ncx.xsl
+++ b/se/data/navdoc2ncx.xsl
@@ -25,6 +25,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 	xmlns:opf="http://www.idpf.org/2007/opf"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:re="http://exslt.org/regular-expressions"
 	xmlns:c="urn:oasis:names:tc:opendocument:xmlns:container"
 	version="2.0">
 
@@ -190,7 +191,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 					    </xsl:when>
 					    <xsl:otherwise>
 					        <xsl:choose>
-					            <xsl:when test="matches($pageNumber,'[0-9]+')">
+					            <xsl:when test="re:match($pageNumber,'[0-9]+')">
 					                <!-- can't distinguish body from back in the nav doc -->
 					                <xsl:text>normal</xsl:text>
 					            </xsl:when>


### PR DESCRIPTION
Most ebooks won't have them but those coming from a printed source and wanting to provide references to actual pages for citing etc. would use a `page-list` nav in the ToC and `epub:type="pagebreak"` spans in the text.

This PR adds support for page-lists to the ToC generation utility, if there are no `pagebreak` spans the additional nav won't show up. The XSLT transform for the NCX file already supported pageMaps, but the `matches` function is not usable with `ltree.xml`, so I had to add another namespace and use the `re:match` function.

Maybe page-list support is not in scope for standard ebooks, but since the toolset is also great for building ebooks in general maybe it is worthwhile to have it in.