### PR TITLE
Add source checks to colophon

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -402,11 +402,11 @@ def lint(self, metadata_xhtml) -> list:
 							if "gutenberg.org" in link and "<a href=\"{}\">Project Gutenberg</a>".format(link) not in file_contents:
 								messages.append(LintMessage("Source not represented in colophon.xhtml. It should read: <a href=\"{}\">Project Gutenberg</a>".format(link), se.MESSAGE_TYPE_WARNING, filename))
 
-							if "hathitrust.org" in link and "<a href=\"{}\">HathiTrust Digital Library</a>".format(link) not in file_contents:
-								messages.append(LintMessage("Source not represented in colophon.xhtml. It should read: <a href=\"{}\">HathiTrust Digital Library</a>".format(link), se.MESSAGE_TYPE_WARNING, filename))
+							if "hathitrust.org" in link and "the<br/>\n\t\t\t<a href=\"{}\">HathiTrust Digital Library</a>".format(link) not in file_contents:
+								messages.append(LintMessage("Source not represented in colophon.xhtml. It should read: the<br/> <a href=\"{}\">HathiTrust Digital Library</a>".format(link), se.MESSAGE_TYPE_WARNING, filename))
 
-							if "archive.org" in link and "<a href=\"{}\">Internet Archive</a>".format(link) not in file_contents:
-								messages.append(LintMessage("Source not represented in colophon.xhtml. It should read: <a href=\"{}\">Internet Archive</a>".format(link), se.MESSAGE_TYPE_WARNING, filename))
+							if "archive.org" in link and "the<br/>\n\t\t\t<a href=\"{}\">Internet Archive</a>".format(link) not in file_contents:
+								messages.append(LintMessage("Source not represented in colophon.xhtml. It should read: the<br/> <a href=\"{}\">Internet Archive</a>".format(link), se.MESSAGE_TYPE_WARNING, filename))
 
 							if "books.google.com" in link and "<a href=\"{}\">Google Books</a>".format(link) not in file_contents:
 								messages.append(LintMessage("Source not represented in colophon.xhtml. It should read: <a href=\"{}\">Google Books</a>".format(link), se.MESSAGE_TYPE_WARNING, filename))

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -394,6 +394,23 @@ def lint(self, metadata_xhtml) -> list:
 					if ">trl<" in metadata_xhtml and "translated from" not in file_contents:
 						messages.append(LintMessage("Translator detected in metadata, but no 'translated from LANG' block in colophon", se.MESSAGE_TYPE_ERROR, filename))
 
+					# are the sources represented correctly?
+					# We don't have a standard yet for more than two sources (transcription and scan) so just ignore that case for now.
+					matches = regex.findall(r"<dc:source>([^<]+?)</dc:source>", metadata_xhtml)
+					if len(matches) <= 2:
+						for link in matches:
+							if "gutenberg.org" in link and "<a href=\"{}\">Project Gutenberg</a>".format(link) not in file_contents:
+								messages.append(LintMessage("Source not represented in colophon.xhtml. It should read: <a href=\"{}\">Project Gutenberg</a>".format(link), se.MESSAGE_TYPE_WARNING, filename))
+
+							if "hathitrust.org" in link and "<a href=\"{}\">HathiTrust Digital Library</a>".format(link) not in file_contents:
+								messages.append(LintMessage("Source not represented in colophon.xhtml. It should read: <a href=\"{}\">HathiTrust Digital Library</a>".format(link), se.MESSAGE_TYPE_WARNING, filename))
+
+							if "archive.org" in link and "<a href=\"{}\">Internet Archive</a>".format(link) not in file_contents:
+								messages.append(LintMessage("Source not represented in colophon.xhtml. It should read: <a href=\"{}\">Internet Archive</a>".format(link), se.MESSAGE_TYPE_WARNING, filename))
+
+							if "books.google.com" in link and "<a href=\"{}\">Google Books</a>".format(link) not in file_contents:
+								messages.append(LintMessage("Source not represented in colophon.xhtml. It should read: <a href=\"{}\">Google Books</a>".format(link), se.MESSAGE_TYPE_WARNING, filename))
+
 				if filename == "titlepage.xhtml":
 					if "<title>Titlepage</title>" not in file_contents:
 						messages.append(LintMessage("Titlepage <title> tag must contain exactly: \"Titlepage\".", se.MESSAGE_TYPE_ERROR, filename))


### PR DESCRIPTION
Adds the same source checks to colophon that are on imprint. This catches instances where imprint and colophon have different sources, which I've accidentally done a couple of times.

Since colophon has the "digital scans available" on a separate line, ended with a ```<br/>```, then the URL on the next line, I chose to only check for the URL, rather than the entire ```the<br/>\s+<a …```. The regex wouldn't have been an issue (I don't think), but I couldn't come up with a good error message. And I was more worried about making sure the URL's were the same than that the "the" was present for Hathi and Internet Archive.

If you want the "the" checked for, just let me know what you'd like the error message to look like and I'll make the changes.