### PR TITLE
Add needed cairo to macOS install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ These instructions were tested on macOS 10.12 to 10.15.
 
 	```shell
 	# Install some pre-flight dependencies.
-	brew install python pipx git
+	brew install cairo python pipx git
 	pipx ensurepath
 
 	# Install required applications.


### PR DESCRIPTION
I got a new mac for the first time in a long time, and after trying to build the book I’m working on got some errors. Tracked it down to a missing libcairo, which is installable with brew. I’m not sure if I just always had this on my old machine and hence never realised, or if it was part of macOS previously and has since been removed, but hey.