### PR TITLE
Move imports to top level, enable pylint check

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -6,7 +6,7 @@ ignore=vendor
 extension-pkg-whitelist=lxml
 
 [MESSAGES CONTROL]
-disable=mixed-indentation,line-too-long,too-many-nested-blocks,too-many-branches,too-many-statements,too-many-boolean-expressions,too-many-lines,too-many-locals,broad-except,bare-except,too-few-public-methods,too-many-arguments,too-many-instance-attributes,import-outside-toplevel
+disable=mixed-indentation,line-too-long,too-many-nested-blocks,too-many-branches,too-many-statements,too-many-boolean-expressions,too-many-lines,too-many-locals,broad-except,bare-except,too-few-public-methods,too-many-arguments,too-many-instance-attributes
 
 [SIMILARITIES]
 min-similarity-lines=15

--- a/se/commands/compare_versions.py
+++ b/se/commands/compare_versions.py
@@ -3,11 +3,15 @@ This module implements the `se compare-versions` command.
 """
 
 import argparse
+import fnmatch
 import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+import git
+import psutil
 
 import se
 
@@ -16,10 +20,6 @@ def compare_versions() -> int:
 	"""
 	Entry point for `se compare-versions`
 	"""
-
-	import fnmatch
-	import psutil
-	import git
 
 	parser = argparse.ArgumentParser(description="Use Firefox to render and compare XHTML files in an ebook repository. Run on a dirty repository to visually compare the repository’s dirty state with its clean state. If a file renders differently, copy screenshots of the new, original, and diff (if available) renderings into the current working directory. Diff renderings may not be available if the two renderings differ in dimensions. WARNING: DO NOT START FIREFOX WHILE THIS PROGRAM IS RUNNING!")
 	parser.add_argument("-i", "--include-common", dest="include_common_files", action="store_true", help="include commonly-excluded SE files like imprint, titlepage, and colophon")

--- a/se/commands/dec2roman.py
+++ b/se/commands/dec2roman.py
@@ -5,6 +5,8 @@ This module implements the `se dec2roman` command.
 import argparse
 import sys
 
+import roman
+
 import se
 
 
@@ -12,8 +14,6 @@ def dec2roman() -> int:
 	"""
 	Entry point for `se dec2roman`
 	"""
-
-	import roman
 
 	parser = argparse.ArgumentParser(description="Convert a decimal number to a Roman numeral.")
 	parser.add_argument("-n", "--no-newline", dest="newline", action="store_false", help="don’t end output with a newline")

--- a/se/commands/extract_ebook.py
+++ b/se/commands/extract_ebook.py
@@ -4,20 +4,20 @@ This module implements the `se extract_ebook` command.
 
 import argparse
 import sys
+import zipfile
+from io import BytesIO, TextIOWrapper
 from pathlib import Path
 
+import magic
+
 import se
+from se.vendor.kindleunpack import kindleunpack
 
 
 def extract_ebook() -> int:
 	"""
 	Entry point for `se extract-ebook`
 	"""
-
-	import zipfile
-	from io import TextIOWrapper, BytesIO
-	import magic
-	from se.vendor.kindleunpack import kindleunpack
 
 	parser = argparse.ArgumentParser(description="Extract an epub, mobi, or azw3 ebook into ./FILENAME.extracted/ or a target directory.")
 	parser.add_argument("-o", "--output-dir", type=str, help="a target directory to extract into")

--- a/se/commands/find_mismatched_diacritics.py
+++ b/se/commands/find_mismatched_diacritics.py
@@ -3,6 +3,7 @@ This module implements the `se find_mismatched_diacritics` command.
 """
 
 import argparse
+import unicodedata
 
 import regex
 
@@ -13,8 +14,6 @@ def find_mismatched_diacritics() -> int:
 	"""
 	Entry point for `se find-mismatched-diacritics`
 	"""
-
-	import unicodedata
 
 	parser = argparse.ArgumentParser(description="Find words with mismatched diacritics in a set of XHTML files. For example, `cafe` in one file and `café` in another.")
 	parser.add_argument("targets", metavar="TARGET", nargs="+", help="an XHTML file, or a directory containing XHTML files")

--- a/se/commands/lint.py
+++ b/se/commands/lint.py
@@ -4,6 +4,8 @@ This module implements the `se lint` command.
 
 import argparse
 
+from termcolor import colored
+
 import se
 from se.se_epub import SeEpub
 
@@ -12,8 +14,6 @@ def lint() -> int:
 	"""
 	Entry point for `se lint`
 	"""
-
-	from termcolor import colored
 
 	parser = argparse.ArgumentParser(description="Check for various Standard Ebooks style errors.")
 	parser.add_argument("-p", "--plain", action="store_true", help="print plain output")

--- a/se/commands/roman2dec.py
+++ b/se/commands/roman2dec.py
@@ -5,6 +5,8 @@ This module implements the `se roman2dec` command.
 import argparse
 import sys
 
+import roman
+
 import se
 
 
@@ -12,8 +14,6 @@ def roman2dec() -> int:
 	"""
 	Entry point for `se roman2dec`
 	"""
-
-	import roman
 
 	parser = argparse.ArgumentParser(description="Convert a Roman numeral to a decimal number.")
 	parser.add_argument("-n", "--no-newline", dest="newline", action="store_false", help="don’t end output with a newline")

--- a/se/commands/unicode_names.py
+++ b/se/commands/unicode_names.py
@@ -4,14 +4,13 @@ This module implements the `se unicode_names` command.
 
 import argparse
 import sys
+import unicodedata
 
 
 def unicode_names() -> int:
 	"""
 	Entry point for `se unicode-names`
 	"""
-
-	import unicodedata
 
 	parser = argparse.ArgumentParser(description="Display Unicode code points, descriptions, and links to more details for each character in a string. Useful for differentiating between different flavors of spaces, dashes, and invisible characters like word joiners.")
 	parser.add_argument("strings", metavar="STRING", nargs="*", help="a Unicode string")

--- a/se/commands/version.py
+++ b/se/commands/version.py
@@ -5,6 +5,8 @@ This module implements the `se version` command.
 import os
 import sys
 
+import pkg_resources
+
 import se
 
 
@@ -12,8 +14,6 @@ def version() -> int:
 	"""
 	Entry point for `se version`
 	"""
-
-	import pkg_resources
 
 	# Is distribution an editable install?
 	# Copied from a pip utility function which is not publicly accessible. See https://stackoverflow.com/questions/42582801/check-whether-a-python-package-has-been-installed-in-editable-egg-link-mode

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -890,7 +890,7 @@ class SeEpub:
 		into this class.
 		"""
 
-		from se.se_epub_lint import lint
+		from se.se_epub_lint import lint # pylint: disable=import-outside-toplevel
 
 		return lint(self, self.metadata_xhtml)
 
@@ -901,7 +901,7 @@ class SeEpub:
 		into this class.
 		"""
 
-		from se.se_epub_build import build
+		from se.se_epub_build import build # pylint: disable=import-outside-toplevel
 
 		build(self, self.metadata_xhtml, self._metadata_tree, run_epubcheck, build_kobo, build_kindle, output_directory, proof, build_covers, verbose)
 
@@ -912,7 +912,7 @@ class SeEpub:
 		into this class.
 		"""
 
-		from se.se_epub_generate_toc import generate_toc
+		from se.se_epub_generate_toc import generate_toc  # pylint: disable=import-outside-toplevel
 
 		return generate_toc(self)
 


### PR DESCRIPTION
With the new file organization, we can move most imports to the top of their respective files and re-enable the pylint check.