### PR TITLE
Fix dark mode in iOS13+ Books

### DIFF
--- a/se/data/templates/compatibility.css
+++ b/se/data/templates/compatibility.css
@@ -31,15 +31,27 @@ img[epub|type~="se:image.color-depth.black-on-transparent"][epub|type~="z3998:pu
 	background: transparent !important;
 }
 
-/* And except in Apple Books, where we can target night mode specifically */
+/* And except in prefers-color-scheme devices / Apple Books, where we can target dark mode specifically */
+/* Books on iOS 13+ and macOS 10.14 should support the media query, so the theme hack can be dropped when they’re the baseline. */
 :root[__ibooks_internal_theme] img[epub|type~="se:image.color-depth.black-on-transparent"]{
 	background: transparent !important;
 }
 
-/* Enable night mode in Apple Books */
 :root[__ibooks_internal_theme*="Night"] img[epub|type~="se:image.color-depth.black-on-transparent"],
 :root[__ibooks_internal_theme*="Gray"] img[epub|type~="se:image.color-depth.black-on-transparent"]{
 	filter: invert(100%);
+}
+
+@media (prefers-color-scheme){
+	img[epub|type~="se:image.color-depth.black-on-transparent"]{
+		background: transparent !important;
+	}
+}
+
+@media (prefers-color-scheme: dark){
+	img[epub|type~="se:image.color-depth.black-on-transparent"]{
+		filter: invert(100%);
+	}
 }
 
 /* Help preserve poetry formatting after Kobo adds its special <span>s */

--- a/se/data/templates/compatibility.css
+++ b/se/data/templates/compatibility.css
@@ -31,8 +31,9 @@ img[epub|type~="se:image.color-depth.black-on-transparent"][epub|type~="z3998:pu
 	background: transparent !important;
 }
 
-/* And except in prefers-color-scheme devices / Apple Books, where we can target dark mode specifically */
-/* Books on iOS 13+ and macOS 10.14 should support the media query, so the theme hack can be dropped when they’re the baseline. */
+/* And except in Apple Books, where we can target dark mode specifically.
+	Books on iOS 13+ / macOS 10.14+ should support prefers-color-scheme, so the
+	theme hack can be dropped when they’re the baseline. */
 :root[__ibooks_internal_theme] img[epub|type~="se:image.color-depth.black-on-transparent"]{
 	background: transparent !important;
 }
@@ -42,15 +43,11 @@ img[epub|type~="se:image.color-depth.black-on-transparent"][epub|type~="z3998:pu
 	filter: invert(100%);
 }
 
+/* If the device supports prefers-color-scheme we can unset the background color.
+	We’ll invert the image in core.css. */
 @media (prefers-color-scheme){
 	img[epub|type~="se:image.color-depth.black-on-transparent"]{
 		background: transparent !important;
-	}
-}
-
-@media (prefers-color-scheme: dark){
-	img[epub|type~="se:image.color-depth.black-on-transparent"]{
-		filter: invert(100%);
 	}
 }
 

--- a/se/data/templates/core.css
+++ b/se/data/templates/core.css
@@ -117,3 +117,9 @@ a[epub|type~="noteref"]{
 section[epub|type~="endnotes"] > ol > li{
 	margin: 1em 0;
 }
+
+@media (prefers-color-scheme: dark){
+	img[epub|type~="se:image.color-depth.black-on-transparent"]{
+		filter: invert(100%);
+	}
+}

--- a/tests/data/draft/jane-austen_unknown-novel/src/epub/css/core.css
+++ b/tests/data/draft/jane-austen_unknown-novel/src/epub/css/core.css
@@ -117,3 +117,9 @@ a[epub|type~="noteref"]{
 section[epub|type~="endnotes"] > ol > li{
 	margin: 1em 0;
 }
+
+@media (prefers-color-scheme: dark){
+	img[epub|type~="se:image.color-depth.black-on-transparent"]{
+		filter: invert(100%);
+	}
+}


### PR DESCRIPTION
iOS 13+ supports the `prefers-color-scheme` media query, so we can use that to invert images. The old and new versions play nicely together, in my testing on the latest versions at least.

Partially fixes https://github.com/standardebooks/tools/issues/377.