### PR TITLE
According to the Manual, "MS." is not an initialism

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -80,7 +80,7 @@ def semanticate(xhtml: str) -> str:
 	xhtml = regex.sub(r"(?<!\<abbr\>)St\.", r"<abbr>St.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)([Gg])ov\.", r"<abbr>\1ov.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)Col\.", r"<abbr>Col.</abbr>", xhtml)
-	xhtml = regex.sub(r"(?<!\<abbr\>)MS(S?)\.", r"""<abbr class="initialism">MS\1.</abbr>""", xhtml)
+	xhtml = regex.sub(r"(?<!\<abbr\>)MS(S?)\.", r"""<abbr>MS\1.</abbr>""", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)([Vv])iz\.", r"<abbr>\1iz.</abbr>", xhtml)
 	xhtml = regex.sub(r"(\b)(?<!\<abbr\>)etc\.", r"\1<abbr>etc.</abbr>", xhtml)
 	xhtml = regex.sub(r"(\b)(?<!\<abbr\>)([Cc])f\.", r"\1<abbr>\2f.</abbr>", xhtml)


### PR DESCRIPTION
Per [the Manual](https://standardebooks.org/manual/1.0.0/8-typography#8.10.4.3), "MS." should be marked as an abbreviation but without class="initialism".