### PR TITLE
Add pp. as an automatic abbreviation

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -84,7 +84,7 @@ def semanticate(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b(?<!\<abbr\>)([Vv])iz\.", r"<abbr>\1iz.</abbr>", xhtml)
 	xhtml = regex.sub(r"\b(?<!\<abbr\>)etc\.", r"<abbr>etc.</abbr>", xhtml)
 	xhtml = regex.sub(r"\b(?<!\<abbr\>)([Cc])f\.", r"<abbr>\1f.</abbr>", xhtml)
-	xhtml = regex.sub(r"\b(?<!\<abbr\>)p\.([\s0-9])", r"<abbr>p.</abbr>\1", xhtml)
+	xhtml = regex.sub(r"\b(?<!\<abbr\>)p(p?)\.([\s0-9])", r"<abbr>p\1.</abbr>\2", xhtml)
 	xhtml = regex.sub(r"\b(?<!\<abbr\>)ed\.", r"<abbr>ed.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)(Jan\.|Feb\.|Mar\.|Apr\.|Jun\.|Jul\.|Aug\.|Sep\.|Sept\.|Oct\.|Nov\.|Dec\.)", r"<abbr>\1</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!\<abbr\>)No\.(\s+[0-9]+)", r"<abbr>No.</abbr>\1", xhtml)


### PR DESCRIPTION
Used for page ranges: https://en.wikipedia.org/wiki/Acronym#Representing_plurals_and_possessives

I used this patch to fix a couple of books in the corpus: https://github.com/standardebooks/john-bunyan_the-pilgrims-progress/commit/33b88d3ff82ce18518d59d7804e09ef4e13e922a and https://github.com/standardebooks/john-stuart-mill_on-liberty/commit/65b6afa2a7d26cc0035d90be0ac9430ef379c18b.