### PR TITLE
Avoid unhandled exception when filename not present in linting message

### DIFF
--- a/se/commands/lint.py
+++ b/se/commands/lint.py
@@ -83,7 +83,11 @@ def lint() -> int:
 					message.text = regex.sub(r"\[(?:/|xhtml|xml|val|attr|val|class|path|url|text|bash|link)(?:=[^\]]*?)*\]", "`", message.text)
 					message.text = regex.sub(r"`+", "`", message.text)
 
-					console.print(f"{message.code} {label} {message.filename.name} {message.text}")
+					message_filename = ""
+					if message.filename:
+						message_filename = message.filename.name
+
+					console.print(f"{message.code} {label} {message_filename} {message.text}")
 
 					if message.submessages:
 						for submessage in message.submessages:
@@ -112,7 +116,9 @@ def lint() -> int:
 						# Replace color markup with `
 						message_text = regex.sub(r"\[(?:/|xhtml|xml|val|attr|val|class|path|url|text|bash|link)(?:=[^\]]*?)*\]", "`", message_text)
 						message_text = regex.sub(r"`+", "`", message_text)
-						message_filename = message.filename.name
+						message_filename = ""
+						if message.filename:
+							message_filename = message.filename.name
 
 					table_data.append([message.code, alert, message_filename, message_text])
 

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -1885,7 +1885,7 @@ def lint(self, skip_lint_ignore: bool) -> list:
 				messages.append(LintMessage("s-037", "No [val]backmatter[/] semantic inflection for what looks like a backmatter file.", se.MESSAGE_TYPE_WARNING, filename))
 
 	if cover_svg_title != titlepage_svg_title:
-		messages.append(LintMessage("s-028", f"[path][link=file://{self.path / 'images/cover.svg'}]cover.svg[/][/] and [path][link=file://{self.path / 'images/titlepage.svg'}]titlepage.svg[/][/] [xhtml]<title>[/] elements don’t match.", se.MESSAGE_TYPE_ERROR))
+		messages.append(LintMessage("s-028", f"[path][link=file://{self.path / 'images/cover.svg'}]cover.svg[/][/] and [path][link=file://{self.path / 'images/titlepage.svg'}]titlepage.svg[/][/] [xhtml]<title>[/] elements don’t match.", se.MESSAGE_TYPE_ERROR, "cover.svg"))
 
 	if has_frontmatter and not has_halftitle:
 		messages.append(LintMessage("s-020", "Frontmatter found, but no halftitle. Halftitle is required when frontmatter is present.", se.MESSAGE_TYPE_ERROR, self.metadata_file_path))


### PR DESCRIPTION
Message s-028 missed the filename so when this message was present in the linting messages a exception "AttributeError: 'NoneType' object has no attribute 'name'" occurred.

Added the filename part to the message and also added some checks to prevent this sort of exception.