### PR TITLE
Correct charabanc substitution

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -381,7 +381,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b([Ff])(aqu?ir|akeer)", r"\1akir", xhtml)			# faqir, fakeer -> fakir
 	xhtml = regex.sub(r"\b([Ii])maum", r"\1mam", xhtml)				# imaum -> imam
 	xhtml = regex.sub(r"\b([Mm])o?ujik", r"\1uzhik", xhtml)				# moujik/mujik -> muzhik
-	xhtml = regex.sub(r"\b([Cc])har[ -][aà][ -]banc", r"\1arabanc", xhtml)		# char-à-banc -> charabanc
+	xhtml = regex.sub(r"\b([Cc])har[ -][aà][ -]banc", r"\1harabanc", xhtml)		# char-à-banc -> charabanc
 	xhtml = regex.sub(r"’([Cc])ellist", r"\1ellist", xhtml)				# 'cellist -> cellist
 	xhtml = regex.sub(r"([Pp])ourtray", r"\1ortray", xhtml)				# pourtray -> portray
 	xhtml = regex.sub(r"([S])toopid", r"\1tupid", xhtml)				# stoopid -> stupid


### PR DESCRIPTION
The charabanc substitution has been missing the 'h' since it was put in. My corpus isn't completely up-to-date, so not sure of the existing impact.