### PR TITLE
modernize-spelling: Add hotelkeeper

### DIFF
--- a/se/data/words
+++ b/se/data/words
@@ -39882,6 +39882,7 @@ hotdogs
 hotel
 hotelier
 hoteliers
+hotelkeeper
 hotels
 hotfoot
 hotfooted


### PR DESCRIPTION
Don't know if we're manually updating this dictionary but I came across "hotel-keeper" which in Merriam-Webster (which we seem to be using for the most part) is written without the hyphen (https://www.merriam-webster.com/dictionary/hotelkeeper) so I decided to add it.