### PR TITLE
Cleaning a single file should take account of extension

### DIFF
--- a/se/commands/clean.py
+++ b/se/commands/clean.py
@@ -22,36 +22,31 @@ def clean(plain_output: bool) -> int:
 
 	console = Console(highlight=False, theme=se.RICH_THEME, force_terminal=se.is_called_from_parallel()) # Syntax highlighting will do weird things when printing paths; force_terminal prints colors when called from GNU Parallel
 
-	for filepath in se.get_target_filenames(args.targets, (".xhtml", ".svg", ".opf", ".ncx", ".xml")):
+	for filepath in se.get_target_filenames(args.targets, (".xhtml", ".svg", ".opf", ".ncx", ".xml", ".css")):
 		if args.verbose:
 			console.print(se.prep_output(f"Processing [path][link=file://{filepath}]{filepath}[/][/] ...", plain_output), end="")
 
-		try:
-			se.formatting.format_xml_file(filepath)
-		except se.MissingDependencyException as ex:
-			se.print_error(ex, plain_output=plain_output)
-			return ex.code
-		except se.SeException as ex:
-			se.print_error(f"File: [path][link=file://{filepath}]{filepath}[/][/]. Exception: {ex}", args.verbose, plain_output=plain_output)
-			return ex.code
+		if filepath.suffix == ".css":
+			with open(filepath, "r+", encoding="utf-8") as file:
+				css = file.read()
 
-		if args.verbose:
-			console.print(" OK")
+				try:
+					processed_css = se.formatting.format_css(css)
 
-	for filepath in se.get_target_filenames(args.targets, ".css"):
-		if args.verbose:
-			console.print(se.prep_output(f"Processing [path][link=file://{filepath}]{filepath}[/][/] ...", plain_output), end="")
+					if processed_css != css:
+						file.seek(0)
+						file.write(processed_css)
+						file.truncate()
+				except se.SeException as ex:
+					se.print_error(f"File: [path][link=file://{filepath}]{filepath}[/][/]. Exception: {ex}", args.verbose, plain_output=plain_output)
+					return ex.code
 
-		with open(filepath, "r+", encoding="utf-8") as file:
-			css = file.read()
-
+		else:
 			try:
-				processed_css = se.formatting.format_css(css)
-
-				if processed_css != css:
-					file.seek(0)
-					file.write(processed_css)
-					file.truncate()
+				se.formatting.format_xml_file(filepath)
+			except se.MissingDependencyException as ex:
+				se.print_error(ex, plain_output=plain_output)
+				return ex.code
 			except se.SeException as ex:
 				se.print_error(f"File: [path][link=file://{filepath}]{filepath}[/][/]. Exception: {ex}", args.verbose, plain_output=plain_output)
 				return ex.code


### PR DESCRIPTION
Currently, running clean against a single xhtml file attempts to also pass it through the CSS processor, causing errors. The single file path of `get_target_filenames` can be updated to also check the file suffix.

An example of the error:

```
$ se clean src/epub/text/sulamith.xhtml --verbose
Processing /Users/robin/Code/standardebooks/corpus/aleksandr-kuprin_short-fiction_j-m-murray/src/epub/text/sulamith.xhtml 
... OK
Processing /Users/robin/Code/standardebooks/corpus/aleksandr-kuprin_short-fiction_j-m-murray/src/epub/text/sulamith.xhtml 
...     Error  File: 
/Users/robin/Code/standardebooks/corpus/aleksandr-kuprin_short-fiction_j-m-murray/src/epub/text/sulamith.xhtml. Exception:
EOF reached before {} block for a qualified rule.
```