### PR TITLE
Extend renumber

### DIFF
--- a/se/commands/renumber_endnotes.py
+++ b/se/commands/renumber_endnotes.py
@@ -33,9 +33,11 @@ def renumber_endnotes(plain_output: bool) -> int:
 			if args.brute_force:
 				se_epub.recreate_endnotes()
 			else:
-				found_endnote_count, changed_endnote_count = se_epub.generate_endnotes()
+				found_endnote_count, changed_endnote_count, change_list = se_epub.generate_endnotes()
 				if args.verbose:
 					print(se.prep_output(f"Found {found_endnote_count} endnote{'s' if found_endnote_count != 1 else ''} and changed {changed_endnote_count} endnote{'s' if changed_endnote_count != 1 else ''}.", plain_output))
+					for change in change_list:
+						print(change)
 		except se.SeException as ex:
 			se.print_error(ex, plain_output=plain_output)
 			return_code = ex.code

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -1335,7 +1335,7 @@ class SeEpub:
 
 		new_anchor = f"note-{current_note_number:d}"
 		if new_anchor != old_anchor:
-			change_list.append(f"{old_anchor}->{new_anchor}")
+			change_list.append(f"{old_anchor}->{new_anchor}, {file_name}")
 			notes_changed += 1
 			# Update the link in the dom
 			link.set_attr("href", f"{self.endnotes_path.name}#{new_anchor}")

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -1245,7 +1245,7 @@ class SeEpub:
 		with open(self.endnotes_path, "w") as file:
 			file.write(endnotes_dom.to_string())
 
-	def generate_endnotes(self) -> Tuple[int, int]:
+	def generate_endnotes(self) -> Tuple[int, int, list]:
 		"""
 		Read the epub spine to regenerate all endnotes in order of appearance, starting from 1.
 		Changes are written to disk.
@@ -1316,7 +1316,7 @@ class SeEpub:
 			with open(self.endnotes_path, "w") as file:
 				file.write(se.formatting.format_xhtml(endnotes_dom.to_string()))
 
-		return current_note_number - 1, notes_changed
+		return current_note_number - 1, notes_changed, change_list
 
 	def __process_link(self, change_list, current_note_number, file_name, link, needs_rewrite, notes_changed) -> Tuple[bool, int]:
 		"""
@@ -1335,7 +1335,7 @@ class SeEpub:
 
 		new_anchor = f"note-{current_note_number:d}"
 		if new_anchor != old_anchor:
-			change_list.append(f"Changed {old_anchor} to {new_anchor} in {file_name}")
+			change_list.append(f"{old_anchor}->{new_anchor}")
 			notes_changed += 1
 			# Update the link in the dom
 			link.set_attr("href", f"{self.endnotes_path.name}#{new_anchor}")


### PR DESCRIPTION
I've expanded the report we get when verbose option is set for renumber-endnotes. It now generates a report like this:

`Found 418 endnotes and changed 389 endnotes.
note-31->note-30
note-32->note-31
note-33->note-32
note-34->note-33
note-35->note-34
note-36->note-35
note-37->note-36
note-38->note-37.
....`

The reason for this is to make it easy to search for changed endnote references which weren't inside actual notes. This is the case in Boswell's _Life of Johnson_, which has many references like this, e.g. "See _ante_, II, note 1." changed to references like `See <a href="endnotes.xhtml#note-1766">here</a>.` These note links _would not be changed_ by the current se renumber-endnotes and will need to be manually searched for and altered.

Having a list which gives a mapping from old note number to new note number will make it easier to find and change such references. Ultimately of course it would be good to automate this latter process as part of the renumbering process itself, but given that it's going to be a rare requirement and would slow processing for 99% of normal usages of the command this is at least a first step.

Outside of this rare requirement, an expanded report will also serve as a detailed record of what has happened if something goes wrong in a renumbering process.
