### PR TITLE
Handle AD/BC terminating periods

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -95,8 +95,12 @@ def semanticate(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b(?<!\<abbr\>)([Vv])s\.", r"<abbr>\1s.</abbr>", xhtml)
 	xhtml = regex.sub(r"\b(?<!\<abbr\>)([Ff])f\.", r"<abbr>\1f.</abbr>", xhtml) # ff. typically used in footnotes, means "and following"
 	xhtml = regex.sub(r"\b(?<!\<abbr\>)([Ll])ib\.", r"<abbr>\1ib.</abbr>", xhtml) # Lib. = Liber = Book
-	xhtml = regex.sub(r"""(\s)(?<!\<abbr epub:type="se:era"\>)A\.?D""", r"""\1<abbr epub:type="se:era">AD</abbr>""", xhtml)
-	xhtml = regex.sub(r"""(\s)(?<!\<abbr epub:type="se:era"\>)B\.?C""", r"""\1<abbr epub:type="se:era">BC</abbr>""", xhtml)
+    # keep a period after AD/BC that terminates a clause
+	xhtml = regex.sub(r"""(\s)(?<!\<abbr epub:type="se:era"\>)A\.?D\.([”’]?</p>|\s+[“‘]?[\p{Uppercase_Letter}])""", r"""\1<abbr epub:type="se:era">AD</abbr>.\2""", xhtml)
+	xhtml = regex.sub(r"""(\s)(?<!\<abbr epub:type="se:era"\>)B\.?C\.([”’]?</p>|\s+[“‘]?[\p{Uppercase_Letter}])""", r"""\1<abbr epub:type="se:era">BC</abbr>.\2""", xhtml)
+    # otherwise, get rid of any periods in the abbreviation
+	xhtml = regex.sub(r"""(\s)(?<!\<abbr epub:type="se:era"\>)A\.?D\.?""", r"""\1<abbr epub:type="se:era">AD</abbr>""", xhtml)
+	xhtml = regex.sub(r"""(\s)(?<!\<abbr epub:type="se:era"\>)B\.?C\.?""", r"""\1<abbr epub:type="se:era">BC</abbr>""", xhtml)
 	# python allows a variable lookbehind with the ( class="eoc")?; HOWEVER, it counts as a
 	#	capture group, so replacement groups have to begin with \2; when looking before and
 	#	after a tag, the replacement groups have to begin with \3.


### PR DESCRIPTION
Might as well get this one in; I'm still working on the eoc. This splits BC/AD handling into two parts, one if it has a trailing period and appears to be the end of a clause (same tests that eoc is doing), in which the trailing period is kept, and another if not, where the trailing period is eliminated.