### PR TITLE
create-draft: Don't copy metadata from template files

### DIFF
--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -401,8 +401,10 @@ def _copy_template_file(filename: str, dest_path: Path) -> None:
 	"""
 	Copy a template file to the given destination Path
 	"""
+	if dest_path.is_dir():
+		dest_path = dest_path / filename
 	with importlib_resources.path("se.data.templates", filename) as src_path:
-		shutil.copy(src_path, dest_path)
+		shutil.copyfile(src_path, dest_path)
 
 def _add_name_abbr(contributor: str) -> str:
 	"""


### PR DESCRIPTION
Hi! I'm trying to use `se` on [NixOS](https://nixos.org/), which installs programs to a read-only directory tree (the "store"). When the Standard Ebooks tools are installed into the Nix store, the templates get installed there too, and when `se create-draft` copies them out of the store, they remain read-only, so it can't write the title etc. to them:

```pytb
Traceback (most recent call last):
  File "/nix/store/r14fypa7gxingfk5k5f4vxp6dp7inbvc-python3.9-standardebooks-2.3.10/bin/.se-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/r14fypa7gxingfk5k5f4vxp6dp7inbvc-python3.9-standardebooks-2.3.10/lib/python3.9/site-packages/se/main.py", line 81, in main
    sys.exit(getattr(module, command_function)(args.plain_output))
  File "/nix/store/r14fypa7gxingfk5k5f4vxp6dp7inbvc-python3.9-standardebooks-2.3.10/lib/python3.9/site-packages/se/commands/create_draft.py", line 1008, in create_draft
    _create_draft(args)
  File "/nix/store/r14fypa7gxingfk5k5f4vxp6dp7inbvc-python3.9-standardebooks-2.3.10/lib/python3.9/site-packages/se/commands/create_draft.py", line 786, in _create_draft
    with open(content_path / "epub" / "text" / "titlepage.xhtml", "r+", encoding="utf-8") as file:
PermissionError: [Errno 13] Permission denied: '/[path redacted]/author_title/src/epub/text/titlepage.xhtml'
```

Changing `_copy_template_file` to use `shutil.copyfile` rather than `shutil.copy` solves this.