### PR TITLE
Generate and use 2x MathML images

### DIFF
--- a/se/images.py
+++ b/se/images.py
@@ -135,12 +135,12 @@ def render_mathml_to_png(driver, mathml: str, output_filename: Path, output_file
 			image = _color_to_alpha(image, (255, 255, 255, 255))
 			image = image.crop(image.getbbox())
 
-			# iBooks srcset bug: once srcset works in iBooks, uncomment this line
-			# image.save(output_filename_2x)
+			image.save(output_filename_2x)
 
 			# Save normal version
-			image = image.resize((image.width // 2, image.height // 2))
-			image.save(output_filename)
+			# iBooks srcset bug: once srcset works in iBooks, uncomment these lines
+			# image = image.resize((image.width // 2, image.height // 2))
+			# image.save(output_filename)
 
 def remove_image_metadata(filename: Path) -> None:
 	"""

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -711,10 +711,14 @@ def build(self, run_epubcheck: bool, build_kobo: bool, build_kindle: bool, outpu
 										if regex.findall("</?(?:m:)?m", processed_line):
 											# Failure! Abandon all hope, and use Firefox to convert the MathML to PNG.
 											se.images.render_mathml_to_png(driver, regex.sub(r"<(/?)m:", "<\\1", line), work_epub_root_directory / "epub" / "images" / f"mathml-{mathml_count}.png", work_epub_root_directory / "epub" / "images" / f"mathml-{mathml_count}-2x.png")
+											# calculate the "normal" height/width from the 2x image
+											image = Image.open(work_epub_root_directory / "epub" / "images" / f"mathml-{mathml_count}-2x.png")
+											img_width = image.size[0] // 2
+											img_height = image.size[1] // 2
 
 											# iBooks srcset bug: once srcset works in iBooks, we can use this line instead of the one below it
 											# processed_xhtml = processed_xhtml.replace(line, f"<img class=\"mathml epub-type-se-image-color-depth-black-on-transparent\" epub:type=\"se:image.color-depth.black-on-transparent\" src=\"../images/mathml-{mathml_count}.png\" srcset=\"../images/mathml-{mathml_count}-2x.png 2x, ../images/mathml-{mathml_count}.png 1x\"/>")
-											processed_xhtml = processed_xhtml.replace(line, f"<img class=\"mathml epub-type-se-image-color-depth-black-on-transparent\" epub:type=\"se:image.color-depth.black-on-transparent\" src=\"../images/mathml-{mathml_count}.png\"/>")
+											processed_xhtml = processed_xhtml.replace(line, f"<img class=\"mathml epub-type-se-image-color-depth-black-on-transparent\" epub:type=\"se:image.color-depth.black-on-transparent\" src=\"../images/mathml-{mathml_count}-2x.png\" height=\"{img_height}\" width=\"{img_width}\"/>")
 											mathml_count = mathml_count + 1
 										else:
 											# Success! Replace the MathML with our new string.


### PR DESCRIPTION
This is a proof-of-concept that at least begins the discussion. I changed images.py to generate the 2x version of the MathML images, then get the width/height of the image, divide them by 2, and put those in height and width attributes on the `img`.

This works for me on both a Mac and an iPad. I don't have any 1x displays to test it on.

![image](https://user-images.githubusercontent.com/19378955/95161210-2beede00-0768-11eb-9afe-ba20b260ecf6.jpeg)

One thing I noted is that the raw dimensions on the 2x versions are not divisible by 2, i.e. they're all odd. That seemed … odd. (Sorry.) Shouldn't they be if they're hiDPI versions?
