### PR TITLE
Improve handling of CSS syntax errors

### DIFF
--- a/se/__init__.py
+++ b/se/__init__.py
@@ -124,6 +124,10 @@ class LintFailedException(SeException):
 	""" Lint failed """
 	code = 13
 
+class InvalidCssException(SeException):
+	""" Invalid CSS """
+	code = 14
+
 def natural_sort(list_to_sort: list) -> list:
 	"""
 	Natural sort a list.

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -256,6 +256,8 @@ def build(self, metadata_xhtml: str, metadata_tree: se.easy_xml.EasyXmlTree, run
 						except lxml.cssselect.ExpressionError:
 							# This gets thrown if we use pseudo-elements, which lxml doesn't support
 							pass
+						except lxml.cssselect.SelectorSyntaxError as ex:
+							raise se.InvalidCssException("Couldn't parse CSS in or near this line: {}\n{}".format(selector, ex))
 
 						# We've already replaced attribute/namespace selectors with classes in the CSS, now add those classes to the matching elements
 						if "[epub|type" in selector:
@@ -282,6 +284,8 @@ def build(self, metadata_xhtml: str, metadata_tree: se.easy_xml.EasyXmlTree, run
 						except lxml.cssselect.ExpressionError:
 							# This gets thrown if we use pseudo-elements, which lxml doesn't support
 							continue
+						except lxml.cssselect.SelectorSyntaxError as ex:
+							raise se.InvalidCssException("Couldn't parse CSS in or near this line: {}\n{}".format(selector, ex))
 
 						# Convert <abbr> to <span>
 						if "abbr" in selector:

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -143,6 +143,8 @@ def _get_unused_selectors(self) -> set:
 			# This gets thrown if we use pseudo-elements, which lxml doesn't support
 			unused_selectors.remove(selector)
 			continue
+		except lxml.cssselect.SelectorSyntaxError as ex:
+			raise se.InvalidCssException("Couldn't parse CSS in or near this line: {}\n{}".format(selector, ex))
 
 		for filename in filenames:
 			if not filename.endswith("titlepage.xhtml") and not filename.endswith("imprint.xhtml") and not filename.endswith("uncopyright.xhtml"):


### PR DESCRIPTION
With this change, se tools print a more descriptive error message when cssselect encounters a CSS syntax error during lint or build.

Previously, the scripts simply exited with a stack trace that was difficult to decipher, and didn't indicate where in the CSS the problem was. This was reported in [this email](https://groups.google.com/d/msg/standardebooks/0CW04wKdKKE/S-gXUGW0DAAJ) on the mailing list.

This update allows se to exit with a clear error message that specifically says that there is a CSS problem and prints the text of the line where the problem was encountered, like this:
> Error: Couldn't parse CSS in or near this line: p[epub|type~"z3998:salutation"]

Limitations of this approach:
* The error doesn't say which file the error was in. Since SE projects should only be editing CSS in local.css, this is probably fine.
* Some kinds of CSS errors are detected on the previous or next line, which can cause unhelpful messages like "Couldn't parse CSS in or near this line: }". I don't know how to improve this. (Maybe print the lines before and after the error? I'm not sure how to do that nicely with the se.print_error function.)
* The original exception from cssselect actually says which character the parser was on when it identified the error. It would be cool to point this out in the error message, but not cool enough for the extra work it would involve.
