### PR TITLE
Add media to @media rules

### DIFF
--- a/se/data/templates/compatibility.css
+++ b/se/data/templates/compatibility.css
@@ -31,8 +31,8 @@ img[epub|type~="se:image.color-depth.black-on-transparent"][epub|type~="z3998:pu
 	background: transparent !important;
 }
 
-/* Or if the device supports prefers-color-scheme. We’ll invert the image in core.css. */
-@media (prefers-color-scheme){
+/* Or if the device supports prefers-color-scheme. We’ll invert the image in core.css. RMSDK requires a target media as well as a state. */
+@media all and (prefers-color-scheme){
 	img[epub|type~="se:image.color-depth.black-on-transparent"]{
 		background: transparent !important;
 	}

--- a/se/data/templates/core.css
+++ b/se/data/templates/core.css
@@ -122,7 +122,8 @@ section[epub|type~="endnotes"] > ol > li{
 	margin: 1em 0;
 }
 
-@media (prefers-color-scheme: dark){
+/* Invert images in dark mode. RMSDK requires a target media as well as a state. */
+@media all and (prefers-color-scheme: dark){
 	img[epub|type~="se:image.color-depth.black-on-transparent"]{
 		filter: invert(100%);
 	}

--- a/tests/data/draft/jane-austen_unknown-novel/src/epub/css/core.css
+++ b/tests/data/draft/jane-austen_unknown-novel/src/epub/css/core.css
@@ -122,7 +122,8 @@ section[epub|type~="endnotes"] > ol > li{
 	margin: 1em 0;
 }
 
-@media (prefers-color-scheme: dark){
+/* Invert images in dark mode. RMSDK requires a target media as well as a state. */
+@media all and (prefers-color-scheme: dark){
 	img[epub|type~="se:image.color-depth.black-on-transparent"]{
 		filter: invert(100%);
 	}


### PR DESCRIPTION
This isn’t technically needed, but apparently it’s required for older Adobe RMSDK (as per https://www.mobileread.com/forums/showpost.php?p=4074195&postcount=41). Tested on Apple Books with no problem, and it’s valid CSS.