### PR TITLE
Add exception msg on file open/parse error

### DIFF
--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -649,7 +649,7 @@ def process_all_content(file_list: list, text_path: str) -> Tuple[list, list]:
 			with open(file_path) as file:
 				dom = se.easy_xml.EasyXhtmlTree(file.read())
 		except Exception as ex:
-			raise se.InvalidFileException(f"Couldn’t open file: [path][link=file://{file_path}]{file_path}[/][/]. {ex}") from ex
+			raise se.InvalidFileException(f"Couldn’t open file: [path][link=file://{file_path}]{file_path}[/][/]. Exception: {ex}") from ex
 
 		add_landmark(dom, textf, landmarks)
 

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -649,7 +649,7 @@ def process_all_content(file_list: list, text_path: str) -> Tuple[list, list]:
 			with open(file_path) as file:
 				dom = se.easy_xml.EasyXhtmlTree(file.read())
 		except Exception as ex:
-			raise se.InvalidFileException(f"Couldn’t open file: [path][link=file://{file_path}]{file_path}[/][/].") from ex
+			raise se.InvalidFileException(f"Couldn’t open file: [path][link=file://{file_path}]{file_path}[/][/]. {ex}") from ex
 
 		add_landmark(dom, textf, landmarks)
 


### PR DESCRIPTION
The change you made last night to move things around "magically" fixed `recompose-epub`; it now shows both the filename and the exception.

However, `print-toc` still only shows the filename. This is, I think, due to the `try` including both the `with open` and the `EasyHtmlTree` statements in `process_all_content`. A second try/except for the latter would work, but I just added `{ex}` to the existing message. I thought even if there was an error opening the file (as opposed to parsing it), it would be helpful to know what the actual error was, plus it keeps the code cleaner.