### PR TITLE
Improve error output for colophon lint check

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -402,7 +402,7 @@ def lint(self, metadata_xhtml) -> list:
 						messages.append(LintMessage("Translator detected in metadata, but no 'translated from LANG' block in colophon", se.MESSAGE_TYPE_ERROR, filename))
 
 					# Check if we forgot to fill any variable slots
-					matches = regex.findall(r"(TITLE|YEAR|AUTHOR|PRODUCER|PG_[A-Z]+|TRANSCRIBER_[0-9]+|[A-Z]+_URL|PAINTING|ARTIST|SE_[A-Z]+)", file_contents)
+					matches = regex.findall(r"([A-Z_]{3,}[0-9]*)", file_contents)
 					for match in matches:
 						messages.append(LintMessage("Missing data in colophon: {}".format(match), se.MESSAGE_TYPE_ERROR, filename))
 


### PR DESCRIPTION
The previous regex used for checking for unfilled variables in the colophon was producing inaccurate error messages. It indicated that PRODUCER was missing rather than PRODUCER_URL and that ARTIST and WIKI_URL were missing rather than ARTIST_WIKI_URL. This new regex check is simpler, finds all of the missing variables in the generated draft colophon, and does not result in any inaccurate error messages.