### PR TITLE
Bash completion instructions for Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ These instructions were tested on macOS 10.12 to 10.16, on Intel macs.
 
 	# Install the toolset.
 	pipx install standardebooks
+	
+	# Optional: Bash users who have set up bash-completion via brew can install tab completion.
+	ln -s $HOME/.local/pipx/venvs/standardebooks/lib/python3.*/site-packages/se/completions/bash/se $(brew --prefix)/etc/bash_completion.d/se
 
 	# Optional: Fish users can install tab completion.
 	ln -s $HOME/.local/pipx/venvs/standardebooks/lib/python3.*/site-packages/se/completions/fish/se $HOME/.config/fish/completions/se.fish


### PR DESCRIPTION
Since the instructions already reference `brew` for installing pre-requisites, and the kind of person who wants to install se bash completion is likely to already have installed brew bash-completions, this line should get them working. And the comment line provides a hint as to where to go looking for more info if bash completions are a new thing to them.

I don't use zsh myself but I think a very similar line would work for them.