### PR TITLE
Guard against accidental italicisation of endnote references

### DIFF
--- a/se/data/templates/core.css
+++ b/se/data/templates/core.css
@@ -97,6 +97,7 @@ section[epub|type~="titlepage"] img{
 
 a[epub|type~="noteref"]{
 	font-size: .75em;
+	font-style: normal;
 	vertical-align: super;
 }
 

--- a/se/data/templates/core.css
+++ b/se/data/templates/core.css
@@ -97,7 +97,7 @@ section[epub|type~="titlepage"] img{
 
 a[epub|type~="noteref"]{
 	font-size: .75em;
-	font-style: normal;
+	font-style: normal !important;
 	vertical-align: super;
 }
 

--- a/tests/data/draft/jane-austen_unknown-novel/src/epub/css/core.css
+++ b/tests/data/draft/jane-austen_unknown-novel/src/epub/css/core.css
@@ -97,6 +97,7 @@ section[epub|type~="titlepage"] img{
 
 a[epub|type~="noteref"]{
 	font-size: .75em;
+	font-style: normal;
 	vertical-align: super;
 }
 

--- a/tests/data/draft/jane-austen_unknown-novel/src/epub/css/core.css
+++ b/tests/data/draft/jane-austen_unknown-novel/src/epub/css/core.css
@@ -97,7 +97,7 @@ section[epub|type~="titlepage"] img{
 
 a[epub|type~="noteref"]{
 	font-size: .75em;
-	font-style: normal;
+	font-style: normal !important;
 	vertical-align: super;
 }
 


### PR DESCRIPTION
As mentioned in https://github.com/robinwhittleton/laurence-sterne_the-life-and-opinions-of-tristram-shandy-gentleman/issues/1. I’ll remove [the override](https://github.com/robinwhittleton/laurence-sterne_the-life-and-opinions-of-tristram-shandy-gentleman/blob/2e823f3f226739e9316b1ac6f405de89b059f1db/src/epub/css/local.css#L84-L86) from local.css in that project if this gets merged.