### PR TITLE
Add a lint check for glossary entries missing from the text

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -2445,7 +2445,7 @@ def lint(self, skip_lint_ignore: bool) -> list:
 					messages.append(LintMessage("s-037", "No [val]backmatter[/] semantic inflection for what looks like a backmatter file.", se.MESSAGE_TYPE_WARNING, filename))
 
 				# Check and log missing glossary keys
-				if has_glossary_search_key_map:
+				if has_glossary_search_key_map and filename.name != "glossary.xhtml" and filename.name not in IGNORED_FILENAMES:
 					for glossary_index, glossary_value in enumerate(glossary_usage):
 						if glossary_value[1] is False and regex.search(glossary_value[0], file_contents, flags=regex.IGNORECASE):
 							glossary_usage[glossary_index] = (glossary_value[0], True)

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -1149,7 +1149,7 @@ def lint(self, skip_lint_ignore: bool) -> list:
 							if text_file.suffix == ".xhtml":
 								text = self.get_file(text_file)
 								for glossary_index, glossary_value in enumerate(glossary_usage):
-									if glossary_value[1] is False and glossary_value[0] in text:
+									if glossary_value[1] is False and regex.search(glossary_value[0], text, flags=regex.IGNORECASE):
 										glossary_usage[glossary_index] = (glossary_value[0], True)
 					# Finally, log any entries that don’t exist in the text
 					entries = []

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -1143,7 +1143,7 @@ def lint(self, skip_lint_ignore: bool) -> list:
 					# Map the glossary to tuples of the values and whether they’re used (initially false)
 					glossary_usage = list(map(lambda node: (node.get_attr("value"), False), xml_dom.xpath(".//*[@value]")))
 					# Walk the tree and mark if any of the glossary entries are used
-					for text_root, _, text_filenames in os.walk(os.path.join(self.path, "src", "epub", "text")):
+					for text_root, _, text_filenames in os.walk(Path(self.path / "src/epub/text")):
 						for text_filename in text_filenames:
 							text_file = (Path(text_root) / text_filename).resolve()
 							if text_file.suffix == ".xhtml":

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -164,7 +164,7 @@ METADATA
 "m-067", "Non-SE link in long description."
 "m-068", "[xml]<dc:title>[/] missing matching [xml]<meta property=\"title-type\">[/]."
 "m-069", "[text]comprised of[/] in metadata. Hint: Is there a better phrase to use here?"
-"m-070", f"Glossary entries not present in the text: [text]{entries_text}[/]."
+"m-070", "Glossary entries not present in the text:"
 
 SEMANTICS & CONTENT
 "s-001", "Illegal numeric entity (like [xhtml]&#913;[/])."
@@ -1156,8 +1156,7 @@ def lint(self, skip_lint_ignore: bool) -> list:
 					for glossary_value in glossary_usage:
 						if glossary_value[1] is False:
 							entries.append(glossary_value[0])
-					entries_text = ", ".join(entries)
-					messages.append(LintMessage("m-070", f"Glossary entries not present in the text: [text]{entries_text}[/]", se.MESSAGE_TYPE_ERROR, filename))
+					messages.append(LintMessage("m-070", "Glossary entries not present in the text:", se.MESSAGE_TYPE_ERROR, filename, entries))
 
 			if filename.suffix == ".xhtml":
 				# Read file contents into a DOM for querying

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -2616,7 +2616,8 @@ def lint(self, skip_lint_ignore: bool) -> list:
 		for glossary_value in glossary_usage:
 			if glossary_value[1] is False:
 				entries.append(glossary_value[0])
-		messages.append(LintMessage("m-070", "Glossary entries not present in the text:", se.MESSAGE_TYPE_ERROR, Path("src/epub/glossary-search-key-map.xml"), entries))
+		if len(entries) > 0:
+			messages.append(LintMessage("m-070", "Glossary entries not present in the text:", se.MESSAGE_TYPE_ERROR, Path("src/epub/glossary-search-key-map.xml"), entries))
 
 	# Now that we have our lint messages, we filter out ones that we've ignored.
 	if ignored_codes:

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -1143,8 +1143,7 @@ def lint(self, skip_lint_ignore: bool) -> list:
 					# Map the glossary to tuples of the values and whether they’re used (initially false)
 					glossary_usage = list(map(lambda node: (node.get_attr("value"), False), xml_dom.xpath(".//*[@value]")))
 					# Walk the tree and mark if any of the glossary entries are used
-					for text_root, text_directories, text_filenames in os.walk(os.path.join(self.path, "src", "epub", "text")):
-						del text_directories
+					for text_root, _, text_filenames in os.walk(os.path.join(self.path, "src", "epub", "text")):
 						for text_filename in text_filenames:
 							text_file = (Path(text_root) / text_filename).resolve()
 							if text_file.suffix == ".xhtml":

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -164,7 +164,7 @@ METADATA
 "m-067", "Non-SE link in long description."
 "m-068", "[xml]<dc:title>[/] missing matching [xml]<meta property=\"title-type\">[/]."
 "m-069", "[text]comprised of[/] in metadata. Hint: Is there a better phrase to use here?"
-"m-070", f"Glossary entry [text]{entry}[/] not present in the text."
+"m-070", f"Glossary entries not present in the text: [text]{entries_text}[/]."
 
 SEMANTICS & CONTENT
 "s-001", "Illegal numeric entity (like [xhtml]&#913;[/])."
@@ -1153,9 +1153,12 @@ def lint(self, skip_lint_ignore: bool) -> list:
 									if glossary_value[1] is False and glossary_value[0] in text:
 										glossary_usage[glossary_index] = (glossary_value[0], True)
 					# Finally, log any entries that don’t exist in the text
+					entries = []
 					for glossary_value in glossary_usage:
 						if glossary_value[1] is False:
-							messages.append(LintMessage("m-070", f"Glossary entry [text]{glossary_value[0]}[/] not present in the text.", se.MESSAGE_TYPE_ERROR, filename))
+							entries.append(glossary_value[0])
+					entries_text = ", ".join(entries)
+					messages.append(LintMessage("m-070", f"Glossary entries not present in the text: [text]{entries_text}[/]", se.MESSAGE_TYPE_ERROR, filename))
 
 			if filename.suffix == ".xhtml":
 				# Read file contents into a DOM for querying


### PR DESCRIPTION
If a glossary is found, we first log all the glossary values, then walk through the text checking for usage. Any unused values can be added to the error messages.

There are a bunch of errors in _Hudibras’_ glossary xml that I’ll fix. I also tested it on _The Worst Journey_ and found that `strong breeze` was missing, so I’ll sweep all glossary files and fix them if you’re happy with this approach.