### PR TITLE
Lint longdesc xmllang

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -128,6 +128,7 @@ METADATA
 "m-054", "Standard Ebooks URL with illegal trailing slash."
 "m-055", "Missing data in metadata."
 "m-056", "Author name present in [xml]<meta property=\"se:long-description\">[/] element, but the first instance of their name is not hyperlinked to their SE author page."
+"m-057", "[xml]xml:lang[/] attribute in [xml]<meta property=\"se:long-description\">[/] element should be [xml]lang[/]."
 
 SEMANTICS & CONTENT
 "s-001", "Illegal numeric entity (like [xhtml]&#913;[/])."
@@ -606,6 +607,10 @@ def lint(self, skip_lint_ignore: bool) -> list:
 				# We can't use xpath here because the long description is escaped; it has no dom to query against.
 				if author_last_name in long_description and not regex.search(fr"<a href=\"https://standardebooks\.org/ebooks/.+?\">.*?{author_last_name}.*?</a>", long_description):
 					messages.append(LintMessage("m-056", "Author name present in [xml]<meta property=\"se:long-description\">[/] element, but the first instance of their name is not hyperlinked to their SE author page.", se.MESSAGE_TYPE_ERROR, self.metadata_file_path))
+
+		# xml:lang is correct for the rest of the publication, but should be lang in the long desc
+		if "xml:lang" in long_description:
+			messages.append(LintMessage("m-057", "[xml]xml:lang[/] attribute in [xml]<meta property=\"se:long-description\">[/] element should be [xml]lang[/].", se.MESSAGE_TYPE_ERROR, self.metadata_file_path))
 
 	except:
 		raise se.InvalidSeEbookException(f"No [xml]<meta property=\"se:long-description\">[/] element in [path][link=file://{self.metadata_file_path}]{self.metadata_file_path.name}[/][/].")

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -252,7 +252,7 @@ XHTML
 "x-013", f"CSS class found in XHTML, but not in [path][link=file://{local_css_path}]local.css[/][/]."
 "x-014", "Illegal [xml]id[/] attribute."
 "x-015", "Illegal element in [xhtml]<head>[/]. Only [xhtml]<title>[/] and [xhtml]<link rel=\"stylesheet\">[/] are allowed."
-"x-016", "[attr]xml:lang[/] attriute with value starting in uppercase letter."
+"x-016", "[attr]xml:lang[/] attribute with value starting in uppercase letter."
 vvvvvvvvUNUSEDvvvvvvvvvv
 "x-011", ""
 """
@@ -1316,7 +1316,7 @@ def lint(self, skip_lint_ignore: bool) -> list:
 
 				nodes = dom.xpath("//*[re:test(@xml:lang, '^[A-Z]')]")
 				if nodes:
-					messages.append(LintMessage("x-016", "[attr]xml:lang[/] attriute with value starting in uppercase letter.", se.MESSAGE_TYPE_ERROR, filename, [node.totagstring() for node in nodes]))
+					messages.append(LintMessage("x-016", "[attr]xml:lang[/] attribute with value starting in uppercase letter.", se.MESSAGE_TYPE_ERROR, filename, [node.totagstring() for node in nodes]))
 
 				# Check for common typos
 				# Don't check the titlepage because it has a standard format and may raise false positives


### PR DESCRIPTION
Longdesc should be valid HTML, not XHTML.

There were a single-digit number of occurrences of this in the corpus which I’ve fixed up.