### PR TITLE
modernize-spelling: logarythm -> logarithm

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -280,6 +280,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b([Hh])iccough", r"\1iccup", xhtml)			# hiccough -> hiccup
 	xhtml = regex.sub(r"\b([Rr])oue(s?)\b", r"\1oué\2", xhtml)			# roue -> roué
 	xhtml = regex.sub(r"\b([Ii])dee fixe\b", r"\1dée fixe\2", xhtml)		# idee fixe -> idée fixe
+	xhtml = regex.sub(r"\b([Ll])ogarythm", r"\1ogarithm", xhtml)			# logarythm -> logarithm
 
 	# Normalize some names
 	xhtml = regex.sub(r"Moliere", r"Molière", xhtml)				# Moliere -> Molière


### PR DESCRIPTION
Found in Mark Twain's _Roughing It_: "He called Ollendorff all manner of hard names﻿—said he never saw such a lurid fool as he was, and ended with the peculiarly venomous opinion that he "did not know as much as a logarythm!". 

Left out `\b` at the end to also catch `logarythmic` and what not.