### PR TITLE
Removed loading of existing note-ids, may not be integers and not needed

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -42,6 +42,7 @@ class Endnote:
 	def __init__(self):
 		self.node = None
 		self.number = 0
+		self.id = ""
 		self.anchor = ""
 		self.contents = []  # The strings and tags inside an <li> element
 		self.back_link = ""
@@ -303,7 +304,7 @@ class SeEpub:
 			for node in dom.xpath("/html/body/section[contains(@epub:type, 'endnotes')]/ol/li[contains(@epub:type, 'endnote')]"):
 				note = Endnote()
 				note.node = node
-				note.number = int(node.get_attr("id").replace("note-", ""))
+				# note that we DON'T need the existing note number, just the anchor as an ID for later matching
 				note.contents = node.xpath("./*")
 				note.anchor = node.get_attr("id") or ""
 
@@ -1222,6 +1223,7 @@ class SeEpub:
 			hash_position = href.find("#") + 1  # we want the characters AFTER the hash
 			if hash_position > 0:
 				old_anchor = href[hash_position:]
+
 		new_anchor = f"note-{current_note_number:d}"
 		if new_anchor != old_anchor:
 			change_list.append(f"Changed {old_anchor} to {new_anchor} in {file_name}")

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -42,7 +42,6 @@ class Endnote:
 	def __init__(self):
 		self.node = None
 		self.number = 0
-		self.id = ""
 		self.anchor = ""
 		self.contents = []  # The strings and tags inside an <li> element
 		self.back_link = ""

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -303,15 +303,18 @@ class SeEpub:
 			for node in dom.xpath("/html/body/section[contains(@epub:type, 'endnotes')]/ol/li[contains(@epub:type, 'endnote')]"):
 				note = Endnote()
 				note.node = node
-				# note that we DON'T need the existing note number, just the anchor as an ID for later matching
+				try:
+					note.number = int(node.get_attr("id").replace("note-", ""))
+				except ValueError:
+					note.number = 0
 				note.contents = node.xpath("./*")
 				note.anchor = node.get_attr("id") or ""
 
-				for back_link in node.xpath("//a[contains(@epub:type, 'backlink')]/@href"):
+				for back_link in node.xpath(".//a[contains(@epub:type, 'backlink')]/@href"):
 					note.back_link = back_link
-
+				if not note.back_link:
+					raise se.InvalidInputException(f"No backlink found in note {note.anchor} in existing endnotes file.")
 				self._endnotes.append(note)
-
 		return self._endnotes
 
 	@property


### PR DESCRIPTION
This removes a line of code which prevents temporarynon-numeric endnote ids such as note-17a or note-Nero227. When merging several sets of notes it is very useful to be able to use a non-numeric note id like those when first processing a project. Examples: merging the individual sets of notes in "The Twelve Caesars" and the three sets of notes for Lavengro and The Romany Rye (footnotes in each book and the editorial notes at the back). I prefixed the Lavengro ones with "LV" and the Romany Rye ones with "RR".

We don't need the existing note number anyway, as we'll be overwriting it.