### PR TITLE
Update pipx developer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ To do that, follow the general installation instructions above; but instead of d
 
 ```shell
 git clone https://github.com/standardebooks/tools.git
-pipx install --editable --spec tools standardebooks
+pipx install --editable tools
 
 # Optional: ZSH users can install tab completion.
 sudo ln -s $(readlink -f .)/tools/se/completions/zsh/_se /usr/share/zsh/vendor-completions/_se && hash -rf && compinit


### PR DESCRIPTION
Since pipx 0.15 the --spec flag has been removed. This new command worked for me to reinstall se.