### PR TITLE
Improve url generation

### DIFF
--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -5,7 +5,6 @@ This module implements the `se create_draft` command.
 import argparse
 from io import StringIO
 import shutil
-import unicodedata
 import urllib.parse
 from argparse import Namespace
 from pathlib import Path

--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -18,6 +18,7 @@ import requests
 from rich.console import Console
 from ftfy import fix_text
 from lxml import etree
+from unidecode import unidecode
 
 import se
 import se.formatting
@@ -98,7 +99,7 @@ def _get_word_widths(string: str, target_height: int) -> list:
 
 		for char in word:
 			# Convert accented characters to unaccented characters
-			char = regex.sub(r"\p{M}", "", unicodedata.normalize("NFKD", char))
+			char = unidecode(char)
 			width += int(LEAGUE_SPARTAN_100_WIDTHS[char] * target_height / 100) + LEAGUE_SPARTAN_KERNING + LEAGUE_SPARTAN_AVERAGE_SPACING
 
 		width = width - LEAGUE_SPARTAN_KERNING - LEAGUE_SPARTAN_AVERAGE_SPACING

--- a/se/formatting.py
+++ b/se/formatting.py
@@ -16,9 +16,10 @@ import roman
 import tinycss2
 from lxml import etree
 from titlecase import titlecase as pip_titlecase
-from se.easy_xml import EasyXhtmlTree
+from unidecode import unidecode
 
 import se
+from se.easy_xml import EasyXhtmlTree
 
 
 # This list of phrasing tags is not intended to be exhaustive. The list is only used
@@ -1147,7 +1148,7 @@ def make_url_safe(text: str) -> str:
 	"""
 
 	# 1. Convert accented characters to unaccented characters
-	text = regex.sub(r"\p{M}", "", unicodedata.normalize("NFKD", text))
+	text = unidecode(text)
 
 	# 2. Trim
 	text = text.strip()

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,8 @@ setup(
 		"selenium==3.141.0",
 		"smartypants==2.0.1",
 		"tinycss2==1.1.0",
-		"titlecase==0.13.0"
+		"titlecase==0.13.0",
+		"Unidecode==1.2.0"
 	],
 	include_package_data=True,
 	entry_points={


### PR DESCRIPTION
The existing solution transposed characters like ö to o, but failed on characters like ø. We can instead use the Unidecode library, which covers automatically everything we’d want to theoretically do.

This adjusts create-draft and formatting to use the new library. It doesn’t change find-mismatched-diacritics, as identifying what a “diacritic” is here is a harder problem.

Any performance hit is in the noise in the tests that I ran. Fixes https://github.com/standardebooks/tools/issues/416.