### PR TITLE
Remove ordinals after roman numerals

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -276,6 +276,9 @@ def modernize_spelling(xhtml: str) -> str:
 	# Remove spaces before contractions like n’t eg "is n’t" -> "isn’t"
 	xhtml = regex.sub(r" n’t\b", "n’t", xhtml)
 
+	# Remove roman ordinals
+	xhtml = regex.sub(r"<span epub:type=\"z3998:roman\">(.*?)</span>(st|nd|rd|th)\b", r'<span epub:type="z3998:roman">\1</span>', xhtml)
+
 	# Canadian spelling follows US
 	if language in ["en-US", "en-CA"]:
 		xhtml = regex.sub(r"\b([Cc])osey", r"\1ozy", xhtml)


### PR DESCRIPTION
This is an editorial modernisation decision should part of spelling.

Tested in Tristram, leading to https://github.com/robinwhittleton/laurence-sterne_the-life-and-opinions-of-tristram-shandy-gentleman/commit/c4f18b41fa962b2e583986fb548a9e4de7610e7f.