### PR TITLE
Update spelling of Kyiv

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -399,7 +399,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\bPekin\b", r"Peking", xhtml)				# Pekin -> Peking
 	xhtml = regex.sub(r"\bBuenos Ayres\b", r"Buenos Aires", xhtml)			# Buenos Ayres -> Buenos Aires
 	xhtml = regex.sub(r"\bCracow", r"Krakow", xhtml)				# Cracow -> Krakow
-	xhtml = regex.sub(r"\bKieff?\b", r"Kiev", xhtml)				# Kief -> Kiev
+	xhtml = regex.sub(r"\bKie(ff?|v)\b", r"Kyiv", xhtml)				# Kieff/Kiev -> Kyiv
 	xhtml = regex.sub(r"\bRo?umania", r"Romania", xhtml)				# Roumania(n) -> Romania(n)
 	xhtml = regex.sub(r"\b([Rr])enascence", r"\1enaissance", xhtml)			# renascence -> renaissance
 	xhtml = regex.sub(r"\bThibet", r"Tibet", xhtml)					# Thibet -> Tibet


### PR DESCRIPTION
I hadn’t realised this, but this has been the Ukrainian preferred spelling since ’95 and is a UN standard, with a campaign to get foreign media to change starting in 2018: https://en.wikipedia.org/wiki/KyivNotKiev. Given the recent standardisation of the media on “Kyiv” (driven by the current invasion) it feels right to also update our corpus to the more modern spelling.