### PR TITLE
modernize-spelling: Add whichever

### DIFF
--- a/se/data/words
+++ b/se/data/words
@@ -90191,6 +90191,7 @@ whetstones
 whetted
 whetting
 whey
+whichever
 whicker
 whickered
 whickering


### PR DESCRIPTION
Found whichever spelled "which-ever". https://www.merriam-webster.com/dictionary/whichever