### PR TITLE
Remove extraneous gap on Kobo in the middle of ’” pair

### DIFF
--- a/se/vendor/kobo_touch_extended/kobo.py
+++ b/se/vendor/kobo_touch_extended/kobo.py
@@ -32,7 +32,7 @@ def append_kobo_spans_from_text(node, text):
 			return False
 		else:
 			# Split text in sentences
-			groups = regex.split(fr'(.*?[\.\!\?\:](?:{se.HAIR_SPACE}…)?[\'"\u201d\u2019]?\s*)', text, flags=regex.MULTILINE)
+			groups = regex.split(fr'(.*?[\.\!\?\:](?:{se.HAIR_SPACE}…)?[\'"\u201d\u2019]?(?:{se.HAIR_SPACE}\u201d)?\s*)', text, flags=regex.MULTILINE)
 			# Remove empty strings resulting from split()
 			groups = [g for g in groups if g != ""]
 


### PR DESCRIPTION
This extends the work done to remove gaps in 4-dot ellipses to also include extra gaps between single/double close quotes.

This regex is getting unwieldy. If we have any more changes later on then we should probably decompose it.