### PR TITLE
Don’t fail lint on presence of JPEG2000 files

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -41,7 +41,7 @@ SE_SEMANTIC_VOCABULARY = ["collection", "compass", "compound", "diary", "diary.d
 
 SE_GENRES = ["Adventure", "Autobiography", "Biography", "Childrens", "Comedy", "Drama", "Fantasy", "Fiction", "Horror", "Memoir", "Mystery", "Nonfiction", "Philosophy", "Poetry", "Satire", "Science Fiction", "Shorts", "Spirituality", "Tragedy", "Travel"]
 IGNORED_CLASSES = ["elision", "eoc", "full-page", "continued", "together"]
-BINARY_EXTENSIONS = [".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".png", ".epub", ".xcf", ".otf"]
+BINARY_EXTENSIONS = [".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".png", ".epub", ".xcf", ".otf", ".jp2"]
 IGNORED_FILENAMES = ["colophon.xhtml", "titlepage.xhtml", "imprint.xhtml", "uncopyright.xhtml", "halftitlepage.xhtml", "toc.xhtml", "loi.xhtml"]
 
 # These are partly defined in semos://1.0.0/8.10.9.2


### PR DESCRIPTION
While working on _Benjamin Bunny_, the best way of getting high quality source imagery has been to copy down the individual scans from archive.org. These are provided in JPEG2000 format, with a .jp2 file extension. As all the images are full-page, I’ve just copied the .jp2 files into the ./images folder, but this causes lint to fail.

This patch simply ignores files with a .jp2 extension, typical for archive.org scans.