### PR TITLE
Fix the build-images script with Inkscape 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,9 @@ sudo ln -s $HOME/.local/pipx/venvs/standardebooks/lib/python3.*/site-packages/se
 sudo ln -s $HOME/.local/pipx/venvs/standardebooks/lib/python3.*/site-packages/se/completions/bash/se /usr/share/bash-completion/completions/se
 ```
 
-## macOS users (up to macOS 10.14)
+## macOS users (up to macOS 10.15)
 
-These instructions were tested on macOS 10.12 to 10.14.
-
-**Warning:** The Standard Ebooks toolset currently will *not* build cover images on macOS 10.15 Catalina due to Inkscape compatibility problems. The older version of Inkscape that works with this project is 32-bit only and no longer runs on 10.15, and the new version [doesn’t yet have a command line interface](https://gitlab.com/inkscape/inkscape/issues/457). For the time being, your best option is to run Ubuntu or Fedora (see above) in a virtual machine, for example with [VirtualBox](https://www.virtualbox.org/).
+These instructions were tested on macOS 10.12 to 10.15.
 
 1. Install the [Homebrew package manager](https://brew.sh). Or, if you already have it installed, make sure it’s up to date:
 

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -470,8 +470,12 @@ class SeEpub:
 		if source_titlepage_svg_filename.is_file():
 			# Convert text to paths
 			# inkscape adds a ton of crap to the SVG and we clean that crap a little later.
+			# 1.0 needs an --export-file flag that 0.92 doesn’t, so we need to normalise that first.
+			output_file_flag = str(dest_titlepage_svg_filename)
+			if "--export-file=" in subprocess.run([str(inkscape_path), "--help"], stdout=subprocess.PIPE).stdout.decode("utf8"):
+				output_file_flag = "--export-file=" + output_file_flag
 			# Path arguments must be cast to string for Windows compatibility.
-			subprocess.run([str(inkscape_path), str(source_titlepage_svg_filename), "--without-gui", "--export-text-to-path", "--export-plain-svg", str(dest_titlepage_svg_filename)], check=False)
+			subprocess.run([str(inkscape_path), str(source_titlepage_svg_filename), "--without-gui", "--export-text-to-path", "--export-plain-svg", output_file_flag], check=False)
 
 			se.images.format_inkscape_svg(dest_titlepage_svg_filename)
 
@@ -522,8 +526,12 @@ class SeEpub:
 					source_cover_jpg_base64 = base64.b64encode(file.read()).decode()
 
 				# Convert text to paths
+				# Inkscape 1.0 needs an --export-file flag that 0.92 doesn’t, so we need to normalise that first.
+				output_file_flag = str(dest_cover_svg_filename)
+				if "--export-file=" in subprocess.run([str(inkscape_path), "--help"], stdout=subprocess.PIPE).stdout.decode("utf8"):
+					output_file_flag = "--export-file=" + output_file_flag
 				# Inkscape adds a ton of crap to the SVG and we clean that crap a little later
-				subprocess.run([str(inkscape_path), str(source_cover_svg_filename), "--without-gui", "--export-text-to-path", "--export-plain-svg", str(dest_cover_svg_filename)], check=False)
+				subprocess.run([str(inkscape_path), str(source_cover_svg_filename), "--without-gui", "--export-text-to-path", "--export-plain-svg", output_file_flag], check=False)
 
 				# Embed cover.jpg
 				with open(dest_cover_svg_filename, "r+", encoding="utf-8") as file:


### PR DESCRIPTION
Bit of an ugly fix, but it seems to work on macOS at least, and hence fixes macOS 10.15’s inability to run the `build-images` script. My Fedora VM’s pipx env doesn’t seem to be automatically working with new code, but I’ve double-checked that the output of `inkscape --help` (with the default Inkscape 0.92.4 there) doesn’t include the `--export-file=` substring.

Thanks to @vr8hub for the hints that got me to a fix.