### PR TITLE
Fix extra gap on Kobo before 4-dot ellipses

### DIFF
--- a/se/vendor/kobo_touch_extended/kobo.py
+++ b/se/vendor/kobo_touch_extended/kobo.py
@@ -18,7 +18,7 @@ import lxml.etree as etree
 
 import se
 
-# Don't capitalize these, they're not contants
+# Don't capitalize these, they're not constants
 paragraph_counter = 1
 segment_counter = 1
 

--- a/se/vendor/kobo_touch_extended/kobo.py
+++ b/se/vendor/kobo_touch_extended/kobo.py
@@ -16,6 +16,8 @@ from copy import deepcopy
 import regex
 import lxml.etree as etree
 
+import se
+
 # Don't capitalize these, they're not contants
 paragraph_counter = 1
 segment_counter = 1
@@ -30,7 +32,7 @@ def append_kobo_spans_from_text(node, text):
 			return False
 		else:
 			# Split text in sentences
-			groups = regex.split(r'(.*?[\.\!\?\:](?:\u200a…)?[\'"\u201d\u2019]?\s*)', text, flags=regex.MULTILINE)
+			groups = regex.split(fr'(.*?[\.\!\?\:](?:{se.HAIR_SPACE}…)?[\'"\u201d\u2019]?\s*)', text, flags=regex.MULTILINE)
 			# Remove empty strings resulting from split()
 			groups = [g for g in groups if g != ""]
 

--- a/se/vendor/kobo_touch_extended/kobo.py
+++ b/se/vendor/kobo_touch_extended/kobo.py
@@ -30,7 +30,7 @@ def append_kobo_spans_from_text(node, text):
 			return False
 		else:
 			# Split text in sentences
-			groups = regex.split(r'(.*?[\.\!\?\:][\'"\u201d\u2019]?\s*)', text, flags=regex.MULTILINE)
+			groups = regex.split(r'(.*?[\.\!\?\:](?:\u200a…)?[\'"\u201d\u2019]?\s*)', text, flags=regex.MULTILINE)
 			# Remove empty strings resulting from split()
 			groups = [g for g in groups if g != ""]
 


### PR DESCRIPTION
The Kobo build-chain breaks sentences into “kobo spans”. These shouldn’t affect the rendering, but as it stands a hair space in the content becomes a full space in the presentation.

This is most obvious with 4 dot ellipses, which we replicate with a full stop followed by a hair space followed by an ellipsis. This revised regex looks for that pattern and avoids splitting, causing the 4-dot ellipsis to render as expected.