### PR TITLE
Add offline option for create-draft command

### DIFF
--- a/se/executables.py
+++ b/se/executables.py
@@ -369,6 +369,7 @@ def create_draft() -> int:
 	parser.add_argument("-e", "--email", dest="email", help="use this email address as the main committer for the local Git repository")
 	parser.add_argument("-s", "--create-se-repo", dest="create_se_repo", action="store_true", help="initialize a new repository on the Standard Ebook server; Standard Ebooks admin powers required")
 	parser.add_argument("-g", "--create-github-repo", dest="create_github_repo", action="store_true", help="initialize a new repository at the Standard Ebooks GitHub account; Standard Ebooks admin powers required; can only be used when --create-se-repo is specified")
+	parser.add_argument("-o", "--offline", dest="offline", action="store_true", help="create draft without network access")
 	parser.add_argument("-a", "--author", dest="author", required=True, help="the author of the ebook")
 	parser.add_argument("-t", "--title", dest="title", required=True, help="the title of the ebook")
 	args = parser.parse_args()

--- a/se/executables_create_draft.py
+++ b/se/executables_create_draft.py
@@ -356,6 +356,8 @@ def create_draft(args: Namespace):
 
 	# Download PG HTML and do some fixups
 	if args.pg_url:
+		if args.offline:
+			raise se.RemoteCommandErrorException("Cannot download Project Gutenberg ebook when offline option is enabled.")
 		args.pg_url = args.pg_url.replace("http://", "https://")
 
 		# Get the ebook metadata
@@ -478,11 +480,18 @@ def create_draft(args: Namespace):
 	_copy_template_file("cover.svg", repo_name / "images" / "cover.svg")
 
 	# Try to find Wikipedia links if possible
-	author_wiki_url, author_nacoaf_url = _get_wikipedia_url(args.author, True)
-	ebook_wiki_url, _ = _get_wikipedia_url(args.title, False)
-	translator_wiki_url = None
-	if args.translator:
-		translator_wiki_url, translator_nacoaf_url = _get_wikipedia_url(args.translator, True)
+	if args.offline:
+		author_wiki_url = None
+		author_nacoaf_url = None
+		ebook_wiki_url = None
+		translator_wiki_url = None
+		translator_nacoaf_url = None
+	else:
+		author_wiki_url, author_nacoaf_url = _get_wikipedia_url(args.author, True)
+		ebook_wiki_url, _ = _get_wikipedia_url(args.title, False)
+		translator_wiki_url = None
+		if args.translator:
+			translator_wiki_url, translator_nacoaf_url = _get_wikipedia_url(args.translator, True)
 
 	# Pre-fill a few templates
 	se.replace_in_file(repo_name / "src" / "epub" / "text" / "titlepage.xhtml", "TITLE_STRING", title_string)


### PR DESCRIPTION
For testing the `create-draft` command it is better if it doesn't try to access external websites. The external access slows things down and may not even be possible in some test environments. This change adds an `--offline` option to the `create-draft` command that prevents it from making external requests to Gutenberg or Wikipedia.