### PR TITLE
Add hiDPI PNGs for pre-rendered MathML

### DIFF
--- a/se/browser.py
+++ b/se/browser.py
@@ -39,6 +39,7 @@ def initialize_selenium_firefox_webdriver() -> webdriver:
 	profile.set_preference("browser.cache.memory.enable", False)
 	profile.set_preference("browser.cache.offline.enable", False)
 	profile.set_preference("browser.http.use-cache", False)
+	profile.set_preference("layout.css.devPixelsPerPx", "2.0")
 
 	try:
 		driver = webdriver.Firefox(firefox_profile=profile, firefox_options=options, service_log_path=os.devnull)

--- a/se/images.py
+++ b/se/images.py
@@ -105,7 +105,7 @@ def _color_to_alpha(image: Image, color=None) -> Image:
 	return new_image
 
 # Note: We can't type hint driver, because we conditionally import selenium for performance reasons
-def render_mathml_to_png(driver, mathml: str, output_filename: Path) -> None:
+def render_mathml_to_png(driver, mathml: str, output_filename: Path, output_filename_2x: Path) -> None:
 	"""
 	Render a string of MathML into a transparent PNG file.
 
@@ -113,6 +113,7 @@ def render_mathml_to_png(driver, mathml: str, output_filename: Path) -> None:
 	driver: A Selenium webdriver, usually initialized from se.browser.initialize_selenium_firefox_webdriver
 	mathml: A string of MathML
 	output_filename: A filename to store PNG output to
+	output_filename_2x: A filename to store hiDPI PNG output to
 
 	OUTPUTS
 	None.
@@ -127,9 +128,15 @@ def render_mathml_to_png(driver, mathml: str, output_filename: Path) -> None:
 			# We have to take a screenshot of the html element, because otherwise we screenshot the viewport, which would result in a truncated image
 			driver.find_element_by_tag_name("html").screenshot(png_file.name)
 
+			# Save hiDPI 2x version
 			image = Image.open(png_file.name)
 			image = _color_to_alpha(image, (255, 255, 255, 255))
-			image.crop(image.getbbox()).save(output_filename)
+			image = image.crop(image.getbbox())
+			image.save(output_filename_2x)
+
+			# Save normal version
+			image = image.resize((image.width // 2, image.height // 2))
+			image.save(output_filename)
 
 def remove_image_metadata(filename: Path) -> None:
 	"""

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -663,9 +663,9 @@ def build(self, run_epubcheck: bool, build_kobo: bool, build_kindle: bool, outpu
 										# Did we succeed? Is there any more MathML in our string?
 										if regex.findall("</?(?:m:)?m", processed_line):
 											# Failure! Abandon all hope, and use Firefox to convert the MathML to PNG.
-											se.images.render_mathml_to_png(driver, regex.sub(r"<(/?)m:", "<\\1", line), work_epub_root_directory / "epub" / "images" / f"mathml-{mathml_count}.png")
+											se.images.render_mathml_to_png(driver, regex.sub(r"<(/?)m:", "<\\1", line), work_epub_root_directory / "epub" / "images" / f"mathml-{mathml_count}.png", work_epub_root_directory / "epub" / "images" / f"mathml-{mathml_count}@2x.png")
 
-											processed_xhtml = processed_xhtml.replace(line, f"<img class=\"mathml epub-type-se-image-color-depth-black-on-transparent\" epub:type=\"se:image.color-depth.black-on-transparent\" src=\"../images/mathml-{mathml_count}.png\" />")
+											processed_xhtml = processed_xhtml.replace(line, f"<img class=\"mathml epub-type-se-image-color-depth-black-on-transparent\" epub:type=\"se:image.color-depth.black-on-transparent\" src=\"../images/mathml-{mathml_count}.png\" srcset=\"../images/mathml-{mathml_count}@2x.png 2x, ../images/mathml-{mathml_count}.png 1x\" />")
 											mathml_count = mathml_count + 1
 										else:
 											# Success! Replace the MathML with our new string.


### PR DESCRIPTION
Images can take a srcset attribute with hiDPI image options. We can tweak the Firefox webdriver to output this, then use pillow to provide a normal resolution version. Screenshots from macOS Apple Books:

Before:
<img width="316" alt="Screenshot 2020-06-15 at 18 25 24" src="https://user-images.githubusercontent.com/7414/84682273-b3a0aa80-af35-11ea-9331-b0909570f13f.png">

After:
<img width="316" alt="Screenshot 2020-06-15 at 18 24 44" src="https://user-images.githubusercontent.com/7414/84682346-cd41f200-af35-11ea-9f97-c8d4c413f611.png">

Only tested on macOS Books: the only other hardware I have available is Kobo and that has native MathML. I don’t see this being a compatibility issue though, the original `src` attribute is there for renderers that don’t support `srcset`.