### PR TITLE
Lint for xml:lang="unk"

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -234,6 +234,7 @@ SEMANTICS & CONTENT
 "s-048", "[val]se:name[/] semantic on block element. [val]se:name[/] indicates the contents is the name of something."
 "s-049", "[xhtml]<header>[/] element whose only child is an [xhtml]<h#>[/] element."
 "s-050", "[xhtml]<span>[/] element appears to exist only to apply [attr]epub:type[/]. [attr]epub:type[/] should go on the parent element instead, without a [xhtml]<span>[/] element."
+"s-051", "Element with [xhtml]xml:lang=\"unk\"[/] (Enawené-Nawé) almost certainly should be [xhtml]xml:lang=\"und\"[/] (undefined)."
 "s-052", "[xhtml]<abbr>[/] element with illegal [attr]title[/] attribute."
 "s-053", "Colophon line not preceded by [xhtml]<br/>[/]."
 "s-054", "[xhtml]<cite>[/] as child of [xhtml]<p>[/] in [xhtml]<blockquote>[/]. [xhtml]<cite>[/] should be the direct child of [xhtml]<blockquote>[/]."
@@ -282,8 +283,6 @@ SEMANTICS & CONTENT
 "s-097", "[xhtml]a[/] element without [attr]href[/] attribute."
 "s-098", "[xhtml]<header>[/] element with only one child."
 "s-099", "List item in endnotes missing [xhtml]endnote[/] semantic."
-UNUSED
-"s-051", f"Wrong height or width. [path][link=file://{self.path / 'images/cover.jpg'}]cover.jpg[/][/] must be exactly {se.COVER_WIDTH} × {se.COVER_HEIGHT}."
 
 TYPOGRAPHY
 "t-001", "Double spacing found. Sentences should be single-spaced. (Note that double spaces might include Unicode no-break spaces!)"
@@ -2134,6 +2133,11 @@ def lint(self, skip_lint_ignore: bool, allowed_messages: List[str] = None) -> li
 				nodes = dom.xpath("/html/body//i[@xml:lang][starts-with(., '“') or re:test(., '”$')]")
 				if nodes:
 					messages.append(LintMessage("t-024", "When italicizing language in dialog, italics go inside quotation marks.", se.MESSAGE_TYPE_WARNING, filename, [node.to_string() for node in nodes]))
+
+				# Check for language tags misusing the unk lang code
+				nodes = dom.xpath("/html/body//*[re:test(@xml:lang, '^unk$')]")
+				if nodes:
+					messages.append(LintMessage("s-051", "Element with [xhtml]xml:lang=\"unk\"[/] (Enawené-Nawé) almost certainly should be [xhtml]xml:lang=\"und\"[/] (undefined).", se.MESSAGE_TYPE_ERROR, filename, [node.to_string() for node in nodes]))
 
 				# Check for language tags transliterated into Latin script but missing `-Latn` suffix
 				nodes = dom.xpath("/html/body//*[re:test(@xml:lang, '^(he|ru|el|zh|bn|hi|sa|uk|yi)$') and re:test(., '[a-zA-Z]')]")


### PR DESCRIPTION
Alex fixed this in _The Return of Tarzan_ already, but I’ve seen it in other productions in the past and it’s an easy lint check.