### PR TITLE
add vim--gtk3 to the OpenBSD tool set

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ These instructions were tested on OpenBSD 6.6, but may also work on the 6.5 rele
 	inkscape--
 	calibre--
 	git--
-	vim--gtk3
+	vim--
 	```
+Optionally, replace `vim--` with `vim--gtk3` to include gvim for its Unicode editing features.
 
 2. Install dependencies using ```doas pkg_add -ivl ~/standard-ebooks-packages```. Follow linking instructions provided by ```pkg_add``` to save keystrokes, unless you want to have multiple python versions and pip versions. In my case, I ran ```doas ln -sf /usr/local/bin/pip3.7 /usr/local/bin/pip```.
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ These instructions were tested on OpenBSD 6.6, but may also work on the 6.5 rele
 	inkscape--
 	calibre--
 	git--
+	vim--gtk3
 	```
 
 2. Install dependencies using ```doas pkg_add -ivl ~/standard-ebooks-packages```. Follow linking instructions provided by ```pkg_add``` to save keystrokes, unless you want to have multiple python versions and pip versions. In my case, I ran ```doas ln -sf /usr/local/bin/pip3.7 /usr/local/bin/pip```.


### PR DESCRIPTION
A recommendation to add to the toolkit for OpenBSD: the vim editor.  1) vim is required for `se interactive-vr`, 2) vimdiff can be configured for use with `git difftool`, nothing in the OpenBSD base or the tools list provides a utility for difftool, 3) gvim is useful for editing Unicode fields -- these cannot be easily edited with vim from a console/xterm -- and 4) the gtk3 infrastructure is already a dependency of calibre. 