### PR TITLE
Simplify Kindle deep-ToC generation

### DIFF
--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -797,22 +797,11 @@ def build(self, metadata_xhtml: str, metadata_tree: se.easy_xml.EasyXmlTree, run
 				soup = BeautifulSoup(xhtml, "lxml")
 
 				for match in soup.select("ol > li > ol > li > ol"):
+					match.parent.insert_after(match)
 					match.unwrap()
 
-				xhtml = str(soup)
-
-				pattern = regex.compile(r"(<li>\s*<a href=\"[^\"]+?\">.+?</a>\s*)<li>")
-				matches = 1
-				while matches > 0:
-					xhtml, matches = pattern.subn(r"\1</li><li>", xhtml)
-
-				pattern = regex.compile(r"</li>\s*</li>")
-				matches = 1
-				while matches > 0:
-					xhtml, matches = pattern.subn("</li>", xhtml)
-
 				file.seek(0)
-				file.write(xhtml)
+				file.write(str(soup))
 				file.truncate()
 
 			# Rebuild the NCX


### PR DESCRIPTION
Rather than doing regex manipulation to sort out the broken tree after unwrapping, we can just place the element in the place we want it before unwrapping it.

I never did find out what caused the bug in https://github.com/standardebooks/tools/issues/237 as this removes all the potentially buggy code.

Tested on Tristram Shandy, and Man and Wife. More testing appreciated before merging.