### PR TITLE
Add a check for a quote starting with a lowercase character after a period

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -1755,6 +1755,11 @@ def lint(self, skip_lint_ignore: bool, allowed_messages: List[str] = None) -> li
 				if typos:
 					messages.append(LintMessage("t-042", "Possible typo: Italics followed by a letter.", se.MESSAGE_TYPE_WARNING, filename, typos))
 
+				# Check for lowercase letters starting quotations after a preceding period
+				typos = dom.xpath("/html/body//p/child::text()[re:test(., '\\.\\s[‘“][a-z]')]")
+				if typos:
+					messages.append(LintMessage("t-042", "Possible typo: Lowercase quotation following a period. Check either that the period should be a comma, or that the quotation should start with a capital.", se.MESSAGE_TYPE_WARNING, filename, typos))
+
 				# Check for body element without child section or article. Ignore the ToC because it has a unique structure
 				nodes = dom.xpath("/html/body[not(./*[name()='section' or name()='article' or (name()='nav' and re:test(@epub:type, '\\b(toc|loi)\\b'))])]")
 				if nodes:


### PR DESCRIPTION
It was slightly surprising to me that we aren’t already checking for this, but an easy thing to add. There are currently 33 instances of this in my clone of the corpus, but each would need to be double-checked against the source files to see whether it’s a problem with the period or the lowercase character.

(I couldn’t get any unicode-aware lowercase matchers to work, but it’s not a major issue.)