### PR TITLE
build-images: Fix exception for invalid source directory

### DIFF
--- a/se/commands/build_images.py
+++ b/se/commands/build_images.py
@@ -22,16 +22,14 @@ def build_images() -> int:
 	args = parser.parse_args()
 
 	for directory in args.directories:
-		directory = Path(directory)
+		directory = Path(directory).resolve()
 
 		if args.verbose:
 			print(f"Processing {directory} ...")
 
-		directory = directory.resolve()
-
-		se_epub = SeEpub(directory)
-
 		try:
+			se_epub = SeEpub(directory)
+
 			if args.verbose:
 				print("\tCleaning metadata ...", end="", flush=True)
 


### PR DESCRIPTION
Command was throwing an exception if the user provided an invalid directory.

Moved the `SePub` init inside the try block so that an exception will print a nice error message. Also moved the `resolve()` statement so that the full directory name is displayed with `-v` option.