### PR TITLE
Fix prologue being added to spine twice

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -791,7 +791,7 @@ class SeEpub:
 		An XML fragment string representing the spine.
 		"""
 
-		excluded_files = se.IGNORED_FILENAMES + ["dedication.xhtml", "introduction.xhtml", "foreword.xhtml", "preface.xhtml", "epigraph.xhtml", "afterword.xhtml", "endnotes.xhtml"]
+		excluded_files = se.IGNORED_FILENAMES + ["dedication.xhtml", "introduction.xhtml", "foreword.xhtml", "preface.xhtml", "epigraph.xhtml", "prologue.xhtml", "afterword.xhtml", "endnotes.xhtml"]
 		spine = ["<itemref idref=\"titlepage.xhtml\"/>", "<itemref idref=\"imprint.xhtml\"/>"]
 
 		filenames = natsorted(os.listdir(self.path / "src" / "epub" / "text"))


### PR DESCRIPTION
My prologues have been getting added twice to the spine, once where they should be and once towards the end, and I finally had time to investigate. It wasn't in the excluded files, so it was processed once explicitly and once implicitly in the list of filenames.