### PR TITLE
Remove workflow dependencies on local bin path

### DIFF
--- a/.github/workflows/se-test.yml
+++ b/.github/workflows/se-test.yml
@@ -15,20 +15,15 @@ jobs:
         python-version: 3.6
     - name: Install Ubuntu packages
       run: |
-        sudo apt update
-        sudo apt install python3-pip python3-dev python3-venv libxml2-utils default-jre calibre git
-    - name: Install pipx
-      run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install --user pipx
-        echo "::add-path::$HOME/.local/bin"
-    - name: Install pipx packages
-      run: |
-        pipx install .
-        pipx inject standardebooks pylint==2.6.0 pytest==6.0.1 mypy==0.782
+        sudo apt-get update
+        sudo apt-get install calibre default-jre git python3-dev python3-pip python3-venv
+    - name: Install test tools
+      run: python3 -m pip install pylint==2.6.0 pytest==6.1.2 mypy==0.790
+    - name: Install se command
+      run: python3 -m pip install .
     - name: Check type annotations with mypy
-      run: $HOME/.local/pipx/venvs/standardebooks/bin/mypy
+      run: mypy
     - name: Check code with pylint
-      run: $HOME/.local/pipx/venvs/standardebooks/bin/pylint tests/*.py se
+      run: pylint tests/*.py se
     - name: Test with pytest
-      run: $HOME/.local/pipx/venvs/standardebooks/bin/pytest
+      run: pytest


### PR DESCRIPTION
GitHub has changed the default PATH for actions. It no longer
includes the ~/.local/bin path. Removed the use of pipx so that
only commands on the system path are used.

Fixes #366.