### PR TITLE
Fix missing translator block in new productions

### DIFF
--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -811,7 +811,7 @@ def _create_draft(args: Namespace):
 
 			if translators:
 				translator_block = f"It was translated from ORIGINAL_LANGUAGE in TRANSLATION_YEAR by<br/>\n\t\t\t{_generate_contributor_string(translators, True)}.</p>"
-				colophon_xhtml = colophon_xhtml.replace("</p>\n\t\t\t<p>This ebook was produced for the<br/>", f"<br/>\n\t\t\t{translator_block}\n\t\t\t<p>This ebook was produced for the<br/>")
+				colophon_xhtml = colophon_xhtml.replace("</p>\n\t\t\t<p>This ebook was produced for<br/>", f"<br/>\n\t\t\t{translator_block}\n\t\t\t<p>This ebook was produced for<br/>")
 
 			if args.pg_id:
 				colophon_xhtml = colophon_xhtml.replace("PG_URL", pg_url)


### PR DESCRIPTION
The colophon template was changed in https://github.com/standardebooks/tools/commit/e782004fcf326966f0bdce60fde4fc0c88e50b40, but `create-draft` was looking for the old template.