### PR TITLE
bump psutil to 5.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
 		"lxml==4.6.2",
 		"natsort==7.1.0",
 		"pillow==8.1.1",
-		"psutil==5.7.3",
+		"psutil==5.8.0",
 		"pyopenssl==20.0.0",  # Required to allow the `requests` package to use https on Mac OSX
 		"pyphen==0.10.0",
 		"regex==2020.11.13",


### PR DESCRIPTION
Doing this would allow the toolkit to install on windows without also needing *6*GB of C++ compiler/header/sdk files to be installed, since psutil 5.8.0 has wheels for windows machines, and it appears they are going to continue supporting the wheels packages. 

https://github.com/giampaolo/psutil/blob/master/INSTALL.rst