### PR TITLE
Replace changed endnote refs

### DIFF
--- a/se/commands/renumber_endnotes.py
+++ b/se/commands/renumber_endnotes.py
@@ -37,7 +37,7 @@ def renumber_endnotes(plain_output: bool) -> int:
 				if args.verbose:
 					print(se.prep_output(f"Found {found_endnote_count} endnote{'s' if found_endnote_count != 1 else ''} and changed {changed_endnote_count} endnote{'s' if changed_endnote_count != 1 else ''}.", plain_output))
 					for change in change_list:
-						print(change)
+						print(f"{change.old_anchor}->{change.new_anchor} in {change.filename}")
 		except se.SeException as ex:
 			se.print_error(ex, plain_output=plain_output)
 			return_code = ex.code

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -1390,3 +1390,4 @@ class SeEpub:
 		# We don't change the anchor or the back ref just yet
 		endnote.source_file = file_name
 		return needs_rewrite, notes_changed
+		

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -1319,7 +1319,6 @@ class SeEpub:
 			# example: (see <a href="endnotes.xhtml#note-1553">this note</a>.)
 			# most but not all such are likely to be in the newly re-written endnotes.xhtml
 			for file_path in self.spine_file_paths:
-				print("trawling body files looking for links")
 				needs_rewrite = False
 				dom = self.get_dom(file_path)
 				for link in dom.xpath("/html/body//a[contains(@href, 'endnotes.xhtml#note-')]"):
@@ -1330,7 +1329,7 @@ class SeEpub:
 
 		return current_note_number - 1, notes_changed, change_list
 
-	def __process_direct_link(self, change_list, link) -> Boolean:
+	def __process_direct_link(self, change_list, link) -> bool:
 		"""
 		Checks all hyperlinks to the endnotes to see if the existing anchor needs to be updated with a new number
 


### PR DESCRIPTION
Alex: there are a few people now needing this, and so far as I’ve been able to test it seems to work well. A reminder what it does is, after renumbering endnotes in the usual way, it hunts for and changes direct links to endnotes of the “see this note here” type.