### PR TITLE
Fix hang with multiple indexed pseudoclasses in a single selector

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -871,7 +871,7 @@ def simplify_css(css: str) -> str:
 		simplified_line = line
 		for selector_to_simplify in se.SELECTORS_TO_SIMPLIFY:
 			while selector_to_simplify in simplified_line:
-				split_selector = regex.split(fr"({selector_to_simplify}(\(.*\))?)", line, 1)
+				split_selector = regex.split(fr"({selector_to_simplify}(\(.*?\))?)", line, 1)
 				replacement_class = split_selector[1].replace(":", ".").replace("(", "-").replace("n-", "n-minus-").replace("n+", "n-plus-").replace(")", "")
 				simplified_line = simplified_line.replace(split_selector[1], replacement_class)
 		if simplified_line != line:

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -236,7 +236,7 @@ def build(self, metadata_xhtml: str, metadata_tree: se.easy_xml.EasyXmlTree, run
 								while selector_to_simplify in selector:
 									# Potentially the pseudoclass we’ll simplify isn’t at the end of the selector,
 									# so we need to temporarily remove the trailing part to target the right elements.
-									split_selector = regex.split(fr"({selector_to_simplify}(\(.*\))?)", selector, 1)
+									split_selector = regex.split(fr"({selector_to_simplify}(\(.*?\))?)", selector, 1)
 									target_element_selector = ''.join(split_selector[0:2])
 
 									replacement_class = split_selector[1].replace(":", "").replace("(", "-").replace("n-", "n-minus-").replace("n+", "n-plus-").replace(")", "")


### PR DESCRIPTION
The old single-character fix: the regex used to detect the index wasn’t minimising and was selecting to the end of the last pseudoclass index.