### PR TITLE
Add a find-unusual-characters command

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,10 @@ We need volunteers to take the lead on the following goals:
 
 	Find words with mismatched diacritics in a set of XHTML files. For example, `cafe` in one file and `café` in another.
 
+-	### `se find-unusual-characters`
+
+	Find unusual characters: characters that would sometimes, but not usually, be expected to appear in a SE production.
+
 -	### `se help`
 
 	List available SE commands.

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ We need volunteers to take the lead on the following goals:
 
 -	### `se find-unusual-characters`
 
-	Find unusual characters: characters that would sometimes, but not usually, be expected to appear in a SE production.
+	Find characters outside a nominal expected range in a set of XHTML files. This can be useful to find transcription mistakes and mojibake.
 
 -	### `se help`
 

--- a/se/commands/find_unusual_characters.py
+++ b/se/commands/find_unusual_characters.py
@@ -1,0 +1,131 @@
+"""
+This module implements the `se find-unusual-characters` command.
+"""
+
+import argparse
+from typing import Dict
+
+import regex
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+import se
+
+def find_unusual_characters(plain_output: bool) -> int:
+	"""
+	Entry point for `se find-unusual-characters`
+	"""
+
+	parser = argparse.ArgumentParser(description="Find characters outside a nominal expected range in a set of XHTML files. This can be useful to find transcription mistakes and mojibake.")
+	parser.add_argument("targets", metavar="TARGET", nargs="+", help="an XHTML file, or a directory containing XHTML files")
+	args = parser.parse_args()
+
+	console = Console(highlight=False, theme=se.RICH_THEME) # Syntax highlighting will do weird things when printing paths
+	return_code = 0
+	unusual_characters: Dict[str, int] = {} # key: word; value: count
+	target_filenames = se.get_target_filenames(args.targets, ".xhtml")
+	files_xhtml = []
+
+	# Read files and cache for later
+	for filename in target_filenames:
+		try:
+			with open(filename, "r", encoding="utf-8") as file:
+				xhtml = file.read()
+				dom = se.easy_xml.EasyXmlTree(xhtml)
+
+				# Save any `alt` and `title` attributes because we may be interested in their contents
+				for node in dom.xpath("//*[@alt or @title]"):
+					for _, value in node.attrs.items():
+						xhtml = xhtml + f" {value} "
+
+				# Strip tags
+				xhtml = regex.sub(r"<[^>]+?>", " ", xhtml)
+
+				files_xhtml.append(xhtml)
+
+		except FileNotFoundError:
+			se.print_error(f"Couldn’t open file: [path][link=file://{filename}]{filename}[/][/].", plain_output=plain_output)
+			return_code = se.InvalidInputException.code
+
+		except se.SeException as ex:
+			se.print_error(str(ex) + f" File: [path][link=file://{filename}]{filename}[/][/].", plain_output=plain_output)
+			return_code = ex.code
+
+	# Create a list of unusual characters.
+	# We start with every character, and remove ones we know are valid in SE productions
+	unusual_character_set = "["
+	# Ignore basic ASCII u0000-u007e
+	unusual_character_set += "\u007f-\u009f"
+	# Ignore NO BREAK SPACE u00a0
+	unusual_character_set += "\u00a1"
+	# Ignore CENT SIGN and POUND SIGN u00a2-u00a3
+	unusual_character_set += "\u00a4-\u00af"
+	# Ignore DEGREE SYMBOL u00b0
+	unusual_character_set += "\u00b1-\u00bb"
+	# Ignore vulgar fractions u00bc-u00be
+	unusual_character_set += "\u00bf"
+	# Ignore standard accented letters u00c0-u00ff
+	unusual_character_set += "\u0100-\u0151"
+	# Ignore œ / Œ u0152-u0153
+	unusual_character_set += "\u0154-\u030c"
+	# Ignore COMBINING VERTICAL LINE ABOVE u030d
+	unusual_character_set += "\u030e-\u036f"
+	# Ignore basic Greek characters u0370-u03ff
+	unusual_character_set += "\u0400-\u1eff"
+	# Ignore extended Greek characters u1f00-u1fff
+	unusual_character_set += "\u2000-\u2009"
+	# Ignore HAIR SPACE u200a
+	unusual_character_set += "\u200b-\u2010"
+	# Ignore valid dashes u2011-u2014
+	unusual_character_set += "\u2015-\u2017"
+	# Ignore valid single quotes u2018-u2019
+	unusual_character_set += "\u201a-\u201b"
+	# Ignore valid double quotes u201c-u201d
+	unusual_character_set += "\u201e-\u2025"
+	# Ignore HORIZONTAL ELLIPSIS u2026
+	unusual_character_set += "\u2027-\u205f"
+	# Ignore WORD JOINER u2060
+	unusual_character_set += "\u2061-\u21a8"
+	# Ignore LEFTWARDS ARROW WITH HOOK u21a9 (used in endquotes)
+	unusual_character_set += "\u21aa-\u22ed"
+	# Ignore VERTICAL ELLIPSIS u22ee
+	unusual_character_set += "\u22ef-\u2e39"
+	# Ignore two-/three-em dashes u2e3a-u2e3b
+	unusual_character_set += "\u2e3c-\ufefe"
+	# Ignore ZERO WIDTH SPACE ufeff
+	unusual_character_set += "]"
+
+	unusual_character_regex = regex.compile(unusual_character_set)
+
+	for xhtml in files_xhtml:
+		for character in regex.findall(unusual_character_regex, xhtml):
+			if character in unusual_characters:
+				unusual_characters[character] = unusual_characters[character] + len(character)
+			else:
+				unusual_characters[character] = len(character)
+
+	# Sort and prepare the output
+	lines = []
+
+	for unusual_character, _ in unusual_characters.items():
+		lines.append((unusual_character, unusual_characters[unusual_character]))
+
+	lines.sort()
+
+	if lines:
+		if plain_output:
+			for unusual_character, unusual_character_count in lines:
+				console.print(f"{unusual_character} ({unusual_character_count})")
+
+		else:
+			table = Table(show_header=False, show_lines=True, box=box.HORIZONTALS)
+			table.add_column("Unusual character")
+			table.add_column("Count", style="dim", no_wrap=True)
+
+			for unusual_character, unusual_character_count in lines:
+				table.add_row(unusual_character, f"({unusual_character_count})")
+
+			console.print(table)
+
+	return return_code

--- a/se/commands/find_unusual_characters.py
+++ b/se/commands/find_unusual_characters.py
@@ -96,10 +96,8 @@ def find_unusual_characters(plain_output: bool) -> int:
 	# Ignore ZERO WIDTH SPACE ufeff
 	unusual_character_set += "]"
 
-	unusual_character_regex = regex.compile(unusual_character_set)
-
 	for xhtml in files_xhtml:
-		for character in regex.findall(unusual_character_regex, xhtml):
+		for character in regex.findall(unusual_character_set, xhtml):
 			if character in unusual_characters:
 				unusual_characters[character] = unusual_characters[character] + len(character)
 			else:

--- a/se/completions/bash/se
+++ b/se/completions/bash/se
@@ -2,7 +2,7 @@ _se(){
 	COMPREPLY=()
 	local cur="${COMP_WORDS[COMP_CWORD]}"
 	local prev="${COMP_WORDS[COMP_CWORD-1]}"
-	local commands="--help --plain --version british2american build build-images build-manifest build-spine build-title build-toc clean compare-versions create-draft dec2roman extract-ebook find-mismatched-dashes find-mismatched-diacritics help hyphenate interactive-replace lint make-url-safe modernize-spelling prepare-release recompose-epub renumber-endnotes roman2dec semanticate shift-endnotes split-file titlecase typogrify unicode-names version word-count xpath"
+	local commands="--help --plain --version british2american build build-images build-manifest build-spine build-title build-toc clean compare-versions create-draft dec2roman extract-ebook find-mismatched-dashes find-mismatched-diacritics find-unusual-characters help hyphenate interactive-replace lint make-url-safe modernize-spelling prepare-release recompose-epub renumber-endnotes roman2dec semanticate shift-endnotes split-file titlecase typogrify unicode-names version word-count xpath"
 	if [[ $COMP_CWORD -gt 1 ]]; then
 		case "${COMP_WORDS[1]}" in
 			british2american)
@@ -71,6 +71,10 @@ _se(){
 				COMPREPLY+=($(compgen -f -X "!*.xhtml" -- "${cur}"))
 				;;
 			find-mismatched-diacritics)
+				COMPREPLY+=($(compgen -d -X ".*" -- "${cur}"))
+				COMPREPLY+=($(compgen -f -X "!*.xhtml" -- "${cur}"))
+				;;
+			find-unusual-characters)
 				COMPREPLY+=($(compgen -d -X ".*" -- "${cur}"))
 				COMPREPLY+=($(compgen -f -X "!*.xhtml" -- "${cur}"))
 				;;

--- a/se/completions/fish/se.fish
+++ b/se/completions/fish/se.fish
@@ -1,6 +1,6 @@
 function __fish_se_no_subcommand --description "Test if se has yet to be given the subcommand"
 	for i in (commandline -opc)
-		if contains -- $i british2american build build-images build-manifest build-spine build-title build-toc clean compare-versions create-draft dec2roman extract-ebook find-mismatched-dashes find-mismatched-diacritics help hyphenate interactive-replace lint make-url-safe modernize-spelling prepare-release recompose-epub renumber-endnotes roman2dec semanticate shift-endnotes split-file titlecase typogrify unicode-names version word-count xpath
+		if contains -- $i british2american build build-images build-manifest build-spine build-title build-toc clean compare-versions create-draft dec2roman extract-ebook find-mismatched-dashes find-mismatched-diacritics find-unusual-characters help hyphenate interactive-replace lint make-url-safe modernize-spelling prepare-release recompose-epub renumber-endnotes roman2dec semanticate shift-endnotes split-file titlecase typogrify unicode-names version word-count xpath
 			return 1
 		end
 	end
@@ -65,6 +65,9 @@ complete -c se -A -n "__fish_seen_subcommand_from find-mismatched-dashes" -s h -
 
 complete -c se -n "__fish_se_no_subcommand" -a find-mismatched-diacritics -d "Find words with mismatched diacritics in a set of XHTML files."
 complete -c se -A -n "__fish_seen_subcommand_from find-mismatched-diacritics" -s h -l help -x -d "show this help message and exit"
+
+complete -c se -n "__fish_se_no_subcommand" -a find-unusual-characters -d "Find characters outside a nominal expected range in a set of XHTML files."
+complete -c se -A -n "__fish_seen_subcommand_from find-unusual-characters" -s h -l help -x -d "show this help message and exit"
 
 complete -c se -n "__fish_se_no_subcommand" -f -a help -d "List available S.E. commands"
 

--- a/se/completions/zsh/_se
+++ b/se/completions/zsh/_se
@@ -26,6 +26,7 @@ case $state in
 			"extract-ebook[Extract an EPUB, MOBI, or AZW3 ebook.]" \
 			"find-mismatched-dashes[Find words with mismatched dashes in a set of XHTML files.]" \
 			"find-mismatched-diacritics[Find words with mismatched diacritics in a set of XHTML files.]" \
+			"find-unusual-characters[Find characters outside a nominal expected range in a set of XHTML files.]" \
 			"help[List available S.E. commands.]" \
 			"hyphenate[Insert soft hyphens at syllable breaks in an XHTML file.]" \
 			"interactive-replace[Perform an interactive search and replace on a list of files using Python-flavored regex. The view is scrolled using the arrow keys, with alt to scroll by page in any direction. Basic Emacs (default) or Vim style navigation is available. The following actions are possible: (y) Accept replacement. (n) Reject replacement. (a) Accept all remaining replacements in this file. (r) Reject all remaining replacements in this file. (c) Center on match. (q) Save this file and quit.]" \
@@ -143,6 +144,11 @@ case $state in
 					'*: :_files -g \*.xhtml'
 				;;
 			find-mismatched-diacritics)
+				_arguments -s \
+					{-h,--help}'[show a help message and exit]' \
+					'*: :_files -g \*.xhtml'
+				;;
+			find-unusual-characters)
 				_arguments -s \
 					{-h,--help}'[show a help message and exit]' \
 					'*: :_files -g \*.xhtml'


### PR DESCRIPTION
This makes it easy to find unexpected characters in a new transcription (for example).

Fixes https://github.com/standardebooks/tools/issues/476.