### PR TITLE
Update README with recommended Mac pipx install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,7 @@ These instructions were tested on macOS 10.12 to 10.15.
 
 	```shell
 	# Install some pre-flight dependencies.
-	brew install python libmagic git
-
-	# Install pipx.
-	python3 -m pip install pipx
-	python3 -m pipx ensurepath
+	brew install python pipx libmagic git
 
 	# Install required applications.
 	brew cask install java calibre xquartz inkscape

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ These instructions were tested on macOS 10.12 to 10.15.
 	```shell
 	# Install some pre-flight dependencies.
 	brew install python pipx libmagic git
+	pipx ensurepath
 
 	# Install required applications.
 	brew cask install java calibre xquartz inkscape


### PR DESCRIPTION
As referenced in https://github.com/standardebooks/tools/issues/188#issuecomment-589883518. I’ve tested this and it works fine.