### PR TITLE
Remove outdated references to epub2 from code comments

### DIFF
--- a/se/epub.py
+++ b/se/epub.py
@@ -15,7 +15,7 @@ import se.easy_xml
 
 def convert_toc_to_ncx(epub_root_absolute_path: Path, toc_filename: str, xsl_filename: Path) -> se.easy_xml.EasyXhtmlTree:
 	"""
-	Take an epub3 HTML5 ToC file and convert it to an epub2 NCX file. NCX output is written to the same directory as the ToC file, in a file named "toc.ncx".
+	Take an HTML5 ToC file and convert it to an NCX file for compatibility with older ereaders. NCX output is written to the same directory as the ToC file, in a file named "toc.ncx".
 
 	epub structure must be in the SE format.
 

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -148,7 +148,7 @@ def build(self, run_epubcheck: bool, build_kobo: bool, build_kindle: bool, outpu
 		# Output the pure epub3 file
 		se.epub.write_epub(work_epub_root_directory, output_directory / epub_output_filename)
 
-		# Now add epub2 compatibility.
+		# Now add compatibility fixes for older ereaders.
 
 		# Include compatibility CSS
 		with open(work_epub_root_directory / "epub" / "css" / "core.css", "a", encoding="utf-8") as core_css_file:
@@ -556,7 +556,7 @@ def build(self, run_epubcheck: bool, build_kobo: bool, build_kindle: bool, outpu
 							file.write(processed_css)
 							file.truncate()
 
-		# Output the modified content.opf so that we can build the kobo book before making more epub2 compatibility hacks
+		# Output the modified content.opf so that we can build the kobo book before making more compatibility hacks that aren’t needed on that platform.
 		with open(work_epub_root_directory / "epub" / "content.opf", "w", encoding="utf-8") as file:
 			file.write(metadata_xml)
 			file.truncate()
@@ -627,7 +627,7 @@ def build(self, run_epubcheck: bool, build_kobo: bool, build_kindle: bool, outpu
 
 				se.epub.write_epub(kobo_work_directory, output_directory / kobo_output_filename)
 
-		# Now work on more epub2 compatibility
+		# Now work on more compatibility fixes
 
 		# Recurse over css files to make some compatibility replacements.
 		for root, _, filenames in os.walk(work_epub_root_directory):
@@ -749,7 +749,7 @@ def build(self, run_epubcheck: bool, build_kobo: bool, build_kindle: bool, outpu
 					# We might get here if we ctrl + c before selenium has finished initializing the driver
 					pass
 
-		# Include epub2 cover metadata
+		# Include cover metadata for older ereaders
 		cover_id = self.metadata_dom.xpath("//item[@properties=\"cover-image\"]/@id")[0].replace(".svg", ".jpg")
 		metadata_xml = regex.sub(r"(<metadata[^>]+?>)", f"\\1\n\t\t<meta content=\"{cover_id}\" name=\"cover\" />", metadata_xml)
 
@@ -770,7 +770,7 @@ def build(self, run_epubcheck: bool, build_kobo: bool, build_kindle: bool, outpu
 
 		metadata_xml = regex.sub(r"properties=\"\s*\"", "", metadata_xml)
 
-		# Generate our NCX file for epub2 compatibility.
+		# Generate our NCX file for compatibility with older ereaders.
 		# First find the ToC file.
 		toc_filename = self.metadata_dom.xpath("//item[@properties=\"nav\"]/@href")[0]
 		metadata_xml = metadata_xml.replace("<spine>", "<spine toc=\"ncx\">")
@@ -805,7 +805,7 @@ def build(self, run_epubcheck: bool, build_kobo: bool, build_kindle: bool, outpu
 		metadata_xml = metadata_xml.replace("</package>", "") + guide_xhtml + "</package>"
 
 		# Guide is done, now write content.opf and clean it.
-		# Output the modified content.opf before making more epub2 compatibility hacks.
+		# Output the modified content.opf before making more compatibility hacks.
 		with open(work_epub_root_directory / "epub" / "content.opf", "w", encoding="utf-8") as file:
 			file.write(metadata_xml)
 			file.truncate()


### PR DESCRIPTION
I’ve left epub2 references in the kindle vendored code intact.