### PR TITLE
Use CSSSelector cache for lint command

### DIFF
--- a/se/easy_xml.py
+++ b/se/easy_xml.py
@@ -4,11 +4,25 @@ Defines the EasyXmlTree class, which is a convenience wrapper around etree.
 The class exposes some helpful functions like css_select() and xpath().
 """
 
-from typing import List, Union
+from typing import Dict, List, Union
 import regex
 from lxml import cssselect, etree
 import se
 
+
+CSS_SELECTOR_CACHE: Dict[str, cssselect.CSSSelector] = {}
+
+def css_selector(selector: str) -> cssselect.CSSSelector:
+	"""
+	Create a CSS selector for the given selector string. Return a cached CSS selector if
+	one already exists.
+	"""
+
+	sel = CSS_SELECTOR_CACHE.get(selector)
+	if not sel:
+		sel = cssselect.CSSSelector(selector, translator="xhtml", namespaces=se.XHTML_NAMESPACES)
+		CSS_SELECTOR_CACHE[selector] = sel
+	return sel
 
 class EasyXmlTree:
 	"""
@@ -24,7 +38,7 @@ class EasyXmlTree:
 		Shortcut to select elements based on CSS selector.
 		"""
 
-		return self.xpath(cssselect.CSSSelector(selector, translator="html", namespaces=se.XHTML_NAMESPACES).path)
+		return self.xpath(css_selector(selector).path)
 
 	def xpath(self, selector: str, return_string: bool = False):
 		"""

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -849,7 +849,7 @@ def lint(self, skip_lint_ignore: bool) -> list:
 					if not filename.endswith("titlepage.xhtml") and not filename.endswith("imprint.xhtml") and not filename.endswith("uncopyright.xhtml"):
 						for selector in local_css_selectors:
 							try:
-								sel = lxml.cssselect.CSSSelector(selector, translator="html", namespaces=se.XHTML_NAMESPACES)
+								sel = se.easy_xml.css_selector(selector)
 							except lxml.cssselect.ExpressionError as ex:
 								# This gets thrown on some selectors not yet implemented by lxml, like *:first-of-type
 								unused_selectors.remove(selector)


### PR DESCRIPTION
I moved the cache to the `se.easy_xml` module because most of the `CSSSelector` creations for the lint command are happening in the `EasyXmlTree.css_select()` method. This change should also speed up the MathML processing in the build command because it was using `EasyXmlTree.css_select()` too.