### PR TITLE
Add additional Muhammad corrections

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -335,6 +335,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\bLaocoon", r"Laocoön", xhtml)				# Lacoon -> Laocoön
 	xhtml = regex.sub(r"Porto Rico", "Puerto Rico", xhtml)				# Porto Rico -> Puerto Rico
 	xhtml = regex.sub(r"Mahomet", "Muhammad", xhtml)				# Mahomet -> Muhammad
+	xhtml = regex.sub(r"M[ao]hommed", "Muhammad", xhtml)		        	# Mahommed -> Muhammad
 	xhtml = regex.sub(r"Esthonian", "Estonian", xhtml)				# Esthonian -> Estonian
 
 	# Remove archaic diphthongs


### PR DESCRIPTION
Gibbon has both of these as well as Mahomet.

Also, he uses Mussulman, Mussulmans, and Mullulmen, as well as Moslem(s?). Do we want to add those? If so I'll do another PR.

Wiki has museumann (two n's) as being a term for Nazi concentration camp prisoners, so I might search for Mussulman\b just in case.