### PR TITLE
Ensure Python 3.9 compatibility with latest pillow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         "importlib_resources==1.0.2",
         "lxml==4.5.0",
         "natsort==7.0.1",
-        "pillow==7.1.1",
+        "pillow==8.0.0",
         "psutil==5.7.0",
         "pyhyphen==3.0.1",
         "pyopenssl==19.1.0",  # Required to allow the `requests` package to use https on Mac OSX


### PR DESCRIPTION
This seems to drop cover generation for 800ms to 750ms on my machine.