### PR TITLE
Allow initialisms with numbers, e.g. D.C.4

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -89,9 +89,9 @@ def semanticate(xhtml: str) -> str:
 	xhtml = regex.sub(r"(?<!\<abbr\>)(Jan\.|Feb\.|Mar\.|Apr\.|Jun\.|Jul\.|Aug\.|Sep\.|Sept\.|Oct\.|Nov\.|Dec\.)", r"<abbr>\1</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)No\.(\s+[0-9]+)", r"<abbr>No.</abbr>\1", xhtml)
 	xhtml = regex.sub(r"\b(?<!\<abbr\>)([Vv])s\.", r"<abbr>\1s.</abbr>", xhtml)
-    # python allows a variable lookbehind with the ( eoc)?; HOWEVER, it counts it as the
-    #   first capture group, so if there are one or more capture groups in the regex itself,
-    #   be sure to start at 2 when specifying the group(s) in the replacement spec.
+	# python allows a variable lookbehind with the ( eoc)?; HOWEVER, it counts it as the
+	#	first capture group, so if there are one or more capture groups in the regex itself,
+	#	be sure to start at 2 when specifying the group(s) in the replacement spec.
 	xhtml = regex.sub(r"""(?<!\<abbr class="initialism( eoc)?"\>)([Ii])\.e\.""", r"""<abbr class="initialism">\2.e.</abbr>""", xhtml)
 	xhtml = regex.sub(r"""(?<!\<abbr class="initialism( eoc)?"\>)([Ee])\.g\.""", r"""<abbr class="initialism">\2.g.</abbr>""", xhtml)
 	xhtml = regex.sub(r"""(?<!\<abbr class="initialism( eoc)?"\>)\bN\.?B\.\b""", r"""<abbr class="initialism">N.B.</abbr>""", xhtml)
@@ -1146,7 +1146,7 @@ def namespace_to_class(selector: str) -> str:
 	A string representing the selector with namespaces replaced by classes
 	"""
 
-	# First, remove periods from epub:type.  We can't remove periods in the entire selector because there might be class selectors involved
+	# First, remove periods from epub:type.	 We can't remove periods in the entire selector because there might be class selectors involved
 	epub_type = regex.search(r"\"[^\"]+?\"", selector).group()
 	if epub_type:
 		selector = selector.replace(epub_type, epub_type.replace(".", "-"))

--- a/se/formatting.py
+++ b/se/formatting.py
@@ -86,20 +86,24 @@ def semanticate(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b(?<!\<abbr\>)([Cc])f\.", r"<abbr>\1f.</abbr>", xhtml)
 	xhtml = regex.sub(r"\b(?<!\<abbr\>)p\.([\s0-9])", r"<abbr>p.</abbr>\1", xhtml)
 	xhtml = regex.sub(r"\b(?<!\<abbr\>)ed\.", r"<abbr>ed.</abbr>", xhtml)
-	xhtml = regex.sub(r"""(?<!\<abbr class="initialism( eoc)?"\>)([Ii])\.e\.""", r"""<abbr class="initialism">\1.e.</abbr>""", xhtml)
-	xhtml = regex.sub(r"""(?<!\<abbr class="initialism( eoc)?"\>)([Ee])\.g\.""", r"""<abbr class="initialism">\1.g.</abbr>""", xhtml)
-	xhtml = regex.sub(r"""(?<!\<abbr class="initialism( eoc)?"\>)\bN\.?B\.\b""", r"""<abbr class="initialism">N.B.</abbr>""", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)(Jan\.|Feb\.|Mar\.|Apr\.|Jun\.|Jul\.|Aug\.|Sep\.|Sept\.|Oct\.|Nov\.|Dec\.)", r"<abbr>\1</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)No\.(\s+[0-9]+)", r"<abbr>No.</abbr>\1", xhtml)
+	xhtml = regex.sub(r"\b(?<!\<abbr\>)([Vv])s\.", r"<abbr>\1s.</abbr>", xhtml)
+    # python allows a variable lookbehind with the ( eoc)?; HOWEVER, it counts it as the
+    #   first capture group, so if there are one or more capture groups in the regex itself,
+    #   be sure to start at 2 when specifying the group(s) in the replacement spec.
+	xhtml = regex.sub(r"""(?<!\<abbr class="initialism( eoc)?"\>)([Ii])\.e\.""", r"""<abbr class="initialism">\2.e.</abbr>""", xhtml)
+	xhtml = regex.sub(r"""(?<!\<abbr class="initialism( eoc)?"\>)([Ee])\.g\.""", r"""<abbr class="initialism">\2.g.</abbr>""", xhtml)
+	xhtml = regex.sub(r"""(?<!\<abbr class="initialism( eoc)?"\>)\bN\.?B\.\b""", r"""<abbr class="initialism">N.B.</abbr>""", xhtml)
 	xhtml = regex.sub(r"""(?<!\<abbr class="degree( eoc)?"\>)Ph\.?\s*D\.?""", r"""<abbr class="degree">Ph. D.</abbr>""", xhtml)
 	xhtml = regex.sub(r"""(?<!\<abbr class="initialism( eoc)?"\>)I\.?O\.?U\.?\b""", r"""<abbr class="initialism">I.O.U.</abbr>""", xhtml)
 	xhtml = regex.sub(r"""(\s)(?<!\<abbr class="era( eoc)?"\>)A\.?D""", r"""\1<abbr class="era">AD</abbr>""", xhtml)
 	xhtml = regex.sub(r"""(\s)(?<!\<abbr class="era( eoc)?"\>)B\.?C""", r"""\1<abbr class="era">BC</abbr>""", xhtml)
 	xhtml = regex.sub(r"""(?<!\<abbr class="time( eoc)?"\>)([ap])\.\s?m\.""", r"""<abbr class="time">\2.m.</abbr>""", xhtml)
-	xhtml = regex.sub(r"\b(?<!\<abbr\>)([Vv])s\.", r"<abbr>\1s.</abbr>", xhtml)
 	xhtml = regex.sub(r"""(?<!\<abbr class="name( eoc)?"\>)Thos\.""", r"""<abbr class="name">Thos.</abbr>""", xhtml)
 	xhtml = regex.sub(r"""(?<!\<abbr class="name( eoc)?"\>)Jas\.""", r"""<abbr class="name">Jas.</abbr>""", xhtml)
 	xhtml = regex.sub(r"""(?<!\<abbr class="name (eoc)?"\>)Chas\.""", r"""<abbr class="name">Chas.</abbr>""", xhtml)
+	xhtml = regex.sub(r"""(?<!\<abbr class="initialism( eoc)?"\>)\b([2-4]D)\b""", r"""<abbr class="initialism">\2</abbr>""", xhtml)
 
 	# Wrap £sd shorthand
 	xhtml = regex.sub(r"([0-9½¼⅙⅚⅛⅜⅝]+)([sd⅞]\.)", r"\1<abbr>\2</abbr>", xhtml)

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -1251,7 +1251,7 @@ def lint(self, skip_lint_ignore: bool) -> list:
 					messages.append(LintMessage("s-030", "[val]z3998:nonfiction[/] should be [val]z3998:non-fiction[/].", se.MESSAGE_TYPE_ERROR, filename))
 
 				# Check for initialisms without periods
-				nodes = [node.tostring() for node in dom.xpath("/html/body//abbr[contains(@class, 'initialism') and not(re:test(., '^([a-zA-Z]\\.)+$'))]") if node.text not in initialism_exceptions]
+				nodes = [node.tostring() for node in dom.xpath("/html/body//abbr[contains(@class, 'initialism') and not(re:test(., '^[0-9]*([a-zA-Z]\\.)+[0-9]*$'))]") if node.text not in initialism_exceptions]
 				if nodes:
 					messages.append(LintMessage("t-030", "Initialism with spaces or without periods.", se.MESSAGE_TYPE_WARNING, filename, set(nodes)))
 

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -397,7 +397,7 @@ def lint(self, skip_lint_ignore: bool) -> list:
 	unused_selectors: List[str] = []
 	missing_metadata_elements = []
 	abbr_elements: List[se.easy_xml.EasyXmlElement] = []
-	initialism_exceptions = ["MS.", "MSS.", "κ.τ.λ.", "TV"] # semos://1.0.0/8.10.5.1; κ.τ.λ. is "etc." in Greek, and we don't match Greek chars.
+	initialism_exceptions = ["2D", "3D", "4D", "MS.", "MSS.", "κ.τ.λ.", "TV"] # semos://1.0.0/8.10.5.1; κ.τ.λ. is "etc." in Greek, and we don't match Greek chars.
 
 	# This is a dict with where keys are the path and values are a list of code dicts.
 	# Each code dict has a key "code" which is the actual code, and a key "used" which is a


### PR DESCRIPTION
This changes the regex in the t-030 check to allow optional numbers at the beginning or ending of the text. I used an asterisk at the end for things like D.C.10; I used one at the beginning because although I couldn't think of an abbreviation starting with two or more numbers, I was afraid there was some. :)

Per my email on the list, though, I'm not sure we shouldn't exception things like 2D/3D; that period looks weird to me on a single letter in the middle of a sentence.