### PR TITLE
use posix path for xslt transform

### DIFF
--- a/se/epub.py
+++ b/se/epub.py
@@ -34,8 +34,7 @@ def convert_toc_to_ncx(epub_root_absolute_path: Path, toc_filename: str, xsl_fil
 
 	toc_tree = se.easy_xml.EasyXhtmlTree(xhtml)
 	transform = etree.XSLT(etree.parse(str(xsl_filename)))
-	posix_path = Path(epub_root_absolute_path ).as_posix() 
-	ncx_tree = transform(etree.fromstring(str.encode(xhtml)), cwd=f"'{posix_path}/'")
+	ncx_tree = transform(etree.fromstring(str.encode(xhtml)), cwd=f"'{epub_root_absolute_path.as_posix()}/'")
 
 	with open(epub_root_absolute_path / "epub" / "toc.ncx", "w", encoding="utf-8") as file:
 		ncx_xhtml = etree.tostring(ncx_tree, encoding="unicode", pretty_print=True, with_tail=False)

--- a/se/epub.py
+++ b/se/epub.py
@@ -34,7 +34,8 @@ def convert_toc_to_ncx(epub_root_absolute_path: Path, toc_filename: str, xsl_fil
 
 	toc_tree = se.easy_xml.EasyXhtmlTree(xhtml)
 	transform = etree.XSLT(etree.parse(str(xsl_filename)))
-	ncx_tree = transform(etree.fromstring(str.encode(xhtml)), cwd=f"'{epub_root_absolute_path}{os.path.sep}'")
+	posix_path = Path(epub_root_absolute_path ).as_posix() 
+	ncx_tree = transform(etree.fromstring(str.encode(xhtml)), cwd=f"'{posix_path}/'")
 
 	with open(epub_root_absolute_path / "epub" / "toc.ncx", "w", encoding="utf-8") as file:
 		ncx_xhtml = etree.tostring(ncx_tree, encoding="unicode", pretty_print=True, with_tail=False)


### PR DESCRIPTION
Changed this to do the posix path transform only for the cwd parameter in the python script instead of the xlst transform file.

I do not have a unix / mac to test this on to be sure it doesn't break the xlst processor there, but it does work on windows and the toc.ncx file is correctly generated.