### PR TITLE
Add check for nbsp's surrounding ampersands (&amp;)

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -661,6 +661,16 @@ def lint(self, metadata_xhtml) -> list:
 					if matches:
 						messages.append(LintMessage("Tags should end with a single >.", se.MESSAGE_TYPE_WARNING, filename))
 
+					# Check for nbsp before ampersand (&amp)
+					matches = regex.findall(r"[^{}]\&amp;".format(se.NO_BREAK_SPACE), file_contents)
+					if matches:
+						messages.append(LintMessage("Required nbsp not found before &amp;", se.MESSAGE_TYPE_WARNING, filename))
+
+					# Check for nbsp after ampersand (&amp)
+					matches = regex.findall(r"\&amp;[^{}]".format(se.NO_BREAK_SPACE), file_contents)
+					if matches:
+						messages.append(LintMessage("Required nbsp not found after &amp;", se.MESSAGE_TYPE_WARNING, filename))
+
 					# Check for nbsp before times
 					matches = regex.findall(r"[0-9]+[^{}]<abbr class=\"time".format(se.NO_BREAK_SPACE), file_contents)
 					if matches:


### PR DESCRIPTION
The manual says to have non-break spaces on either side of an ampersand. It's specifically talking about company names, but I can't think of a different situation where we would use ampersands and _not_ want the surround non-break spaces. If there is such a situation, then you can ignore this PR. :)

This adds lint checks for the nbsp's on either side of an ampersand.