### PR TITLE
Use correct font weight in initial cover / titlepage

### DIFF
--- a/se/data/templates/cover.svg
+++ b/se/data/templates/cover.svg
@@ -9,6 +9,7 @@
 		text{
 			fill: #fff;
 			font-family: "League Spartan";
+			font-weight: bold;
 			letter-spacing: 5px;
 			text-anchor: middle;
 		}

--- a/se/data/templates/titlepage.svg
+++ b/se/data/templates/titlepage.svg
@@ -4,6 +4,7 @@
 	<style type="text/css">
 		text{
 			font-family: "League Spartan";
+			font-weight: bold;
 			letter-spacing: 5px;
 			text-anchor: middle;
 		}

--- a/tests/data/draft/jane-austen_unknown-novel/images/cover.svg
+++ b/tests/data/draft/jane-austen_unknown-novel/images/cover.svg
@@ -9,6 +9,7 @@
 		text{
 			fill: #fff;
 			font-family: "League Spartan";
+			font-weight: bold;
 			letter-spacing: 5px;
 			text-anchor: middle;
 		}

--- a/tests/data/draft/jane-austen_unknown-novel/images/titlepage.svg
+++ b/tests/data/draft/jane-austen_unknown-novel/images/titlepage.svg
@@ -4,6 +4,7 @@
 	<style type="text/css">
 		text{
 			font-family: "League Spartan";
+			font-weight: bold;
 			letter-spacing: 5px;
 			text-anchor: middle;
 		}


### PR DESCRIPTION
Just a minor thing here, but this fixes the cover/titlepage text weight for people with the correct fonts installed who preview how prospective cover art looks. It doesn’t affect the build as that always picks the bold font file.

Letter spacing is still off, but this at least looks passably like the final cover rather than just broken.