### PR TITLE
create-draft: Allows single or double quotes when parsing encoding attribute

### DIFF
--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -676,7 +676,7 @@ def _create_draft(args: Namespace):
 	# Write PG data if we have it
 	if args.pg_id and pg_ebook_html:
 		try:
-			dom = etree.parse(StringIO(regex.sub(r"encoding=\".+?\"", "", pg_ebook_html)), parser)
+			dom = etree.parse(StringIO(regex.sub(r"encoding=(?P<quote>[\'\"]).+?(?P=quote)", "", pg_ebook_html)), parser)
 			namespaces = {"re": "http://exslt.org/regular-expressions"}
 
 			for node in dom.xpath("//*[re:test(text(), '\\*\\*\\*\\s*Produced by.+')]", namespaces=namespaces):


### PR DESCRIPTION
A few PG texts use single quotes for the header attributes, e.g.,

`<?xml version='1.0' encoding='utf-8'?>`
                                                         
which causes `se create-draft` to fail. This happened [in Apr 2021](https://groups.google.com/g/standardebooks/c/Rgs0T2xVOzc/m/F_N05t9IAwAJ ), and it's present on others as well.

I took a whack at allowing either single or double quotes in the regex to remove the `encoding` attribute value from `pg_ebook_html` before parsing.