### PR TITLE
semanticate: Add abbreviation for Col.

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -79,6 +79,7 @@ def semanticate(xhtml: str) -> str:
 	xhtml = regex.sub(r"(?<!\<abbr\>)Ltd\.", r"<abbr>Ltd.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)St\.", r"<abbr>St.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)([Gg])ov\.", r"<abbr>\1ov.</abbr>", xhtml)
+	xhtml = regex.sub(r"(?<!\<abbr\>)Col\.", r"<abbr>Col.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)MS(S?)\.", r"""<abbr class="initialism">MS\1.</abbr>""", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)([Vv])iz\.", r"<abbr>\1iz.</abbr>", xhtml)
 	xhtml = regex.sub(r"(\b)(?<!\<abbr\>)etc\.", r"\1<abbr>etc.</abbr>", xhtml)


### PR DESCRIPTION
[https://en.wiktionary.org/wiki/Col.](https://en.wiktionary.org/wiki/Col.) (colonel). Can also be spelled without the period at times so I can add that as well, but I'm guessing it would be mostly spelled with the period because "col" by itself is also a word. 

Since we have abbreviations like St., Gov., Capt., Lt., etc. I think "Col." is a good addition.