### PR TITLE
Add Ukranian to the set of scripts that need a Latn suffix

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -1831,7 +1831,7 @@ def lint(self, skip_lint_ignore: bool) -> list:
 					messages.append(LintMessage("t-024", "When italicizing language in dialog, italics go inside quotation marks.", se.MESSAGE_TYPE_WARNING, filename, [node.to_string() for node in nodes]))
 
 				# Check for language tags transliterated into Latin script but missing `-Latn` suffix
-				nodes = dom.xpath("/html/body//*[re:test(@xml:lang, '^(he|ru|el|zh|bn|hi|sa)$') and re:test(., '[a-zA-Z]')]")
+				nodes = dom.xpath("/html/body//*[re:test(@xml:lang, '^(he|ru|el|zh|bn|hi|sa|uk)$') and re:test(., '[a-zA-Z]')]")
 				if nodes:
 					messages.append(LintMessage("s-082", "Element containing Latin script for a non-Latin-script language, but its [attr]xml:lang[/] attribute value is missing the [val]-Latn[/] language tag suffix. Hint: For example Russian transliterated into Latin script would be [val]ru-Latn[/].", se.MESSAGE_TYPE_ERROR, filename, [node.to_string() for node in nodes]))
 


### PR DESCRIPTION
This will need a minor corpus update.

```
$ rg 'xml:lang="uk"' --count
aleksandr-kuprin_yama_bernard-guilbert-guerney/src/epub/text/endnotes.xhtml:1
vladimir-korolenko_short-fiction_aline-delano_sergius-stepniak_william-westall_thomas-seltzer_the-ru/src/epub/text/in-bad-company.xhtml:2
vladimir-korolenko_short-fiction_aline-delano_sergius-stepniak_william-westall_thomas-seltzer_the-ru/src/epub/text/the-day-of-atonement.xhtml:20
vladimir-korolenko_short-fiction_aline-delano_sergius-stepniak_william-westall_thomas-seltzer_the-ru/src/epub/text/birds-of-heaven.xhtml:3
vladimir-korolenko_short-fiction_aline-delano_sergius-stepniak_william-westall_thomas-seltzer_the-ru/src/epub/text/the-blind-musician.xhtml:46
nikolai-gogol_short-fiction_claud-field_isabel-f-hapgood_vizetelly-and-company_george-tolstoy/src/epub/text/the-viy.xhtml:4
nikolai-gogol_short-fiction_claud-field_isabel-f-hapgood_vizetelly-and-company_george-tolstoy/src/epub/text/taras-bulba.xhtml:10
```