### PR TITLE
Confirm java is really installed on Mac OSX

### DIFF
--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -103,7 +103,19 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 
 	run_ace = False
 	if run_epubcheck:
+		java_present = True
 		if not shutil.which("java"):
+			java_present = False
+		# Mac Big Sur+ has a "dummy" /usr/bin/java; test -version to see if java is really installed
+		elif os.uname()[0] == "Darwin":
+			try:
+				java_check = subprocess.run(["java", "-version"], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=False)
+				if java_check.stderr.decode().find("Unable to locate") >= 0:
+					java_present = False
+			except:
+				java_present = False
+
+		if not java_present:
 			raise se.MissingDependencyException("Couldn’t locate [bash]java[/]. Is it installed?")
 
 		if shutil.which("ace"):


### PR DESCRIPTION
Subprocesses in python is not an area I know much about, so I read a bit, looked at the calibre call a bit, and experimented a bit.

This just does a try of `java -version` and if it contains "Unable to locate" or it fails, then it assumes java isn't present. I use a flag, since there are now three places where we determine java isn't present. I've tested it both with and without a "real" java on Big Sur, and it does the right thing both ways. I don't have a Linux VM (or Windows) to test on, but the os.uname test should prevent the test on anything but OSX.