### PR TITLE
Update se_epub_build.py

### DIFF
--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -586,6 +586,9 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 					# Replace `vw` or `vh` units with percent, a reasonable approximation
 					processed_css = regex.sub(r"([0-9\.]+\s*)v(w|h);", r"\1%;", processed_css)
 
+					# We converted svgs to pngs, so replace references
+					processed_css = regex.sub(r'(url\(".*\.)(svg)("\))', r"\1png\3", processed_css)
+
 					if processed_css != css:
 						file.seek(0)
 						file.write(processed_css)


### PR DESCRIPTION
Add a replace references for svg that are used with url elements in the CSS (eg background-image). otherwise, epubcheck throws an error because they're converted but the url("../images/filename.svg") is not changed to url("../images/filename.png")