### PR TITLE
Improve LCSH ID query

### DIFF
--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -883,7 +883,7 @@ def _create_draft(args: Namespace):
 
 					# Now, get the LCSH ID by querying LCSH directly.
 					try:
-						response = requests.get(f"https://id.loc.gov/search/?q=%22{urllib.parse.quote(subject)}%22")
+						response = requests.get(f"https://id.loc.gov/search/?q=cs:http://id.loc.gov/authorities/subjects&q=%22{urllib.parse.quote(subject)}%22")
 						result = regex.search(fr"<a title=\"Click to view record\" href=\"/authorities/subjects/([^\"]+?)\">{regex.escape(subject.replace(' -- ', '--'))}</a>", response.text)
 
 						loc_id = "Unknown"

--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -883,7 +883,7 @@ def _create_draft(args: Namespace):
 
 					# Now, get the LCSH ID by querying LCSH directly.
 					try:
-						response = requests.get(f"https://id.loc.gov/search/?q=cs:http://id.loc.gov/authorities/subjects&q=%22{urllib.parse.quote(subject)}%22")
+						response = requests.get(f"https://id.loc.gov/search/?q=cs:http://id.loc.gov/authorities/subjects&q=\"{urllib.parse.quote(subject)}\"")
 						result = regex.search(fr"<a title=\"Click to view record\" href=\"/authorities/subjects/([^\"]+?)\">{regex.escape(subject.replace(' -- ', '--'))}</a>", response.text)
 
 						loc_id = "Unknown"


### PR DESCRIPTION
I've noticed that the tools are pretty bad at getting the LCSH IDs and a whole lot of them are `Unknown`. Turns out that it's a really simple fix. It was just that the previous query didn't specify that we wanted Subject Headings and searched through all the other schemes. And since we only looked at the first page of the results a bunch were lost.

Just one example, https://github.com/standardebooks/anne-bronte_the-tenant-of-wildfell-hall/blob/master/src/epub/content.opf#L32 It has all of them as `Unknown` even though 5 of the 6 should actually be known (and would be found with the new request query).

I'm not sure what the rules are regarding url encodings so I just left it unencoded and it works. If we have some code style rules I can of course encode them but it looks like `requests.get` does it automatically.

I imagine we would want to run this on the whole corpus at some point to update everything?