### PR TITLE
Update template to claim WCAG 2.1 compliance

### DIFF
--- a/se/data/templates/content.opf
+++ b/se/data/templates/content.opf
@@ -25,7 +25,7 @@
 		<meta property="schema:accessibilityFeature">structuralNavigation</meta>
 		<meta property="schema:accessibilityFeature">tableOfContents</meta>
 		<meta property="schema:accessibilityHazard">none</meta>
-		<meta property="schema:accessibilitySummary">This publication conforms to WCAG 2.0 Level AA.</meta>
+		<meta property="schema:accessibilitySummary">This publication conforms to WCAG 2.1 Level AA.</meta>
 		<link href="onix.xml" media-type="application/xml" properties="onix" rel="record"/>
 		<dc:title id="title">TITLE</dc:title>
 		<meta property="file-as" refines="#title">TITLE_SORT</meta>


### PR DESCRIPTION
There’s really nothing new in 2.1 that affects us (see https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/) but we might as well claim compliance with the latest version of the standard.