### PR TITLE
modernize-spelling: reenforce[ment] -> reinforce[ment]

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -341,7 +341,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b([Aa])ny where\b", r"\1nywhere", xhtml)			# any where -> anywhere
 	xhtml = regex.sub(r"\b([Ee])very thing\b", r"\1verything", xhtml)		# every thing -> everything
 	xhtml = regex.sub(r"\b([Aa])ny thing\b", r"\1nything", xhtml)			# any thing -> anything
-	xhtml = regex.sub(r"\b([Rr])e-enforcement", r"\1inforcement", xhtml)		# re-enforcement -> reinforcement
+	xhtml = regex.sub(r"\b([Rr])e-?enforce", r"\1inforce", xhtml)		# re-enforce -> reinforce
 
 	# Normalize some names
 	xhtml = regex.sub(r"Moliere", r"Molière", xhtml)				# Moliere -> Molière


### PR DESCRIPTION
As just discussed. I've also had reenforce, so I made the `ment` optional. (This also catches reenforced and reenforces.)