### PR TITLE
Restrict pytest version

### DIFF
--- a/.github/workflows/se-test.yml
+++ b/.github/workflows/se-test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install pipx packages
       run: |
         pipx install .
-        pipx inject standardebooks pylint pytest mypy
+        pipx inject standardebooks pylint 'pytest<6' mypy
     - name: Check type annotations with mypy
       run: $HOME/.local/pipx/venvs/standardebooks/bin/mypy
     - name: Check code with pylint


### PR DESCRIPTION
Current tests are not compatible with version 6.x of pytest.

Fixes #320 
