### PR TITLE
Disable import-outside-toplevel pylint error

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -6,4 +6,4 @@ ignore=vendor
 extension-pkg-whitelist=lxml
 
 [MESSAGES CONTROL]
-disable=mixed-indentation,line-too-long,too-many-nested-blocks,too-many-branches,too-many-statements,too-many-boolean-expressions,too-many-lines,too-many-locals,broad-except,bare-except,too-few-public-methods,too-many-arguments,too-many-instance-attributes
+disable=mixed-indentation,line-too-long,too-many-nested-blocks,too-many-branches,too-many-statements,too-many-boolean-expressions,too-many-lines,too-many-locals,broad-except,bare-except,too-few-public-methods,too-many-arguments,too-many-instance-attributes,import-outside-toplevel


### PR DESCRIPTION
I tried changing the code to move the imports. The performance penalty was just over 100 ms which seemed like a lot for the faster commands which run in around 500 ms on my machine. So in the end I just disabled the warning.