### PR TITLE
Prevented double counting of endnotes within endnotes

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -1134,6 +1134,8 @@ class SeEpub:
 		change_list: List[str] = []
 
 		for file_path in self.spine_file_paths:
+			if file_path.name == "endnotes.xhtml": #don't want to process this file here
+				continue
 			dom = self.get_dom(file_path)
 
 			processed += 1


### PR DESCRIPTION
We were processing endnotes.xhtml as though it was another contents file, so I've bypassed that.

This should fix the double-counting which Emma reported.