### PR TITLE
Converted print-toc to use xpath instead of Beautiful Soup

### DIFF
--- a/se/easy_xml.py
+++ b/se/easy_xml.py
@@ -189,6 +189,7 @@ class EasyXmlElement:
 		"""
 
 		attribute = attribute.replace("epub:", "{http://www.idpf.org/2007/ops}")
+		attribute = attribute.replace("xml:", "{http://www.w3.org/XML/1998/namespace}")
 
 		return self.lxml_element.get(attribute)
 

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -956,8 +956,8 @@ class SeEpub:
 		change_list = []
 
 		for file_name in self.get_content_files():
-			if file_name in ["titlepage.xhtml", "colophon.xhtml", "uncopyright.xhtml", "imprint.xhtml", "halftitle.xhtml", "endnotes.xhtml"]:
-				continue
+			if file_name in ["titlepage.xhtml", "colophon.xhtml", "uncopyright.xhtml", "imprint.xhtml", "halftitle.xhtml"]:
+				continue  # note that we DO process endnotes.xhtml itself with this
 
 			processed += 1
 
@@ -1005,9 +1005,14 @@ class SeEpub:
 
 			# If we need to write back the body text file
 			if needs_rewrite:
-				new_file = open(file_path, "w")
-				new_file.write(se.formatting.format_xhtml(dom.to_string()))
-				new_file.close()
+				if "endnotes.xhtml" not in file_path:  # no point in re-writing endnotes.xhtml here, it will get overwritten later.
+					new_file = open(file_path, "w")
+					new_file.write(se.formatting.format_xhtml(dom.to_string()))
+					new_file.close()
+				else:  # Instead...
+					for content in endnote.contents:
+						print(content)
+
 
 		if processed == 0:
 			raise se.InvalidInputException("No files processed. Did you update the manifest and order the spine?")

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -956,8 +956,8 @@ class SeEpub:
 		change_list = []
 
 		for file_name in self.get_content_files():
-			if file_name in ["titlepage.xhtml", "colophon.xhtml", "uncopyright.xhtml", "imprint.xhtml", "halftitle.xhtml"]:
-				continue  # note that we DO process endnotes.xhtml itself with this
+			if file_name in ["titlepage.xhtml", "colophon.xhtml", "uncopyright.xhtml", "imprint.xhtml", "halftitle.xhtml", "endnotes.xhtml"]:
+				continue
 
 			processed += 1
 
@@ -1005,22 +1005,16 @@ class SeEpub:
 
 			# If we need to write back the body text file
 			if needs_rewrite:
-				if "endnotes.xhtml" not in file_path:  # no point in re-writing endnotes.xhtml here, it will get overwritten later.
-					new_file = open(file_path, "w")
-					new_file.write(se.formatting.format_xhtml(dom.to_string()))
-					new_file.close()
-				else:  # Instead...
-					for content in endnote.contents:
-						print(content)
-
+				with open(file_path, "w") as file:
+					file.write(se.formatting.format_xhtml(dom.to_string()))
 
 		if processed == 0:
 			raise se.InvalidInputException("No files processed. Did you update the manifest and order the spine?")
 
 		if notes_changed > 0:
 			# Now we need to recreate the endnotes file
-			for ol_tag in self._endnotes_dom.xpath("/html/body/section[contains(@epub:type, 'endnotes')]/ol[1]"):
-				for node in ol_tag.xpath("./li[contains(@epub:type, 'endnote')]"):
+			for ol_node in self._endnotes_dom.xpath("/html/body/section[contains(@epub:type, 'endnotes')]/ol[1]"):
+				for node in ol_node.xpath("./li[contains(@epub:type, 'endnote')]"):
 					node.remove()
 
 				self.endnotes.sort(key=lambda endnote: endnote.number)
@@ -1032,7 +1026,7 @@ class SeEpub:
 						for node in endnote.node.xpath(".//a[contains(@epub:type, 'backlink')]"):
 							node.set_attr("href", f"{endnote.source_file}#noteref-{endnote.number}")
 
-						ol_tag.append(endnote.node)
+						ol_node.append(endnote.node)
 
 			with open(self.path / "src" / "epub" / "text" / "endnotes.xhtml", "w") as file:
 				file.write(se.formatting.format_xhtml(self._endnotes_dom.to_string()))

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -538,11 +538,10 @@ def evaluate_descendants(node: EasyXmlElement, toc_item):
 				toc_item.title_is_ordinal = True
 				# strip label
 				child_strings = regex.sub(r"<span epub:type=\"label\">(.*?)</span>", " \\1 ", child_strings)
-				# adjust roman
-				child_strings = regex.sub(r"ordinal z3998:roman", "z3998:roman", child_strings)
-				child_strings = regex.sub(r"z3998:roman ordinal", "z3998:roman", child_strings)
-				# remove ordinal
+				# remove ordinal if it's by itself in a span
 				child_strings = regex.sub(r"<span epub:type=\"ordinal\">(.*?)</span>", " \\1 ", child_strings)
+				# remove ordinal if it's joined with a roman (which we want to keep)
+				child_strings = regex.sub(r"\bordinal\b", "", child_strings)
 				# remove extra spaces
 				child_strings = regex.sub(r"[ ]{2,}", " ", child_strings)
 				toc_item.title = child_strings.strip()
@@ -602,7 +601,7 @@ def get_book_division(node: EasyXmlElement) -> BookDivision:
 		retval = BookDivision.SUBCHAPTER
 	if "chapter" in section_epub_type:
 		retval = BookDivision.CHAPTER
-	if "article" in parent_sections[0].tag:
+	if "article" in parent_sections[-1].tag:
 		retval = BookDivision.ARTICLE
 
 	return retval

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -130,19 +130,6 @@ class TocItem:
 
 		return out_string
 
-
-def get_first(node: EasyXmlTree, wanted: str):
-	"""
-	get the first matching node which occurs in the file
-	:param node: an EasyXmlTree node
-	:param wanted: xpath pattern to find
-	:return: an EasyXmlTree node with the first heading encountered
-	"""
-	nodes = node.xpath(wanted)
-	if len(nodes) > 0:
-		return nodes[0]
-	return None
-
 def get_place(node: EasyXmlElement) -> Position:
 	"""
 	Returns place of file in ebook, eg frontmatter, backmatter, etc.

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -586,7 +586,7 @@ def evaluate_descendants(node: EasyXmlElement, toc_item):
 	OUTPUTS:
 	toc_item: qualified ToC item
 	"""
-	children = node.xpath("*")
+	children = node.xpath("./h2 | ./h3 | ./h4 | ./h5 | ./h6")
 	for child in children:  # we expect these to be h2, h3, h4 etc
 		if not toc_item.lang:
 			toc_item.lang = child.get_attr("xml:lang")


### PR DESCRIPTION
Alex: this is my attempt to convert print-toc to use xpath throughout. I've run it on at least a few of the projects which have caused us ToC problems in the past and it now seems to work. It would be good if you could try it on a few others, though!

There are some infelicities, such as lines 375 to 384 of se_epub_generate_toc.py. Ideally I would construct a whole new EasyXtree structure, but I couldn't figure out how to do this. Still, it works.

Note that I also had to modify easy_xml.py .