### PR TITLE
manual f-string update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@ __pycache__
 /dist
 /*.egg-info
 /.mypy_cache
-/.pytest_cache
-/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__
 /dist
 /*.egg-info
 /.mypy_cache
+/.pytest_cache
+/.vscode

--- a/se/__init__.py
+++ b/se/__init__.py
@@ -196,7 +196,7 @@ def print_error(message: Union[SeException, str], verbose: bool = False) -> None
 	# is rendered in blue
 	message = regex.sub(r"`(.+?)`", stylize(r"\1", fg("light_blue")), message)
 
-	print(f"{MESSAGE_INDENT if verbose else ''}{stylize(' Error ', bg('red') + attr('bold'))} {sys.stderr}")
+	print(f"{MESSAGE_INDENT if verbose else ''}{stylize(' Error ', bg('red') + attr('bold'))} {message}", file=sys.stderr)
 
 def print_warning(message: str, verbose: bool = False) -> None:
 	"""

--- a/se/__init__.py
+++ b/se/__init__.py
@@ -203,7 +203,7 @@ def print_warning(message: str, verbose: bool = False) -> None:
 	Helper function to print a colored warning message to the console.
 	"""
 
-	print(f"{MESSAGE_INDENT if verbose else ''} {stylize(' Warning ', bg('yellow') + attr('bold'))} {message}")
+	print(f"{MESSAGE_INDENT if verbose else ''}{stylize(' Warning ', bg('yellow') + attr('bold'))} {message}")
 
 def is_positive_integer(value: str) -> int:
 	"""

--- a/se/__init__.py
+++ b/se/__init__.py
@@ -196,14 +196,14 @@ def print_error(message: Union[SeException, str], verbose: bool = False) -> None
 	# is rendered in blue
 	message = regex.sub(r"`(.+?)`", stylize(r"\1", fg("light_blue")), message)
 
-	print("{}{} {}".format(MESSAGE_INDENT if verbose else "", stylize(" Error ", bg("red") + attr("bold")), message), file=sys.stderr)
+	print(f"{MESSAGE_INDENT if verbose else ''}{stylize(' Error ', bg('red') + attr('bold'))} {sys.stderr}")
 
 def print_warning(message: str, verbose: bool = False) -> None:
 	"""
 	Helper function to print a colored warning message to the console.
 	"""
 
-	print("{}{} {}".format(MESSAGE_INDENT if verbose else "", stylize(" Warning ", bg("yellow") + attr("bold")), message))
+	print(f"{MESSAGE_INDENT if verbose else ''} {stylize(' Warning ', bg('yellow') + attr('bold'))} {message}")
 
 def is_positive_integer(value: str) -> int:
 	"""
@@ -270,6 +270,6 @@ def get_xhtml_language(xhtml: str) -> str:
 		language = None
 
 	if language not in supported_languages:
-		raise InvalidLanguageException("No valid xml:lang attribute in <html> root. Only {} are supported.".format(", ".join(supported_languages[:-1]) + ", and " + supported_languages[-1]))
+		raise InvalidLanguageException(f"No valid xml:lang attribute in <html> root. Only {', '.join(supported_languages[:-1])}, and {supported_languages[-1]} are supported.")
 
 	return language

--- a/se/commands/british2american.py
+++ b/se/commands/british2american.py
@@ -34,7 +34,7 @@ def british2american() -> int:
 						convert = False
 						if args.verbose:
 							print("")
-						se.print_warning("File appears to already use American quote style, ignoring. Use --force to convert anyway.{}".format(" File: " + str(filename) if not args.verbose else ""), args.verbose)
+						se.print_warning(f"File appears to already use American quote style, ignoring. Use --force to convert anyway.{' File: ' + str(filename) if not args.verbose else ''}", args.verbose)
 
 				if convert:
 					new_xhtml = se.typography.convert_british_to_american(xhtml)

--- a/se/commands/modernize_spelling.py
+++ b/se/commands/modernize_spelling.py
@@ -32,10 +32,10 @@ def modernize_spelling() -> int:
 					problem_spellings = se.spelling.detect_problem_spellings(xhtml)
 
 					for problem_spelling in problem_spellings:
-						print("{}{}".format((filename.name) + ": " if not args.verbose else "", problem_spelling))
+						print(f"{(filename.name) + ': ' if not args.verbose else ''}{problem_spelling}")
 
 				except se.InvalidLanguageException as ex:
-					se.print_error("{}{}".format(ex, f" File: `{filename}`" if not args.verbose else ""))
+					se.print_error(f"{ex}{' File: `' + filename + '`' if not args else ''}")
 					return ex.code
 
 				if args.modernize_hyphenation:

--- a/se/commands/version.py
+++ b/se/commands/version.py
@@ -26,5 +26,5 @@ def version() -> int:
 		if os.path.isfile(egg_link):
 			dist_is_editable = True
 
-	print("{}{}".format(se.VERSION, " (developer installation)" if dist_is_editable else ""))
+	print(f"{se.VERSION}{' (developer installation)' if dist_is_editable else ''}")
 	return 0

--- a/se/commands/word_count.py
+++ b/se/commands/word_count.py
@@ -47,6 +47,6 @@ def word_count() -> int:
 		elif total_word_count >= se.NOVEL_MIN_WORD_COUNT:
 			category = "se:novel"
 
-	print("{}{}".format(total_word_count, "\t" + category if args.categorize else ""))
+	print(f"{total_word_count}\t{category if args.categorize else ''}")
 
 	return 0

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -1028,7 +1028,7 @@ class SeEpub:
 				with open(self.path / "src" / "epub" / "text" / "endnotes.xhtml", "w") as file:
 					file.write(se.formatting.format_xhtml(str(self._endnotes_soup), is_endnotes_file=True))
 
-				report += "Changed {:d} endnote{}.".format(notes_changed, "s" if notes_changed != 1 else "")
+				report += f"Changed {notes_changed:d} endnote{'s' if notes_changed != 1 else ''}."
 			else:
 				report += "No changes made."
 

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -97,10 +97,10 @@ def build(self, metadata_xhtml: str, metadata_tree: se.easy_xml.EasyXmlTree, run
 
 		url_author = url_author.rstrip("_")
 
-		epub_output_filename = "{}_{}{}.epub".format(url_author, url_title, ".proof" if proof else "")
-		epub3_output_filename = "{}_{}{}.epub3".format(url_author, url_title, ".proof" if proof else "")
-		kobo_output_filename = "{}_{}{}.kepub.epub".format(url_author, url_title, ".proof" if proof else "")
-		kindle_output_filename = "{}_{}{}.azw3".format(url_author, url_title, ".proof" if proof else "")
+		epub_output_filename = f"{url_author}_{url_title}{'.proof' if proof else ''}.epub"
+		epub3_output_filename = f"{url_author}_{url_title}{'.proof' if proof else ''}.epub3"
+		kobo_output_filename = f"{url_author}_{url_title}{'.proof' if proof else ''}.kepub.epub"
+		kindle_output_filename = f"{url_author}_{url_title}{'.proof' if proof else ''}.azw3"
 
 		# Clean up old output files if any
 		se.quiet_remove(output_directory / f"thumbnail_{asin}_EBOK_portrait.jpg")


### PR DESCRIPTION
So there didn't end up being that many if you don't count everything in se/vendor. It's passing the pylint and pytest tests. I didn't see how to set up the mypy tests in the readme.

I did end up leaving 7 instances of .format() in the code. Right now I think replacing these 7 wouldn't be worth the trouble. 

There are various reasons why f-strings are a pain for these. 5 of them are in regex strings, and because f-string doesn't always play nicely with quotes and escapes and things like that I thought I'd leave them. Also there's an example of nested .format() calls which I had trouble replacing, and one where the .format() call needs an escaped character, which you can't do in an f-string.

Here are my notes on the unchanged ones for future reference in case someone wants to tackle them later:

### .format() calls that I'm leaving in

se/commands/compare_versions.py

lines 170-171, because we can't have an escaped character in the fstring bracket {}

```Python
for filename in se.natural_sort(list(files_with_differences)):
    print("{}Difference in {}\n".format("\t" if args.verbose else "", filename), end="", flush=True)
```

se/commands/unicode_names.py

lines 28-30, I tried but the :04X part wasn't working. didn't want to mess with it.

```Python
for line in lines:
    for character in line:
        print(character + "\tU+{:04X}".format(ord(character)) + "\t" + unicodedata.name(character) + 
                 "\t" + "http://unicode.org/cldr/utility/character.jsp?a={:04X}".format(ord(character)))
```

se/epub.py

line 46, regex that already has {} brackets and quotes in it, looks like a pain to replace:

```Python
ncx_xhtml = regex.sub(r"<navPoint id=\"id[a-z0-9]+?\"", lambda x: "<navPoint id=\"navpoint-{count}\" playOrder=\"{count}\"".format(count=next(counter)), ncx_xhtml)

```

se/epub_build.py

4 regexes, lines 402, 429, 442, 636