### PR TITLE
Add a shift-illustrations command

### DIFF
--- a/se/commands/shift_illustrations.py
+++ b/se/commands/shift_illustrations.py
@@ -1,0 +1,40 @@
+"""
+This module implements the `se shift-illustrations` command.
+"""
+
+import argparse
+
+import se
+from se.se_epub import SeEpub
+
+
+def shift_illustrations(plain_output: bool) -> int:
+	"""
+	Entry point for `se shift-illustrations`
+	"""
+
+	parser = argparse.ArgumentParser(description="Increment or decrement the specified illustration and all following illustrations by 1 or a specified amount.")
+	group = parser.add_mutually_exclusive_group(required=True)
+	group.add_argument("-d", "--decrement", action="store_true", help="decrement the target illustration number and all following illustrations")
+	group.add_argument("-i", "--increment", action="store_true", help="increment the target illustration number and all following illustrations")
+	parser.add_argument("-a", "--amount", metavar="NUMBER", dest="amount", default=1, type=se.is_positive_integer, help="the amount to increment or decrement by; defaults to 1")
+	parser.add_argument("target_illustration_number", metavar="ENDNOTE-NUMBER", type=se.is_positive_integer, help="the illustration number to start shifting at")
+	parser.add_argument("directory", metavar="DIRECTORY", help="a Standard Ebooks source directory")
+	args = parser.parse_args()
+
+	return_code = 0
+
+	try:
+		if args.increment:
+			step = args.amount
+		else:
+			step = args.amount * -1
+
+		se_epub = SeEpub(args.directory)
+		se_epub.shift_illustrations(args.target_illustration_number, step)
+
+	except se.SeException as ex:
+		se.print_error(ex, plain_output=plain_output)
+		return_code = ex.code
+
+	return return_code

--- a/se/completions/bash/se
+++ b/se/completions/bash/se
@@ -2,7 +2,7 @@ _se(){
 	COMPREPLY=()
 	local cur="${COMP_WORDS[COMP_CWORD]}"
 	local prev="${COMP_WORDS[COMP_CWORD-1]}"
-	local commands="--help --plain --version british2american build build-ids build-images build-manifest build-spine build-title build-toc clean compare-versions create-draft dec2roman extract-ebook find-mismatched-dashes find-mismatched-diacritics find-unusual-characters help hyphenate interactive-replace lint make-url-safe modernize-spelling prepare-release recompose-epub renumber-endnotes roman2dec semanticate shift-endnotes split-file titlecase typogrify unicode-names version word-count xpath"
+	local commands="--help --plain --version british2american build build-ids build-images build-manifest build-spine build-title build-toc clean compare-versions create-draft dec2roman extract-ebook find-mismatched-dashes find-mismatched-diacritics find-unusual-characters help hyphenate interactive-replace lint make-url-safe modernize-spelling prepare-release recompose-epub renumber-endnotes roman2dec semanticate shift-endnotes shift-illustrations split-file titlecase typogrify unicode-names version word-count xpath"
 	if [[ $COMP_CWORD -gt 1 ]]; then
 		case "${COMP_WORDS[1]}" in
 			british2american)

--- a/se/completions/fish/se.fish
+++ b/se/completions/fish/se.fish
@@ -1,6 +1,6 @@
 function __fish_se_no_subcommand --description "Test if se has yet to be given the subcommand"
 	for i in (commandline -opc)
-		if contains -- $i british2american build build-ids build-images build-manifest build-spine build-title build-toc clean compare-versions create-draft dec2roman extract-ebook find-mismatched-dashes find-mismatched-diacritics find-unusual-characters help hyphenate interactive-replace lint make-url-safe modernize-spelling prepare-release recompose-epub renumber-endnotes roman2dec semanticate shift-endnotes split-file titlecase typogrify unicode-names version word-count xpath
+		if contains -- $i british2american build build-ids build-images build-manifest build-spine build-title build-toc clean compare-versions create-draft dec2roman extract-ebook find-mismatched-dashes find-mismatched-diacritics find-unusual-characters help hyphenate interactive-replace lint make-url-safe modernize-spelling prepare-release recompose-epub renumber-endnotes roman2dec semanticate shift-endnotes shift-illustrations split-file titlecase typogrify unicode-names version word-count xpath
 			return 1
 		end
 	end
@@ -149,6 +149,11 @@ complete -c se -n "__fish_se_no_subcommand" -a shift-endnotes -d "Increment the 
 complete -c se -A -n "__fish_seen_subcommand_from shift-endnotes" -s d -l decrement -d "decrement the target endnote number and all following endnotes"
 complete -c se -A -n "__fish_seen_subcommand_from shift-endnotes" -s h -l help -x -d "show this help message and exit"
 complete -c se -A -n "__fish_seen_subcommand_from shift-endnotes" -s i -l increment -d "increment the target endnote number and all following endnotes"
+
+complete -c se -n "__fish_se_no_subcommand" -a shift-illustrations -d "Increment the specified illustration and all following illustrations by 1."
+complete -c se -A -n "__fish_seen_subcommand_from shift-illustrations" -s d -l decrement -d "decrement the target illustration number and all following illustrations"
+complete -c se -A -n "__fish_seen_subcommand_from shift-illustrations" -s h -l help -x -d "show this help message and exit"
+complete -c se -A -n "__fish_seen_subcommand_from shift-illustrations" -s i -l increment -d "increment the target illustration number and all following illustrations"
 
 complete -c se -n "__fish_se_no_subcommand" -a split-file -d "Split an XHTML file into many files."
 complete -c se -A -n "__fish_seen_subcommand_from split-file" -s f -l filename-format -d "a format string for the output files; `%n` is replaced with the current chapter number; defaults to `chapter-%n.xhtml`"

--- a/se/completions/zsh/_se
+++ b/se/completions/zsh/_se
@@ -40,6 +40,7 @@ case $state in
 			"roman2dec[Convert a Roman numeral to a decimal number.]" \
 			"semanticate[Apply some scriptable semantics rules from the Standard Ebooks semantics manual.]" \
 			"shift-endnotes[Increment the specified endnote and all following endnotes by 1.]" \
+			"shift-illustrations[Increment the specified illustration and all following illustrations by 1.]" \
 			"split-file[Split an XHTML file into many files.]" \
 			"titlecase[Convert a string to titlecase.]" \
 			"typogrify[Apply some scriptable typography rules from the Standard Ebooks typography manual to a Standard Ebook source directory.]" \


### PR DESCRIPTION
Basically a clone of shift-endnotes in functionality; it shifts illustrations up and down. Requires all illustrations to be named illustration-x, but that’s as per SEMOS. It’s extension agnostic.

I needed this locally for Beatrix Potter which is currently at ~580 images. I’ve found some more to add in at around the 120 mark, which would have meant a lot of manual work.