### PR TITLE
Fix README instructions for macOS Java installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ These instructions were tested on macOS 10.12 to 10.15.
 
 	```shell
 	# Install some pre-flight dependencies.
-	brew install cairo git pipx python
+	brew install cairo git openjdk pipx python
 	pipx ensurepath
+	sudo ln -sfn /usr/local/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
 
 	# Install required applications.
-	brew cask install java calibre
+	brew cask install calibre
 
 	# Install the toolset.
 	pipx install standardebooks


### PR DESCRIPTION
The `java` cask in brew has been removed in favour of the non-cask `java`, which is just a synonym for `openjdk`. This works, but needs to be manually bound to system `java` (command taken from `brew info openjdk`).

Fixes https://github.com/standardebooks/tools/issues/371.