### PR TITLE
Truncate repo name to 100 chars max during create-draft

### DIFF
--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -893,7 +893,7 @@ def _create_draft(args: Namespace):
 		metadata_xml = metadata_xml.replace("SE_IDENTIFIER", identifier)
 		metadata_xml = metadata_xml.replace(">TITLE_SORT<", f">{escape(sorted_title)}<")
 		metadata_xml = metadata_xml.replace(">TITLE<", f">{escape(title)}<")
-		metadata_xml = metadata_xml.replace("VCS_IDENTIFIER", str(repo_name))
+		metadata_xml = metadata_xml.replace("VCS_IDENTIFIER", str(repo_name[0:100]))
 
 		if pg_producers:
 			producers_xhtml = ""


### PR DESCRIPTION
Github has a limit of 100 characters for repo names. We currently lint for this, but don’t enforce this constraint during draft creation.