### PR TITLE
Fix toc_link method exception error

### DIFF
--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -73,7 +73,7 @@ class TocItem:
 
 		out_string = ""
 		if not self.title:
-			raise se.InvalidInputException(f"Couldn't find title in': [path][link=file://{self.file_link}[/][/].")
+			raise se.InvalidInputException(f"Couldn't find title in': [path][link=file://{self.file_link}]{self.file_link}[/][/].")
 
 		if self.subtitle and self.lang:
 			# test for a foreign language subtitle, and adjust accordingly

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -73,7 +73,7 @@ class TocItem:
 
 		out_string = ""
 		if not self.title:
-			raise se.InvalidInputException(f"Couldn't find title in': [path][link=file://{self.file_link}]{self.file_link}[/][/].")
+			raise se.InvalidInputException(f"Couldn't find title in: [path][link=file://{self.file_link}]{self.file_link}[/][/].")
 
 		if self.subtitle and self.lang:
 			# test for a foreign language subtitle, and adjust accordingly


### PR DESCRIPTION
Add a second self.file_link in the error message outside the link so the filename will display in the error.