### PR TITLE
Update licences to cover the current reality

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Standard Ebooks and its contributors release the contents of this repository under the GPLv3 license, with the exception of the contents of the `se/data/templates` directory, which are released under the CC0 1.0 Universal Public Domain Dedication.
+Standard Ebooks and its contributors release the contents of this repository under the GPLv3 license, with the exception of the contents of the `se/data/templates` directory, which are released under the CC0 1.0 Universal Public Domain Dedication, and the remaining components in the `se/data` directory whose licenses are specified in their respective directory or file.
 
 You can read the GPLv3 license here: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/se/data/fonts/league-spartan/league-spartan-bold.svg
+++ b/se/data/fonts/league-spartan/league-spartan-bold.svg
@@ -2,9 +2,8 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
 <metadata>
-Created by FontForge 20190801 at Sun Sep 21 12:04:50 2014
- By Jared Updike
-copyright missing
+  By Jared Updike
+  Copyright (c) September 22 2014, Micah Rich micah@micahrich.com, with Reserved Font Name: "League Spartan".
 </metadata>
 <defs>
 <font id="LeagueSpartan-Bold" horiz-adv-x="683" >


### PR DESCRIPTION
Also fix the copyright reference in our League Spartan font file.

Sorry this is a bit wordy, but it turns out we’ve literally got tens of licences in use in tools.