### PR TITLE
Remove endnotes from titles before printing them

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -960,6 +960,10 @@ def generate_title(xhtml: str) -> str:
 	if h_elements:
 		h_element = h_elements[0]
 
+		# Strip any endnote references first
+		for endnote_tag in h_element.select("[id^='noteref']"):
+			endnote_tag.decompose()
+
 		# se://5.3.2.2
 		# Header is just a Roman numeral
 		if h_element.has_attr("epub:type") and "z3998:roman" in h_element["epub:type"]:


### PR DESCRIPTION
BS4 selection doesn’t seem to understand namespaced attribute selectors, so selecting based on `id` instead.