### PR TITLE
Allow system to error when spine doesn’t contain all markup

### DIFF
--- a/se/commands/build_ids.py
+++ b/se/commands/build_ids.py
@@ -12,6 +12,7 @@ import se
 import se.easy_xml
 import se.formatting
 from se.se_epub import SeEpub
+from se.se_epub_lint import files_not_in_spine
 
 def build_ids(plain_output: bool) -> int:
 	"""
@@ -31,6 +32,12 @@ def build_ids(plain_output: bool) -> int:
 				console.print(se.prep_output(f"Processing [path][link=file://{directory}]{directory}[/][/] ...", plain_output))
 
 			se_epub = SeEpub(directory)
+
+			# First, check for spine sanity: no point in proceeding if it’s not correct
+			missing_spine_files = files_not_in_spine(se_epub)
+			if missing_spine_files:
+				missing_spine_file_list = ", ".join([file.name for file in missing_spine_files])
+				raise se.InvalidSeEbookException(f"Additional files not in spine: {missing_spine_file_list}")
 
 			replacements: List[Tuple[se.easy_xml.EasyXmlElement, str]] = []
 			id_counter = 0

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -95,7 +95,7 @@ FILESYSTEM
 "f-004", f"File does not match [path][link=file://{core_css_file_path}]{core_css_file_path}[/][/]."
 "f-005", f"File does not match [path][link=file://{logo_svg_file_path}]{logo_svg_file_path}[/][/]."
 "f-006", f"File does not match [path][link=file://{uncopyright_file_path}]{uncopyright_file_path}[/][/]."
-"f-008", f"Filename is not URL-safe. Expected: [path]{url_safe_filename}[/]."
+"f-007", "File not listed in [xml]<spine>[/]."
 "f-008", f"Filename is not URL-safe. Expected: [path]{url_safe_filename}[/]."
 "f-009", "Illegal leading [text]0[/] in filename."
 "f-010", "Problem decoding file as utf-8."
@@ -687,6 +687,12 @@ def lint(self, skip_lint_ignore: bool, allowed_messages: List[str] = None) -> li
 			messages.append(LintMessage("m-047", "Ignoring [path]*[/] is too general. Target specific files if possible.", se.MESSAGE_TYPE_WARNING, lint_ignore_path))
 
 	# Done parsing ignore list
+
+	# Check that the spine has all the expected files in the book
+	missing_spine_files = files_not_in_spine(self)
+	if missing_spine_files:
+		for missing_spine_file in missing_spine_files:
+			messages.append(LintMessage("f-007", "File not listed in [xml]<spine>[/].", se.MESSAGE_TYPE_ERROR, missing_spine_file))
 
 	# Get the ebook language for later use
 	try:

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -602,9 +602,8 @@ def files_not_in_spine(self) -> set:
 	Set of files not in the spine (typically an empty set)
 	"""
 
-	xhtml_files = set(self.path.glob("src/epub/**/*.xhtml"))
-	spine_files = set(self.spine_file_paths)
-	spine_files.add(self.toc_path)
+	xhtml_files = set(self.content_path.glob("**/*.xhtml"))
+	spine_files = set(self.spine_file_paths + [self.toc_path])
 	return xhtml_files.difference(spine_files)
 
 def lint(self, skip_lint_ignore: bool, allowed_messages: List[str] = None) -> list:

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -591,6 +591,22 @@ def _get_selectors_and_rules (self) -> tuple:
 
 	return (local_css_rules, duplicate_selectors)
 
+def files_not_in_spine(self) -> set:
+	"""
+	Check the spine against the actual files.
+
+	INPUTS
+	None
+
+	OUTPITS
+	Set of files not in the spine (typically an empty set)
+	"""
+
+	xhtml_files = set(self.path.glob("src/epub/**/*.xhtml"))
+	spine_files = set(self.spine_file_paths)
+	spine_files.add(self.toc_path)
+	return xhtml_files.difference(spine_files)
+
 def lint(self, skip_lint_ignore: bool, allowed_messages: List[str] = None) -> list:
 	"""
 	Check this ebook for some common SE style errors.


### PR DESCRIPTION
This implements a function that checks for differences between the spine and the actual markup files. If files are found in the file system that aren’t in the spine we can error early. `lint` and `build-ids` have been amended to error in this way.