### PR TITLE
semanticate: Add abbreviation for Gov.

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -78,7 +78,7 @@ def semanticate(xhtml: str) -> str:
 	xhtml = regex.sub(r"(?<!\<abbr\>)Inc\.", r"<abbr>Inc.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)Ltd\.", r"<abbr>Ltd.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)St\.", r"<abbr>St.</abbr>", xhtml)
-	xhtml = regex.sub(r"(?<!\<abbr\>)Gov\.", r"<abbr>Gov.</abbr>", xhtml)
+	xhtml = regex.sub(r"(?<!\<abbr\>)[Gg]ov\.", r"<abbr>\1ov.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)MS(S?)\.", r"""<abbr class="initialism">MS\1.</abbr>""", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)([Vv])iz\.", r"<abbr>\1iz.</abbr>", xhtml)
 	xhtml = regex.sub(r"(\b)(?<!\<abbr\>)etc\.", r"\1<abbr>etc.</abbr>", xhtml)

--- a/se/formatting.py
+++ b/se/formatting.py
@@ -78,7 +78,7 @@ def semanticate(xhtml: str) -> str:
 	xhtml = regex.sub(r"(?<!\<abbr\>)Inc\.", r"<abbr>Inc.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)Ltd\.", r"<abbr>Ltd.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)St\.", r"<abbr>St.</abbr>", xhtml)
-	xhtml = regex.sub(r"(?<!\<abbr\>)[Gg]ov\.", r"<abbr>\1ov.</abbr>", xhtml)
+	xhtml = regex.sub(r"(?<!\<abbr\>)([Gg])ov\.", r"<abbr>\1ov.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)MS(S?)\.", r"""<abbr class="initialism">MS\1.</abbr>""", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)([Vv])iz\.", r"<abbr>\1iz.</abbr>", xhtml)
 	xhtml = regex.sub(r"(\b)(?<!\<abbr\>)etc\.", r"\1<abbr>etc.</abbr>", xhtml)

--- a/se/formatting.py
+++ b/se/formatting.py
@@ -78,6 +78,7 @@ def semanticate(xhtml: str) -> str:
 	xhtml = regex.sub(r"(?<!\<abbr\>)Inc\.", r"<abbr>Inc.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)Ltd\.", r"<abbr>Ltd.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)St\.", r"<abbr>St.</abbr>", xhtml)
+	xhtml = regex.sub(r"(?<!\<abbr\>)Gov\.", r"<abbr>Gov.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)MS(S?)\.", r"""<abbr class="initialism">MS\1.</abbr>""", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)([Vv])iz\.", r"<abbr>\1iz.</abbr>", xhtml)
 	xhtml = regex.sub(r"(\b)(?<!\<abbr\>)etc\.", r"\1<abbr>etc.</abbr>", xhtml)


### PR DESCRIPTION
Abbreviation for Gov. -> Governor. https://en.wiktionary.org/wiki/Gov. It's also sometimes lowercased (look here at "More Definitions": https://www.merriam-webster.com/dictionary/gov), but that could also mean "government". Though I guess that could also be surrounded with the `<abbr>` tag automatically. If you want me to add it, I can.