### PR TITLE
Add Python headers to required packages for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ sudo ln -s $HOME/.local/pipx/venvs/standardebooks/lib/python3.*/site-packages/se
 
 ```shell
 # Install some pre-flight dependencies.
-sudo dnf install firefox ImageMagick calibre librsvg2-tools vim inkscape libxml2 perl-Image-ExifTool java-1.8.0-openjdk
+sudo dnf install firefox ImageMagick calibre librsvg2-tools vim inkscape libxml2 perl-Image-ExifTool java-1.8.0-openjdk python3-devel
 
 # Install pipx.
 python3 -m pip install --user pipx


### PR DESCRIPTION
This turned out to be needed for a standard new Fedora install in a test VM, so that pipx could install standardebooks.