### PR TITLE
Fix missing generated epub-type-x classes

### DIFF
--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -228,13 +228,11 @@ def build(self, run_epubcheck: bool, build_kobo: bool, build_kindle: bool, outpu
 									selector = selector.replace(split_selector[1], "." + replacement_class, 1)
 									sel = se.easy_xml.css_selector(target_element_selector)
 									for element in tree.xpath(sel.path, namespaces=se.XHTML_NAMESPACES):
-										current_class = element.get("class")
-										if current_class is not None and replacement_class not in current_class:
-											current_class = current_class + " " + replacement_class
-										else:
-											current_class = replacement_class
+										current_class = element.get("class", "")
 
-										element.set("class", current_class)
+										if replacement_class not in current_class:
+											current_class = f"{current_class} {replacement_class}".strip()
+											element.set("class", current_class)
 
 						except lxml.cssselect.ExpressionError:
 							# This gets thrown if we use pseudo-elements, which lxml doesn't support


### PR DESCRIPTION
The code that generates classes to bypass spotty pseudoclass support was expecting to always run first, before the code that added generated epub-type classes. For reasons unknown, this is sometimes happening in reverse. When that happens, the code that generates pseudoclass replacements simply overwrites the now-earlier epub-type classes.

While a correct fix would be to structure the code to make it deterministic, we can at least work around it by backporting (and hence normalising) the class-setting logic from the epub-type routine to the pseudoclass routine.

With this applied we still see evidence of the non-determinism, but it’s no longer destructive (for example, we could see both `class="first-child epub-type-z3998-persona"` and `class="epub-type-z3998-persona first-child"`).

Fixes https://github.com/standardebooks/tools/issues/364.