### PR TITLE
Allow nested at-rules for lint 

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -417,7 +417,7 @@ def _get_selectors_and_rules (self) -> tuple:
 		rules: A CSSStyleSheet with the rules
 		local_css_rules: A dictionary where key = selector and value = rules
 		duplicate_selectors: Selectors which are counted as duplicates and will be warned about
-		single_selectors: Selectors which aren't duplicates
+		single_selectors: Not multiple selectors separated by comma
 		top_level: Boolean set to True on first level of recursion and False thereafter
 
 		OUTPUTS
@@ -467,7 +467,7 @@ def _get_selectors_and_rules (self) -> tuple:
 	# Initial recursive call
 	_recursive_helper(all_rules, local_css_rules, duplicate_selectors, single_selectors, True)
 
-	return (local_css_rules, duplicate_selectors, single_selectors)
+	return (local_css_rules, duplicate_selectors)
 
 # Cache file contents so we don't hit the disk repeatedly
 _FILE_CACHE: Dict[str, str] = {}
@@ -615,11 +615,7 @@ def lint(self, skip_lint_ignore: bool) -> list:
 	cssutils.log.enabled = False
 
 	# Get the css rules and selectors from helper function
-	local_css_rules, duplicate_selectors, single_selectors = _get_selectors_and_rules(self)
-
-	print(local_css_rules)
-	print(duplicate_selectors)
-	print(single_selectors)
+	local_css_rules, duplicate_selectors = _get_selectors_and_rules(self)
 
 	if duplicate_selectors:
 		messages.append(LintMessage("c-009", "Duplicate CSS selectors. Duplicates are only acceptable if overriding SE base styles.", se.MESSAGE_TYPE_WARNING, local_css_path, list(set(duplicate_selectors))))

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -450,10 +450,7 @@ def _get_selectors_and_rules (self) -> tuple:
 					if selector.selectorText not in local_css_rules:
 						local_css_rules[selector.selectorText] = ""
 
-					if top_level:
-						local_css_rules[selector.selectorText] = rule.style.cssText + ";"
-					else:
-						local_css_rules[selector.selectorText] += rule.style.cssText + ";"
+					local_css_rules[selector.selectorText] += rule.style.cssText + ";"
 
 		return (local_css_rules, duplicate_selectors)
 

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -403,38 +403,69 @@ def _get_selectors_and_rules (self) -> tuple:
 	None
 
 	OUTPUTS
-	3-tuple (local_css_rules, duplicate_selectors, single_selectors)
+	3-tuple (local_css_rules, duplicate_selectors, single_selectors) to be used by the lint function
 	"""
+
+	def _recursive_helper(rules: cssutils.css.cssstylesheet.CSSStyleSheet, local_css_rules: dict, duplicate_selectors: list, single_selectors: list, top_level: bool):
+		"""
+		Because of the possibilty of nested @supports and @media at-rules, we
+		need to use recursion to get to rules and selectors within at-rules.
+		This function is the helper for _get_selectors_and_rules and does the
+		actual work.
+
+		INPUTS
+		rules: A CSSStyleSheet with the rules
+		local_css_rules: A dictionary where key = selector and value = rules
+		duplicate_selectors: Selectors which are counted as duplicates and will be warned about
+		single_selectors: Selectors which aren't duplicates
+		top_level: Boolean set to True on first level of recursion and False thereafter
+
+		OUTPUTS
+		3-tuple (local_css_rules, duplicate_selectors, single_selectors) to be used by the lint function
+		"""
+		for rule in rules:
+			# i.e. @supports or @media
+			if isinstance(rule, cssutils.css.CSSMediaRule):
+				# Recurisive call to rules within CSSMediaRule.
+				new_rules = _recursive_helper(rule.cssRules, local_css_rules, duplicate_selectors, single_selectors, False)
+
+				# Then update local_css_rules. The duplicate and single selector lists aren't updated 
+				# because anything within CSSMediaRules isn't counted as a duplicate
+				local_css_rules.update(new_rules[0])
+
+			# Recursive end condition
+			if isinstance(rule, cssutils.css.CSSStyleRule):
+				for selector in rule.selectorList:
+					# Check for duplicate selectors.
+					# We consider a selector a duplicate if it's a TOP LEVEL selector (i.e. we don't check within @supports)
+					# and ALSO if it is a SINGLE selector (i.e. not multiple selectors separated by ,)
+					# For example abbr{} abbr{} would be a duplicate, but not abbr{} abbr,p{}
+					if "," not in rule.selectorText:
+						if top_level:
+							if selector.selectorText in single_selectors:
+								duplicate_selectors.append(selector.selectorText)
+							else:
+								single_selectors.append(selector.selectorText)
+
+					if selector.selectorText not in local_css_rules:
+						local_css_rules[selector.selectorText] = ""
+
+					if top_level:
+						local_css_rules[selector.selectorText] = rule.style.cssText + ";"
+					else:
+						local_css_rules[selector.selectorText] += rule.style.cssText + ";"
+
+		return (local_css_rules, duplicate_selectors, single_selectors)
 
 	local_css_rules: Dict[str, str] = {} # A dict where key = selector and value = rules
 	duplicate_selectors = []
 	single_selectors: List[str] = []
 
 	# cssutils doesn't understand @supports, but it *does* understand @media, so do a replacement here for the purposes of parsing
-	for rule in cssutils.parseString(self.local_css.replace("@supports", "@media"), validate=False):
-		# i.e. @supports
-		if isinstance(rule, cssutils.css.CSSMediaRule):
-			for supports_rule in rule.cssRules:
-				for selector in supports_rule.selectorList:
-					if selector.selectorText not in local_css_rules:
-						local_css_rules[selector.selectorText] = ""
+	all_rules = cssutils.parseString(self.local_css.replace("@supports", "@media"), validate=False)
 
-					local_css_rules[selector.selectorText] += supports_rule.style.cssText + ";"
-
-		# top-level rule
-		if isinstance(rule, cssutils.css.CSSStyleRule):
-			for selector in rule.selectorList:
-				# Check for duplicate selectors.
-				# We consider a selector a duplicate if it's a TOP LEVEL selector (i.e. we don't check within @supports)
-				# and ALSO if it is a SINGLE selector (i.e. not multiple selectors separated by ,)
-				# For example abbr{} abbr{} would be a duplicate, but not abbr{} abbr,p{}
-				if "," not in rule.selectorText:
-					if selector.selectorText in single_selectors:
-						duplicate_selectors.append(selector.selectorText)
-					else:
-						single_selectors.append(selector.selectorText)
-
-				local_css_rules[selector.selectorText] = rule.style.cssText + ";"
+	# Initial recursive call
+	_recursive_helper(all_rules, local_css_rules, duplicate_selectors, single_selectors, True)
 
 	return (local_css_rules, duplicate_selectors, single_selectors)
 

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -403,7 +403,7 @@ def _get_selectors_and_rules (self) -> tuple:
 	None
 
 	OUTPUTS
-	3-tuple (local_css_rules, duplicate_selectors, single_selectors) to be used by the lint function
+	2-tuple (local_css_rules, duplicate_selectors) to be used by the lint function
 	"""
 
 	def _recursive_helper(rules: cssutils.css.cssstylesheet.CSSStyleSheet, local_css_rules: dict, duplicate_selectors: list, single_selectors: list, top_level: bool):
@@ -421,7 +421,7 @@ def _get_selectors_and_rules (self) -> tuple:
 		top_level: Boolean set to True on first level of recursion and False thereafter
 
 		OUTPUTS
-		3-tuple (local_css_rules, duplicate_selectors, single_selectors) to be used by the lint function
+		2-tuple (local_css_rules, duplicate_selectors) to be used by the lint function
 		"""
 		for rule in rules:
 			# i.e. @supports or @media
@@ -429,7 +429,7 @@ def _get_selectors_and_rules (self) -> tuple:
 				# Recurisive call to rules within CSSMediaRule.
 				new_rules = _recursive_helper(rule.cssRules, local_css_rules, duplicate_selectors, single_selectors, False)
 
-				# Then update local_css_rules. The duplicate and single selector lists aren't updated 
+				# Then update local_css_rules. The duplicate and single selector lists aren't updated
 				# because anything within CSSMediaRules isn't counted as a duplicate
 				local_css_rules.update(new_rules[0])
 
@@ -455,7 +455,7 @@ def _get_selectors_and_rules (self) -> tuple:
 					else:
 						local_css_rules[selector.selectorText] += rule.style.cssText + ";"
 
-		return (local_css_rules, duplicate_selectors, single_selectors)
+		return (local_css_rules, duplicate_selectors)
 
 	local_css_rules: Dict[str, str] = {} # A dict where key = selector and value = rules
 	duplicate_selectors = []
@@ -616,6 +616,10 @@ def lint(self, skip_lint_ignore: bool) -> list:
 
 	# Get the css rules and selectors from helper function
 	local_css_rules, duplicate_selectors, single_selectors = _get_selectors_and_rules(self)
+
+	print(local_css_rules)
+	print(duplicate_selectors)
+	print(single_selectors)
 
 	if duplicate_selectors:
 		messages.append(LintMessage("c-009", "Duplicate CSS selectors. Duplicates are only acceptable if overriding SE base styles.", se.MESSAGE_TYPE_WARNING, local_css_path, list(set(duplicate_selectors))))


### PR DESCRIPTION
In advance, sorry for the long explanation but I found a couple of issues that need a bit of explaining:

While working on Roughing It I came across a bug in the lint function: it would crash with nested at-rules because of the assumption that anything nested within an at-rule would be a selector. And just a clarification since some websites call a single @supports a nested at-rule: by nested at-rules I mean something like an @supports within an @media.

Nested at-rules are allowed according to the spec (https://www.w3.org/TR/css-conditional-3/#contents-of One example/more explanation can be found here https://www.w3.org/TR/css-conditional-3/#processing).

This code fixes that bug by recursion so technically it should work for any number of nested at-rules (tested up to three). I tested it on 200 ebooks and the `local_css_rules`, `duplicate_selectors`, and `single_selectors` variables were all kept the same with the new code so it looks like it works well. On a side note, it looks like we never use the `single_selectors` variable. If you don't think we need it, this would be a good time to get rid of it.

In terms of the code I'm no python expert so I don't know if there's any naming conventions for the recursive helper function I made. I can of course rename it if some convention exists. And feel free to change any of the comments I made but I tried my best to make them helpful.

....................................................................

And while fixing this bug I came across what I think is another bug. If you have more than one of the same top-level selector, the second will override the first value in the `local_css_rules` dictionary. Best explained by an example from https://github.com/standardebooks/maurice-leblanc_the-hollow-needle_alexander-teixeira-de-mattos/blob/master/src/epub/css/local.css:

```css
[epub|type~="z3998:postscript"]{
	margin-top: 1em;
}

[epub|type~="z3998:postscript"],
[epub|type~="z3998:recipient"] + p{
	text-indent: 0;
}
```
The `local_css_rules` dictionary after running lint here will have this as an entry `'[epub|type~="z3998:postscript"]': 'text-indent: 0;'` instead of `'[epub|type~="z3998:postscript"]': 'margin-top: 1em;text-indent: 0;'`

The only time I can really see this mattering is here:
```python
if "abbr" in selector and "nowrap" in rules:
	abbr_with_whitespace.append(selector)
```

So for a contrived worst case scenario you can imagine some css like this:
```css
#chapter-1 abbr,
#chapter-1 div{
	white-space: nowrap;
}
#chapter-1 abbr{
	background: blue;
}
```

The `local_css_rules` will contain this entry `'#chapter-1 abbr': 'background: blue;'` when it should really contain `'#chapter-1 abbr': 'white-space: nowrap;background: blue;'` and so lint wouldn't complain even though it should.

For now, I've made the new code have this same "bug" intentionally because I don't want to unintentionally break something if there's a reason for overwriting the dictionary entry. Fixing this bug would just mean replacing
```python
if top_level:
	local_css_rules[selector.selectorText] = rule.style.cssText + ";"
else:
	local_css_rules[selector.selectorText] += rule.style.cssText + ";"
```
in the new code with
```python
local_css_rules[selector.selectorText] += rule.style.cssText + ";"
```
So I can fix this very easily if you also agree that it's not the desired behavior.