### PR TITLE
Update chapter template and split-file command to use roman numerals …

### DIFF
--- a/se/commands/split_file.py
+++ b/se/commands/split_file.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import importlib_resources
 import regex
+import roman
 
 import se
 
@@ -20,7 +21,7 @@ def _split_file_output_file(filename_format_string: str, chapter_number: int, te
 	filename = filename_format_string.replace("%n", str(chapter_number))
 
 	xhtml = template_xhtml.replace("ID", regex.sub(r"\.xhtml$", "", filename))
-	xhtml = xhtml.replace("NUMBER", str(chapter_number))
+	xhtml = xhtml.replace("NUMERAL", str(roman.toRoman(chapter_number)))
 	xhtml = xhtml.replace("TEXT", chapter_xhtml)
 
 	with open(filename, "w", encoding="utf-8") as file:
@@ -35,7 +36,7 @@ def split_file() -> int:
 	parser = argparse.ArgumentParser(description="Split an XHTML file into many files at all instances of <!--se:split-->, and include a header template for each file.")
 	parser.add_argument("-f", "--filename-format", metavar="STRING", type=str, default="chapter-%n.xhtml", help="a format string for the output files; `%%n` is replaced with the current chapter number; defaults to `chapter-%%n.xhtml`")
 	parser.add_argument("-s", "--start-at", metavar="INTEGER", type=se.is_positive_integer, default="1", help="start numbering chapters at this number, instead of at 1")
-	parser.add_argument("-t", "--template-file", metavar="FILE", type=str, default="", help="a file containing an XHTML template to use for each chapter; the string `NUMBER` is replaced by the chapter number, and the string `TEXT` is replaced by the chapter body")
+	parser.add_argument("-t", "--template-file", metavar="FILE", type=str, default="", help="a file containing an XHTML template to use for each chapter; the string `NUMERAL` is replaced by the chapter numeral, and the string `TEXT` is replaced by the chapter body")
 	parser.add_argument("filename", metavar="FILE", help="an HTML/XHTML file")
 	args = parser.parse_args()
 

--- a/se/completions/fish/se.fish
+++ b/se/completions/fish/se.fish
@@ -137,7 +137,7 @@ complete -c se -n "__fish_se_no_subcommand" -a split-file -d "Split an XHTML fil
 complete -c se -A -n "__fish_seen_subcommand_from split-file" -s f -l filename-format -d "a format string for the output files; `%n` is replaced with the current chapter number; defaults to `chapter-%n.xhtml`"
 complete -c se -A -n "__fish_seen_subcommand_from split-file" -s h -l help -x -d "show this help message and exit"
 complete -c se -A -n "__fish_seen_subcommand_from split-file" -s s -l start-at -d "start numbering chapters at this number, instead of at 1"
-complete -c se -A -n "__fish_seen_subcommand_from split-file" -s t -l template-file -d "a file containing an XHTML template to use for each chapter; the string `NUMBER` is replaced by the chapter number, and the string `TEXT` is replaced by the chapter body"
+complete -c se -A -n "__fish_seen_subcommand_from split-file" -s t -l template-file -d "a file containing an XHTML template to use for each chapter; the string `NUMERAL` is replaced by the chapter numeral, and the string `TEXT` is replaced by the chapter body"
 
 complete -c se -n "__fish_se_no_subcommand" -a titlecase -d "Convert a string to titlecase."
 complete -c se -A -n "__fish_seen_subcommand_from titlecase" -s h -l help -x -d "show this help message and exit"

--- a/se/completions/zsh/_se
+++ b/se/completions/zsh/_se
@@ -218,7 +218,7 @@ case $state in
 					{-f,--filename-format}'[a format string for the output files; `%n` is replaced with the current chapter number; defaults to `chapter-%n.xhtml`]' \
 					{-h,--help}'[show a help message and exit]' \
 					{-s,--start-at}'[start numbering chapters at this number, instead of at 1]' \
-					{-t,--template-file}'[a file containing an XHTML template to use for each chapter; the string `NUMBER` is replaced by the chapter number, and the string `TEXT` is replaced by the chapter body]' \
+					{-t,--template-file}'[a file containing an XHTML template to use for each chapter; the string `NUMERAL` is replaced by the chapter numeral, and the string `TEXT` is replaced by the chapter body]' \
 					'*: :_files -g \*.\(htm\|html\|xhtml\)'
 				;;
 			titlecase)

--- a/se/data/templates/chapter-template.xhtml
+++ b/se/data/templates/chapter-template.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-US">
 	<head>
-		<title>Chapter NUMBER</title>
+		<title>NUMERAL</title>
 		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
 	</head>


### PR DESCRIPTION
…instead of arabic numerals.

I don't see a good reason to keep the pre-1.6.0 titles in the templates so I just updated them as well as the `split-file` command to substitute everything correctly. I know `print-title` fixes it to the new standard so it's not necessary but, unless I'm missing something, we might as well keep the templates up to date.

I also changed all of the usage statements and template to say `NUMERAL` instead of `NUMBER`. I realize arabic numerals are also a thing but I think `NUMERAL` suggests that it's roman. If you don't think that's necessary I can revert it. Or even make it `ROMAN_NUMERAL` or something.