### PR TITLE
Report more details about encoding and XML errors

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -155,6 +155,11 @@ def _get_unused_selectors(self) -> set:
 
 				try:
 					tree = etree.fromstring(str.encode(xhtml))
+				except UnicodeError:
+					raise se.InvalidXhtmlException("Error encoding file: {}, source: {}".format(filename,err.object[err.start:err.end]))
+				except etree.XMLSyntaxError as e:
+					log = e.error_log.filter_from_level(etree.ErrorLevels.FATAL)
+					raise se.InvalidXhtmlException("Couldn't parse XHTML in file: {}, error: {}".format(filename, log[0]))
 				except Exception:
 					raise se.InvalidXhtmlException("Couldn't parse XHTML in file: {}".format(filename))
 

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -155,14 +155,8 @@ def _get_unused_selectors(self) -> set:
 
 				try:
 					tree = etree.fromstring(str.encode(xhtml))
-				except UnicodeError as ex:
-					raise se.InvalidXhtmlException("Error encoding file: {}, source: {}".format(filename, ex.object[ex.start:ex.end]))
 				except etree.XMLSyntaxError as ex:
-					log = ex.error_log.filter_from_level(etree.ErrorLevels.FATAL)
-					if len(log) > 0:
-						raise se.InvalidXhtmlException("Couldn't parse XHTML in file: {}, error: {}".format(filename, log[0]))
-					else
-						raise se.InvalidXhtmlException("Couldn't parse XHTML in file: {}".format(filename))
+					raise se.InvalidXhtmlException("Couldn't parse XHTML in file: {}, error: {}".format(filename, str(ex)))
 				except Exception:
 					raise se.InvalidXhtmlException("Couldn't parse XHTML in file: {}".format(filename))
 

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -155,11 +155,14 @@ def _get_unused_selectors(self) -> set:
 
 				try:
 					tree = etree.fromstring(str.encode(xhtml))
-				except UnicodeError:
-					raise se.InvalidXhtmlException("Error encoding file: {}, source: {}".format(filename,err.object[err.start:err.end]))
-				except etree.XMLSyntaxError as e:
-					log = e.error_log.filter_from_level(etree.ErrorLevels.FATAL)
-					raise se.InvalidXhtmlException("Couldn't parse XHTML in file: {}, error: {}".format(filename, log[0]))
+				except UnicodeError as ex:
+					raise se.InvalidXhtmlException("Error encoding file: {}, source: {}".format(filename, ex.object[ex.start:ex.end]))
+				except etree.XMLSyntaxError as ex:
+					log = ex.error_log.filter_from_level(etree.ErrorLevels.FATAL)
+					if len(log) > 0:
+						raise se.InvalidXhtmlException("Couldn't parse XHTML in file: {}, error: {}".format(filename, log[0]))
+					else
+						raise se.InvalidXhtmlException("Couldn't parse XHTML in file: {}".format(filename))
 				except Exception:
 					raise se.InvalidXhtmlException("Couldn't parse XHTML in file: {}".format(filename))
 


### PR DESCRIPTION
When there's an XML error in a file, lint just dies telling us the filename, but there is no indication what the error might be or where it is. In larger files (stories/chapters/etc.), it can take a while to find the problem. On the Mac, Quicklook will tell you the line/byte of the error, so this hasn't been a huge problem for me, but it would be a lot easier to get more detail direct from lint, and even more so for Windows/Linux.

This adds exceptions to the existing try/except for both encoding errors from the encode, and XML errors from lxml's etree. In a file where I was missing a closing quote on an epub:type, the error would look like this with the change. The "11:227" is the line and byte. (Without the closing quote, it searches the rest of the file for the closing bracket, thinking everything is part of the string. _Technically_ the error is incorrect, but the line/byte is enough information to easily see the problem.)

`Error: Couldn't parse XHTML in file: /Users/vrice/src/books/o-henry_short-fiction/src/epub/text/a-little-local-colour.xhtml, error: <string>:11:227:FATAL:PARSER:ERR_LT_IN_ATTRIBUTE: Unescaped '<' not allowed in attributes values`