### PR TITLE
Hide stderr output for inkscape commands

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -476,10 +476,10 @@ class SeEpub:
 			# inkscape adds a ton of crap to the SVG and we clean that crap a little later.
 			# 1.0 needs an --export-file flag that 0.92 doesn’t, so we need to normalise that first.
 			output_file_flag = str(dest_titlepage_svg_filename)
-			if "--export-file=" in subprocess.run([str(inkscape_path), "--help"], stdout=subprocess.PIPE, check=False).stdout.decode("utf8"):
+			if "--export-file=" in subprocess.run([str(inkscape_path), "--without-gui", "--help"], stdout=subprocess.PIPE, check=True).stdout.decode("utf8"):
 				output_file_flag = "--export-file=" + output_file_flag
 			# Path arguments must be cast to string for Windows compatibility.
-			subprocess.run([str(inkscape_path), str(source_titlepage_svg_filename), "--without-gui", "--export-text-to-path", "--export-plain-svg", output_file_flag], check=False)
+			subprocess.run([str(inkscape_path), str(source_titlepage_svg_filename), "--without-gui", "--export-text-to-path", "--export-plain-svg", output_file_flag], stderr=subprocess.DEVNULL, check=True)
 
 			se.images.format_inkscape_svg(dest_titlepage_svg_filename)
 
@@ -532,10 +532,10 @@ class SeEpub:
 				# Convert text to paths
 				# Inkscape 1.0 needs an --export-file flag that 0.92 doesn’t, so we need to normalise that first.
 				output_file_flag = str(dest_cover_svg_filename)
-				if "--export-file=" in subprocess.run([str(inkscape_path), "--help"], stdout=subprocess.PIPE, check=False).stdout.decode("utf8"):
+				if "--export-file=" in subprocess.run([str(inkscape_path), "--without-gui", "--help"], stdout=subprocess.PIPE, check=True).stdout.decode("utf8"):
 					output_file_flag = "--export-file=" + output_file_flag
 				# Inkscape adds a ton of crap to the SVG and we clean that crap a little later
-				subprocess.run([str(inkscape_path), str(source_cover_svg_filename), "--without-gui", "--export-text-to-path", "--export-plain-svg", output_file_flag], check=False)
+				subprocess.run([str(inkscape_path), str(source_cover_svg_filename), "--without-gui", "--export-text-to-path", "--export-plain-svg", output_file_flag], stderr=subprocess.DEVNULL, check=True)
 
 				# Embed cover.jpg
 				with open(dest_cover_svg_filename, "r+", encoding="utf-8") as file:


### PR DESCRIPTION
When running the `build-images` command without an X11 server (on Windows Subsystem for Linux), the calls to `inkscape` display some messages to stderr. These message are harmless but annoying so I have suppressed them. At the same time I have enabled the `subprocess.call()` check flag so that we catch any actual errors.

I also found that if the `DISPLAY` environment variable was set but the X11 server was not running, the `inkscape --help` command failed unless it also included the `--without-gui` option, so I have added it to the calls.