### PR TITLE
Add a fix-mojibake command

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ We need volunteers to take the lead on the following goals:
 
 	Find words with mismatched diacritics in Standard Ebook source directories. For example, `cafe` in one file and `café` in another.
 
+-	### `se fix-mojibake`
+
+	Find and remove all [mojibake](https://en.wikipedia.org/wiki/Mojibake) from Standard Ebooks source directories.
+
 -	### `se help`
 
 	List available SE commands.

--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -15,7 +15,6 @@ import importlib_resources
 import regex
 import requests
 from bs4 import BeautifulSoup
-from ftfy import fix_text
 
 import se
 import se.formatting
@@ -395,7 +394,7 @@ def _create_draft(args: Namespace):
 			raise se.RemoteCommandErrorException(f"Couldn’t download Project Gutenberg ebook HTML. Error: {ex}")
 
 		try:
-			fixed_pg_ebook_html = fix_text(pg_ebook_html, uncurl_quotes=False)
+			fixed_pg_ebook_html = se.formatting.fix_mojibake(pg_ebook_html)
 			pg_ebook_html = se.strip_bom(fixed_pg_ebook_html)
 		except Exception as ex:
 			raise se.InvalidEncodingException(f"Couldn’t determine text encoding of Project Gutenberg HTML file. Error: {ex}")

--- a/se/commands/fix_mojibake.py
+++ b/se/commands/fix_mojibake.py
@@ -1,0 +1,40 @@
+"""
+This module implements the `se fix-mojibake` command.
+"""
+
+import argparse
+
+import se
+import se.formatting
+
+
+def fix_mojibake() -> int:
+	"""
+	Entry point for `se fix-mojibake`
+	"""
+
+	parser = argparse.ArgumentParser(description="Automatically remove mojibake from Standard Ebooks source directories.")
+	parser.add_argument("-v", "--verbose", action="store_true", help="increase output verbosity")
+	parser.add_argument("targets", metavar="TARGET", nargs="+", help="an XHTML file, or a directory containing XHTML files")
+	args = parser.parse_args()
+
+	for filename in se.get_target_filenames(args.targets, (".xhtml",)):
+		if args.verbose:
+			print(f"Processing {filename} ...", end="", flush=True)
+
+		try:
+			with open(filename, "r+", encoding="utf-8") as file:
+				xhtml = file.read()
+				processed_xhtml = se.formatting.fix_mojibake(xhtml)
+
+				if processed_xhtml != xhtml:
+					file.seek(0)
+					file.write(processed_xhtml)
+					file.truncate()
+		except FileNotFoundError:
+			se.print_error(f"Not a file: {filename}")
+
+		if args.verbose:
+			print(" OK")
+
+	return 0

--- a/se/completions/bash/se
+++ b/se/completions/bash/se
@@ -2,7 +2,7 @@ _se(){
 	COMPREPLY=()
 	local cur="${COMP_WORDS[COMP_CWORD]}"
 	local prev="${COMP_WORDS[COMP_CWORD-1]}"
-	local commands="--help --version british2american build build-images clean compare-versions create-draft dec2roman extract-ebook find-mismatched-diacritics help hyphenate interactive-sr lint make-url-safe modernize-spelling prepare-release print-manifest-and-spine print-toc recompose-epub renumber-endnotes reorder-endnotes roman2dec semanticate split-file split-file split-file titlecase typogrify unicode-names version word-count"
+	local commands="--help --version british2american build build-images clean compare-versions create-draft dec2roman extract-ebook find-mismatched-diacritics fix-mojibake help hyphenate interactive-sr lint make-url-safe modernize-spelling prepare-release print-manifest-and-spine print-toc recompose-epub renumber-endnotes reorder-endnotes roman2dec semanticate split-file split-file split-file titlecase typogrify unicode-names version word-count"
 	if [[ $COMP_CWORD -gt 1 ]]; then
 		case "${COMP_WORDS[1]}" in
 			british2american)
@@ -52,6 +52,11 @@ _se(){
 				COMPREPLY+=($(compgen -f -X "!*.epub3" -- "${cur}"))
 				;;
 			find-mismatched-diacritics)
+				COMPREPLY+=($(compgen -d -X ".*" -- "${cur}"))
+				COMPREPLY+=($(compgen -f -X "!*.xhtml" -- "${cur}"))
+				;;
+			fix-mojibake)
+				COMPREPLY+=($(compgen -W "-h --help -v --verbose" -- "${cur}"))
 				COMPREPLY+=($(compgen -d -X ".*" -- "${cur}"))
 				COMPREPLY+=($(compgen -f -X "!*.xhtml" -- "${cur}"))
 				;;

--- a/se/completions/fish/se.fish
+++ b/se/completions/fish/se.fish
@@ -1,6 +1,6 @@
 function __fish_se_no_subcommand --description "Test if se has yet to be given the subcommand"
 	for i in (commandline -opc)
-		if contains -- $i british2american build build-images clean compare-versions create-draft dec2roman extract-ebook find-mismatched-diacritics help hyphenate interactive-sr lint make-url-safe modernize-spelling prepare-release print-manifest-and-spine print-toc recompose-epub renumber-endnotes reorder-endnotes roman2dec semanticate split-file titlecase typogrify unicode-names version word-count
+		if contains -- $i british2american build build-images clean compare-versions create-draft dec2roman extract-ebook find-mismatched-diacritics fix-mojibake help hyphenate interactive-sr lint make-url-safe modernize-spelling prepare-release print-manifest-and-spine print-toc recompose-epub renumber-endnotes reorder-endnotes roman2dec semanticate split-file titlecase typogrify unicode-names version word-count
 			return 1
 		end
 	end
@@ -60,6 +60,10 @@ complete -c se -A -n "__fish_seen_subcommand_from extract-ebook" -s v -l verbose
 
 complete -c se -n "__fish_se_no_subcommand" -a find-mismatched-diacritics -d "Find words with mismatched diacritics in Standard Ebook source directories"
 complete -c se -A -n "__fish_seen_subcommand_from find-mismatched-diacritics" -s h -l help -x -d "show this help message and exit"
+
+complete -c se -n "__fish_se_no_subcommand" -a fix-mojibake -d "Automatically remove mojibake from Standard Ebooks source directories"
+complete -c se -A -n "__fish_seen_subcommand_from fix-mojibake" -s h -l help -x -d "show this help message and exit"
+complete -c se -A -n "__fish_seen_subcommand_from fix-mojibake" -s v -l verbose -d "increase output verbosity"
 
 complete -c se -n "__fish_se_no_subcommand" -f -a help -d "List available SE commands"
 

--- a/se/completions/zsh/_se
+++ b/se/completions/zsh/_se
@@ -19,6 +19,7 @@ case $state in
 			"dec2roman[Convert a decimal number to a Roman numeral]" \
 			"extract-ebook[Extract an EPUB, MOBI, or AZW3 ebook]" \
 			"find-mismatched-diacritics[Find words with mismatched diacritics in Standard Ebook source directories]" \
+			"fix-mojibake[Automatically remove mojibake from Standard Ebooks source directories]" \
 			"help[List available SE commands]" \
 			"hyphenate[Insert soft hyphens at syllable breaks in an XHTML file]" \
 			"interactive-sr[Use Vim to perform an interactive search and replace on a list of files]" \
@@ -108,6 +109,12 @@ case $state in
 			find-mismatched-diacritics)
 				_arguments -s \
 					{-h,--help}'[show a help message and exit]' \
+					'*: :_files -g \*.xhtml'
+				;;
+			fix-mojibake)
+				_arguments -s \
+					{-h,--help}'[show a help message and exit]' \
+					{-v,--verbose}'[increase output verbosity]' \
 					'*: :_files -g \*.xhtml'
 				;;
 			help)

--- a/se/formatting.py
+++ b/se/formatting.py
@@ -14,6 +14,7 @@ import shutil
 import string
 import regex
 import tinycss2
+from ftfy import fix_text
 from titlecase import titlecase as pip_titlecase
 import se
 
@@ -922,3 +923,15 @@ def simplify_css(css: str) -> str:
 		css = css.replace(line, fixed_line)
 
 	return css
+
+def fix_mojibake(xhtml: str) -> str:
+	"""
+	Helper function to remove mojibake from a string of XHTML. Uses the ftfy library.
+
+	INPUTS
+	xhtml: A string of XHTML.
+
+	OUTPUTS
+	A string of XHTML with mojibake removed.
+	"""
+	return fix_text(xhtml, uncurl_quotes=False)

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "beautifulsoup4==4.8.0",
         "cairosvg==2.4.2",
         "cssselect==1.0.3",
-        "ftfy==5.5.1",
+        "ftfy==5.7",
         "gitpython==3.0.8",
         "importlib_resources==1.0.2",
         "lxml==4.4.0",

--- a/tests/data/fix-mojibake/in/fix-mojibake.xhtml
+++ b/tests/data/fix-mojibake/in/fix-mojibake.xhtml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-US">
+	<head>
+		<title>Chapter 1</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="bodymatter z3998:fiction">
+		<section id="chapter-1" epub:type="chapter">
+			<h2>Chapter 1</h2>
+			<p>Dawn was quivering upon the meadows near ChambÃ©ry. Nothing could be easier than to turn Mossy into an Ã¦sthetic Christian.</p>
+		</section>
+	</body>
+</html>

--- a/tests/data/fix-mojibake/out/fix-mojibake.xhtml
+++ b/tests/data/fix-mojibake/out/fix-mojibake.xhtml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-US">
+	<head>
+		<title>Chapter 1</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="bodymatter z3998:fiction">
+		<section id="chapter-1" epub:type="chapter">
+			<h2>Chapter 1</h2>
+			<p>Dawn was quivering upon the meadows near Chambéry. Nothing could be easier than to turn Mossy into an æsthetic Christian.</p>
+		</section>
+	</body>
+</html>

--- a/tests/test_text_cmds.py
+++ b/tests/test_text_cmds.py
@@ -9,6 +9,7 @@ from helpers import assemble_book, must_run, files_are_golden
 TEXT_CMDS = [
     ("british2american", ""),
     ("clean", "--single-lines"),
+    ("fix-mojibake", ""),
     ("modernize-spelling", ""),
     ("semanticate", ""),
     ("typogrify", ""),


### PR DESCRIPTION
I needed to remove mojibake from a recent project (two volumes, `create-draft` had successfully fixed the first volume but the second had been copied down manually) and it occurred to me that I could just expose our existing use of `ftfy` as an external command.

What do you think. Useful? For reference, this worked well when I tested it against my project. Lint and test are passing.