### PR TITLE
Fix line endings when running on Windows

### DIFF
--- a/se/commands/british2american.py
+++ b/se/commands/british2american.py
@@ -33,7 +33,7 @@ def british2american(plain_output: bool) -> int:
 			console.print(se.prep_output(f"Processing [path][link=file://{filename}]{filename}[/][/] ...", plain_output), end="")
 
 		try:
-			with open(filename, "r+", encoding="utf-8") as file:
+			with open(filename, "r+", encoding="utf-8", newline="\n") as file:
 				xhtml = file.read()
 				new_xhtml = xhtml
 

--- a/se/commands/build_ids.py
+++ b/se/commands/build_ids.py
@@ -63,7 +63,7 @@ def build_ids(plain_output: bool) -> int:
 
 						# If we changed this file, make sure to write it to disk
 						if write_to_disk:
-							with open(other_file, "w", encoding="utf-8") as file:
+							with open(other_file, "w", encoding="utf-8", newline="\n") as file:
 								file.write(other_file_dom.to_string())
 
 					id_counter = id_counter + 1
@@ -72,7 +72,7 @@ def build_ids(plain_output: bool) -> int:
 				replacements = replacements + se.formatting.find_unexpected_ids(dom)
 
 				# Write our wiped file, we'll update it later
-				with open(filename, "w", encoding="utf-8") as file:
+				with open(filename, "w", encoding="utf-8", newline="\n") as file:
 					file.write(dom.to_string())
 
 			# Now, actually perform the replacements
@@ -82,7 +82,7 @@ def build_ids(plain_output: bool) -> int:
 				files.append(se_epub.glossary_search_key_map_path)
 
 			for filename in files:
-				with open(filename, "r+", encoding="utf-8") as file:
+				with open(filename, "r+", encoding="utf-8", newline="\n") as file:
 					file_contents = file.read()
 
 					for node, new_id in replacements:

--- a/se/commands/build_manifest.py
+++ b/se/commands/build_manifest.py
@@ -60,7 +60,7 @@ def build_manifest(plain_output: bool) -> int:
 					for node in access_mode_sufficient_nodes:
 						node.remove()
 
-				with open(se_epub.metadata_file_path, "w", encoding="utf-8") as file:
+				with open(se_epub.metadata_file_path, "w", encoding="utf-8", newline="\n") as file:
 					file.write(se.formatting.format_xml(se_epub.metadata_dom.to_string()))
 
 		except se.SeException as ex:

--- a/se/commands/build_spine.py
+++ b/se/commands/build_spine.py
@@ -39,7 +39,7 @@ def build_spine(plain_output: bool) -> int:
 					for node in se_epub.metadata_dom.xpath("/package"):
 						node.append(se_epub.generate_spine())
 
-				with open(se_epub.metadata_file_path, "w", encoding="utf-8") as file:
+				with open(se_epub.metadata_file_path, "w", encoding="utf-8", newline="\n") as file:
 					file.write(se.formatting.format_xml(se_epub.metadata_dom.to_string()))
 
 		except se.SeException as ex:

--- a/se/commands/build_title.py
+++ b/se/commands/build_title.py
@@ -36,7 +36,7 @@ def build_title(plain_output: bool) -> int:
 
 	for filename in targets:
 		try:
-			with open(filename, "r+", encoding="utf-8") as file:
+			with open(filename, "r+", encoding="utf-8", newline="\n") as file:
 				dom = se.easy_xml.EasyXmlTree(file.read())
 
 				title = se.formatting.generate_title(dom)

--- a/se/commands/build_toc.py
+++ b/se/commands/build_toc.py
@@ -37,7 +37,7 @@ def build_toc(plain_output: bool) -> int:
 				print(se_epub.generate_toc())
 			else:
 				toc = se_epub.generate_toc()
-				with open(se_epub.toc_path, "w", encoding="utf-8") as file:
+				with open(se_epub.toc_path, "w", encoding="utf-8", newline="\n") as file:
 					file.write(toc)
 
 		except se.SeException as ex:

--- a/se/commands/clean.py
+++ b/se/commands/clean.py
@@ -27,7 +27,7 @@ def clean(plain_output: bool) -> int:
 			console.print(se.prep_output(f"Processing [path][link=file://{filepath}]{filepath}[/][/] ...", plain_output), end="")
 
 		if filepath.suffix == ".css":
-			with open(filepath, "r+", encoding="utf-8") as file:
+			with open(filepath, "r+", encoding="utf-8", newline="\n") as file:
 				css = file.read()
 
 				try:

--- a/se/commands/compare_versions.py
+++ b/se/commands/compare_versions.py
@@ -188,7 +188,7 @@ def compare_versions(plain_output: bool) -> int:
 						with importlib_resources.open_text("se.data.templates", "diff-template.html", encoding="utf-8") as file:
 							html = file.read().replace("<!--se:sections-->", html.strip())
 
-						with open(output_directory / "diff.html", "w") as file:
+						with open(output_directory / "diff.html", "w", newline="\n") as file:
 							file.write(html)
 	except KeyboardInterrupt as ex:
 		# Bubble the exception up, but proceed to `finally` so we quit the driver

--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -64,7 +64,7 @@ def _replace_in_file(file_path: Path, search: Union[str, list], replace: Union[s
 	Helper function to replace in a file.
 	"""
 
-	with open(file_path, "r+", encoding="utf-8") as file:
+	with open(file_path, "r+", encoding="utf-8", newline="\n") as file:
 		data = file.read()
 		processed_data = data
 
@@ -754,7 +754,7 @@ def _create_draft(args: Namespace):
 			output = pg_ebook_html
 
 		try:
-			with open(pg_file_local_path, "w", encoding="utf-8") as file:
+			with open(pg_file_local_path, "w", encoding="utf-8", newline="\n") as file:
 				file.write(output)
 		except OSError as ex:
 			raise se.InvalidFileException(f"Couldn’t write to ebook directory. Exception: {ex}")
@@ -793,7 +793,7 @@ def _create_draft(args: Namespace):
 	if not args.offline and title not in ("Short Fiction", "Poetry", "Essays", "Plays"):
 		ebook_wiki_url, _ = _get_wikipedia_url(title, False)
 
-	with open(content_path / "epub" / "text" / "titlepage.xhtml", "r+", encoding="utf-8") as file:
+	with open(content_path / "epub" / "text" / "titlepage.xhtml", "r+", encoding="utf-8", newline="\n") as file:
 		titlepage_xhtml = file.read()
 
 		titlepage_xhtml = titlepage_xhtml.replace("TITLE", escape(title))
@@ -823,11 +823,11 @@ def _create_draft(args: Namespace):
 		if illustrators:
 			contributors["illustrated by"] = _generate_contributor_string(illustrators, False)
 
-		with open(repo_path / "images" / "titlepage.svg", "w", encoding="utf-8") as file:
+		with open(repo_path / "images" / "titlepage.svg", "w", encoding="utf-8", newline="\n") as file:
 			file.write(_generate_titlepage_svg(title, [author["name"] for author in authors], contributors, title_string))
 
 		# Create the cover SVG
-		with open(repo_path / "images" / "cover.svg", "w", encoding="utf-8") as file:
+		with open(repo_path / "images" / "cover.svg", "w", encoding="utf-8", newline="\n") as file:
 			file.write(_generate_cover_svg(title, [author["name"] for author in authors], title_string))
 
 		# Build the cover/titlepage for distribution
@@ -839,7 +839,7 @@ def _create_draft(args: Namespace):
 			_replace_in_file(content_path / "epub" / "text" / "imprint.xhtml", "PG_URL", pg_url)
 
 		# Fill out the colophon
-		with open(content_path / "epub" / "text" / "colophon.xhtml", "r+", encoding="utf-8") as file:
+		with open(content_path / "epub" / "text" / "colophon.xhtml", "r+", encoding="utf-8", newline="\n") as file:
 			colophon_xhtml = file.read()
 
 			colophon_xhtml = colophon_xhtml.replace("SE_IDENTIFIER", identifier)
@@ -887,7 +887,7 @@ def _create_draft(args: Namespace):
 			file.truncate()
 
 	# Fill out the metadata file
-	with open(content_path / "epub" / "content.opf", "r+", encoding="utf-8") as file:
+	with open(content_path / "epub" / "content.opf", "r+", encoding="utf-8", newline="\n") as file:
 		metadata_xml = file.read()
 
 		metadata_xml = metadata_xml.replace("SE_IDENTIFIER", identifier)

--- a/se/commands/hyphenate.py
+++ b/se/commands/hyphenate.py
@@ -28,7 +28,7 @@ def hyphenate(plain_output: bool) -> int:
 		if args.verbose:
 			console.print(se.prep_output(f"Processing [path][link=file://{filename}]{filename}[/][/] ...", plain_output), end="")
 
-		with open(filename, "r+", encoding="utf-8") as file:
+		with open(filename, "r+", encoding="utf-8", newline="\n") as file:
 			xhtml = file.read()
 
 			is_ignored, dom = se.get_dom_if_not_ignored(xhtml, ["toc"])

--- a/se/commands/interactive_replace.py
+++ b/se/commands/interactive_replace.py
@@ -326,7 +326,7 @@ def interactive_replace(plain_output: bool) -> int: # pylint: disable=unused-arg
 
 					# Can't check is_file_dirty, we have to compare file contents
 					if xhtml != original_xhtml:
-						with open(filepath, "w", encoding="utf-8") as file:
+						with open(filepath, "w", encoding="utf-8", newline="\n") as file:
 							file.write(xhtml)
 
 					break
@@ -334,7 +334,7 @@ def interactive_replace(plain_output: bool) -> int: # pylint: disable=unused-arg
 				# Reject all remaining replacements and continue to the next file
 				if curses.keyname(char) in (b"r", b"R") or esc_pressed:
 					if is_file_dirty:
-						with open(filepath, "w", encoding="utf-8") as file:
+						with open(filepath, "w", encoding="utf-8", newline="\n") as file:
 							file.write(xhtml)
 
 					break
@@ -342,7 +342,7 @@ def interactive_replace(plain_output: bool) -> int: # pylint: disable=unused-arg
 				# Save this file and quit immediately
 				if curses.keyname(char) in (b"q", b"Q"):
 					if is_file_dirty:
-						with open(filepath, "w", encoding="utf-8") as file:
+						with open(filepath, "w", encoding="utf-8", newline="\n") as file:
 							file.write(xhtml)
 
 					# Throw a blank exception so that we break out of the loop
@@ -438,7 +438,7 @@ def interactive_replace(plain_output: bool) -> int: # pylint: disable=unused-arg
 						pad.refresh(pad_y, pad_x, 1, line_numbers_width, screen_height - 2, screen_width - 1)
 
 			if is_file_dirty:
-				with open(filepath, "w", encoding="utf-8") as file:
+				with open(filepath, "w", encoding="utf-8", newline="\n") as file:
 					file.write(xhtml)
 
 	except Exception as ex:

--- a/se/commands/modernize_spelling.py
+++ b/se/commands/modernize_spelling.py
@@ -29,7 +29,7 @@ def modernize_spelling(plain_output: bool) -> int:
 			console.print(se.prep_output(f"Processing [path][link=file://{filename}]{filename}[/][/] ...", plain_output), end="")
 
 		try:
-			with open(filename, "r+", encoding="utf-8") as file:
+			with open(filename, "r+", encoding="utf-8", newline="\n") as file:
 				xhtml = file.read()
 
 				try:

--- a/se/commands/recompose_epub.py
+++ b/se/commands/recompose_epub.py
@@ -26,7 +26,7 @@ def recompose_epub(plain_output: bool) -> int:
 		recomposed_epub = se_epub.recompose(args.xhtml, Path(args.extra_css_file) if args.extra_css_file else None)
 
 		if args.output:
-			with open(args.output, "w", encoding="utf-8") as file:
+			with open(args.output, "w", encoding="utf-8", newline="\n") as file:
 				file.write(recomposed_epub)
 		else:
 			print(recomposed_epub)

--- a/se/commands/semanticate.py
+++ b/se/commands/semanticate.py
@@ -28,7 +28,7 @@ def semanticate(plain_output: bool) -> int:
 			console.print(se.prep_output(f"Processing [path][link=file://{filename}]{filename}[/][/] ...", plain_output), end="")
 
 		try:
-			with open(filename, "r+", encoding="utf-8") as file:
+			with open(filename, "r+", encoding="utf-8", newline="\n") as file:
 				xhtml = file.read()
 
 				is_ignored, _ = se.get_dom_if_not_ignored(xhtml)

--- a/se/commands/split_file.py
+++ b/se/commands/split_file.py
@@ -25,7 +25,7 @@ def _split_file_output_file(filename_format_string: str, chapter_number: int, te
 	xhtml = xhtml.replace("NUMBER", str(chapter_number))
 	xhtml = xhtml.replace("TEXT", chapter_xhtml)
 
-	with open(filename, "w", encoding="utf-8") as file:
+	with open(filename, "w", encoding="utf-8", newline="\n") as file:
 		file.write(xhtml)
 
 def split_file(plain_output: bool) -> int:

--- a/se/commands/typogrify.py
+++ b/se/commands/typogrify.py
@@ -31,7 +31,7 @@ def typogrify(plain_output: bool) -> int:
 			console.print(se.prep_output(f"Processing [path][link=file://{filename}]{filename}[/][/] ...", plain_output), end="")
 
 		try:
-			with open(filename, "r+", encoding="utf-8") as file:
+			with open(filename, "r+", encoding="utf-8", newline="\n") as file:
 				xhtml = file.read()
 
 				is_ignored, dom = se.get_dom_if_not_ignored(xhtml, ["titlepage", "imprint", "copyright-page"])

--- a/se/epub.py
+++ b/se/epub.py
@@ -47,7 +47,7 @@ def convert_toc_to_ncx(epub_root_absolute_path: Path, toc_filename: str, xsl_fil
 		node.set_attr("playOrder", f"{count}")
 		count = count + 1
 
-	with open(epub_root_absolute_path / "epub" / "toc.ncx", "w", encoding="utf-8") as file:
+	with open(epub_root_absolute_path / "epub" / "toc.ncx", "w", encoding="utf-8", newline="\n") as file:
 		file.write(ncx_dom.to_string())
 
 	return toc_tree

--- a/se/formatting.py
+++ b/se/formatting.py
@@ -522,7 +522,7 @@ def format_xml_file(filename: Path) -> None:
 	None.
 	"""
 
-	with open(filename, "r+", encoding="utf-8") as file:
+	with open(filename, "r+", encoding="utf-8", newline="\n") as file:
 		xml = file.read()
 
 		if filename.suffix == ".xhtml":

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -756,7 +756,7 @@ class SeEpub:
 			for node in dom.xpath("/svg/style"):
 				node.set_text("\n\t\tpath{\n\t\t\tfill: #fff;\n\t\t}\n\n\t\t.title-box{\n\t\t\tfill: #000;\n\t\t\tfill-opacity: .75;\n\t\t}\n\t")
 
-			with open(dest_cover_svg_filename, "w", encoding="utf-8") as file:
+			with open(dest_cover_svg_filename, "w", encoding="utf-8", newline="\n") as file:
 				file.write(dom.to_string())
 
 	def shift_endnotes(self, target_endnote_number: int, step: int = 1) -> None:
@@ -800,7 +800,7 @@ class SeEpub:
 
 		# Write the endnotes file
 		try:
-			with open(self.endnotes_path, "w", encoding="utf-8") as file:
+			with open(self.endnotes_path, "w", encoding="utf-8", newline="\n") as file:
 				file.write(dom.to_string())
 
 		except Exception as ex:
@@ -824,7 +824,7 @@ class SeEpub:
 					node.set_attr("href", regex.sub(fr"#note-{endnote_number}$", f"#note-{new_endnote_number}", node.get_attr("href")))
 					node.set_text(regex.sub(fr"\b{endnote_number}\b", f"{new_endnote_number}", node.text))
 
-			with open(file_path, "w", encoding="utf-8") as file:
+			with open(file_path, "w", encoding="utf-8", newline="\n") as file:
 				file.write(dom.to_string())
 
 	def shift_illustrations(self, target_illustration_number: int, step: int = 1) -> None:
@@ -884,7 +884,7 @@ class SeEpub:
 
 		# Write the LoI file
 		try:
-			with open(self.loi_path, "w", encoding="utf-8") as file:
+			with open(self.loi_path, "w", encoding="utf-8", newline="\n") as file:
 				file.write(dom.to_string())
 
 		except Exception as ex:
@@ -902,7 +902,7 @@ class SeEpub:
 					for img in node.xpath("./img"):
 						img.set_attr("src", img.get_attr("src").replace(f"illustration-{illustration_number}", f"illustration-{new_illustration_number}"))
 
-			with open(file_path, "w", encoding="utf-8") as file:
+			with open(file_path, "w", encoding="utf-8", newline="\n") as file:
 				file.write(dom.to_string())
 
 	def set_release_timestamp(self) -> None:
@@ -923,7 +923,7 @@ class SeEpub:
 			for node in self.metadata_dom.xpath("/package/metadata/meta[@property='dcterms:modified']"):
 				node.set_text(now_iso)
 
-			with open(self.metadata_file_path, "w", encoding="utf-8") as file:
+			with open(self.metadata_file_path, "w", encoding="utf-8", newline="\n") as file:
 				file.write(self.metadata_dom.to_string())
 
 			for file_path in self.content_path.glob("**/*.xhtml"):
@@ -933,7 +933,7 @@ class SeEpub:
 					for node in dom.xpath("/html/body/section[contains(@epub:type, 'colophon')]//b[contains(text(), 'January 1, 1900')]"):
 						node.replace_with(se.easy_xml.EasyXmlElement(etree.fromstring(str.encode("<b>" + now_friendly + "</b>"))))
 
-					with open(file_path, "w", encoding="utf-8") as file:
+					with open(file_path, "w", encoding="utf-8", newline="\n") as file:
 						file.write(dom.to_string())
 
 	def update_flesch_reading_ease(self) -> None:
@@ -961,7 +961,7 @@ class SeEpub:
 		for node in self.metadata_dom.xpath("/package/metadata/meta[@property='se:reading-ease.flesch']"):
 			node.set_text(str(se.formatting.get_flesch_reading_ease(text)))
 
-		with open(self.metadata_file_path, "w", encoding="utf-8") as file:
+		with open(self.metadata_file_path, "w", encoding="utf-8", newline="\n") as file:
 			file.write(self.metadata_dom.to_string())
 
 	def get_word_count(self) -> int:
@@ -1002,7 +1002,7 @@ class SeEpub:
 		for node in self.metadata_dom.xpath("/package/metadata/meta[@property='se:word-count']"):
 			node.set_text(str(self.get_word_count()))
 
-		with open(self.metadata_file_path, "r+", encoding="utf-8") as file:
+		with open(self.metadata_file_path, "r+", encoding="utf-8", newline="\n") as file:
 			file.seek(0)
 			file.write(self.metadata_dom.to_string())
 			file.truncate()
@@ -1353,7 +1353,7 @@ class SeEpub:
 
 				current_note_number += 1
 
-			with open(file_path, "w") as file:
+			with open(file_path, "w", newline="\n") as file:
 				file.write(dom.to_string())
 
 		# Renumber all endnotes starting from 1
@@ -1367,7 +1367,7 @@ class SeEpub:
 
 			current_note_number += 1
 
-		with open(self.endnotes_path, "w") as file:
+		with open(self.endnotes_path, "w", newline="\n") as file:
 			file.write(endnotes_dom.to_string())
 
 	def generate_endnotes(self) -> Tuple[int, int, list]:
@@ -1406,7 +1406,7 @@ class SeEpub:
 
 			# If we need to write back the body text file
 			if needs_rewrite:
-				with open(file_path, "w") as file:
+				with open(file_path, "w", newline="\n") as file:
 					file.write(se.formatting.format_xhtml(dom.to_string()))
 
 		# Now process any endnotes WITHIN the endnotes
@@ -1438,7 +1438,7 @@ class SeEpub:
 
 						ol_node.append(endnote.node)
 
-			with open(self.endnotes_path, "w") as file:
+			with open(self.endnotes_path, "w", newline="\n") as file:
 				file.write(se.formatting.format_xhtml(endnotes_dom.to_string()))
 
 			# now trawl through the body files to locate any direct links to endnotes (not in an actual endnote reference)
@@ -1450,7 +1450,7 @@ class SeEpub:
 				for link in dom.xpath("/html/body//a[contains(@href, 'endnotes.xhtml#note-')]"):
 					needs_rewrite = self.__process_direct_link(change_list, link)
 				if needs_rewrite:
-					with open(file_path, "w") as file:
+					with open(file_path, "w", newline="\n") as file:
 						file.write(se.formatting.format_xhtml(dom.to_string()))
 
 		return current_note_number - 1, notes_changed, change_list

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -199,11 +199,11 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 					for node in metadata_dom.xpath("//meta[@property='dcterms:modified']"):
 						node.set_text(last_updated_iso)
 
-					with open(work_compatible_epub_dir / "epub" / self.metadata_file_path.name, "w", encoding="utf-8") as file:
+					with open(work_compatible_epub_dir / "epub" / self.metadata_file_path.name, "w", encoding="utf-8", newline="\n") as file:
 						file.write(metadata_dom.to_string())
 
 					# Update the colophon with release info
-					with open(file_path, "r+", encoding="utf-8") as file:
+					with open(file_path, "r+", encoding="utf-8", newline="\n") as file:
 						xhtml = file.read()
 
 						xhtml = xhtml.replace("<p>The first edition of this ebook was released on<br/>", f"<p>This edition was released on<br/>\n\t\t\t<b>{last_updated_friendly}</b><br/>\n\t\t\tand is based on<br/>\n\t\t\t<b>revision {self.last_commit.short_sha}</b>.<br/>\n\t\t\tThe first edition of this ebook was released on<br/>")
@@ -232,7 +232,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 		# Simplify the CSS first.  Later we'll update the document to match our simplified selectors.
 		# While we're doing this, we store the original css into a single variable so we can extract the original selectors later.
 		for file_path in work_compatible_epub_dir.glob("**/*.css"):
-			with open(file_path, "r+", encoding="utf-8") as file:
+			with open(file_path, "r+", encoding="utf-8", newline="\n") as file:
 				css = file.read()
 
 				total_css = total_css + css + "\n"
@@ -418,7 +418,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 							element.lxml_element.insert(0, fragment)
 
 					# All done, write the SVG so that we can convert to PNG
-					with open(file_path, "w", encoding="utf-8") as file:
+					with open(file_path, "w", encoding="utf-8", newline="\n") as file:
 						file.write(dom.to_string())
 
 				# Convert SVGs to PNGs at 2x resolution
@@ -568,14 +568,14 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 				# while replacements > 0:
 				# 	processed_xhtml, replacements = regex.subn(r"<title>([^<>]+?)<span class=\"quote-align\">([^<>]+?)</span>", r"""<title>\1\2""", processed_xhtml)
 
-				with open(file_path, "w", encoding="utf-8") as file:
+				with open(file_path, "w", encoding="utf-8", newline="\n") as file:
 					file.write(processed_xhtml)
 
 				# Since we changed the dom string using regex, we have to flush its cache entry so we can re-build it later
 				self.flush_dom_cache_entry(file_path)
 
 			if file_path.suffix == ".css":
-				with open(file_path, "r+", encoding="utf-8") as file:
+				with open(file_path, "r+", encoding="utf-8", newline="\n") as file:
 					css = file.read()
 					processed_css = css
 
@@ -661,7 +661,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 					endnotes_id_map[node.get_attr("id")] = new_filename
 
 				# Write the new file
-				with open(endnote_file.parent / new_filename, "w", encoding="utf-8") as file:
+				with open(endnote_file.parent / new_filename, "w", encoding="utf-8", newline="\n") as file:
 					file.write(current_endnotes_file.to_string())
 
 				# Update the manifest and spine
@@ -695,15 +695,15 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 					has_anchor = True
 
 				if has_anchor:
-					with open(file_path, "w", encoding="utf-8") as file:
+					with open(file_path, "w", encoding="utf-8", newline="\n") as file:
 						file.write(dom.to_string())
 
 			# Output the modified the ToC file
-			with open(work_compatible_epub_dir / "epub" / toc_relative_path, "w", encoding="utf-8") as file:
+			with open(work_compatible_epub_dir / "epub" / toc_relative_path, "w", encoding="utf-8", newline="\n") as file:
 				file.write(se.formatting.format_xhtml(toc_dom.to_string()))
 
 		# Output the modified the metadata file so that we can build the kobo book before making more compatibility hacks that aren’t needed on that platform.
-		with open(work_compatible_epub_dir / "epub" / self.metadata_file_path.name, "w", encoding="utf-8") as file:
+		with open(work_compatible_epub_dir / "epub" / self.metadata_file_path.name, "w", encoding="utf-8", newline="\n") as file:
 			file.write(se.formatting.format_xhtml(metadata_dom.to_string()))
 
 		if build_kobo:
@@ -718,7 +718,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 					for node in dom.xpath("/package[contains(@prefix, 'se:')]/metadata"):
 						node.append(etree.fromstring("""<meta property="se:transform">kobo</meta>"""))
 
-					with open(file_path, "w", encoding="utf-8") as file:
+					with open(file_path, "w", encoding="utf-8", newline="\n") as file:
 						file.write(dom.to_string())
 
 				# Kobo .kepub files need each clause wrapped in a special <span> tag to enable highlighting.
@@ -790,11 +790,11 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 					xhtml = xhtml.replace(" xmlns:html=\"http://www.w3.org/1999/xhtml\"", "")
 					xhtml = regex.sub(r"<(/?)html:span", r"<\1span", xhtml)
 
-					with open(file_path, "w", encoding="utf-8") as file:
+					with open(file_path, "w", encoding="utf-8", newline="\n") as file:
 						file.write(xhtml)
 
 				if file_path.suffix == ".css":
-					with open(file_path, "r+", encoding="utf-8") as file:
+					with open(file_path, "r+", encoding="utf-8", newline="\n") as file:
 						css = file.read()
 						processed_css = css
 
@@ -819,7 +819,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 
 		# Recurse over css files to make some compatibility replacements.
 		for file_path in work_compatible_epub_dir.glob("**/*.css"):
-			with open(file_path, "r+", encoding="utf-8") as file:
+			with open(file_path, "r+", encoding="utf-8", newline="\n") as file:
 				css = file.read()
 				processed_css = css
 
@@ -1009,7 +1009,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 						# Update the metadata file to remove the `mathml` property
 						metadata_item_node.remove_attr_value("properties", "mathml")
 
-					with open(filename, "w", encoding="utf-8") as file:
+					with open(filename, "w", encoding="utf-8", newline="\n") as file:
 						file.write(dom.to_string())
 
 			except KeyboardInterrupt as ex:
@@ -1082,7 +1082,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 
 		# Guide is done, now write the metadata file and clean it.
 		# Output the modified metadata file before making more compatibility hacks.
-		with open(work_compatible_epub_dir / "epub" / self.metadata_file_path.name, "w", encoding="utf-8") as file:
+		with open(work_compatible_epub_dir / "epub" / self.metadata_file_path.name, "w", encoding="utf-8", newline="\n") as file:
 			file.write(se.formatting.format_opf(metadata_dom.to_string()))
 
 		# All done, clean the output
@@ -1264,7 +1264,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 
 		if build_kindle:
 			# Kindle doesn't go more than 2 levels deep for ToC, so flatten it here.
-			with open(work_compatible_epub_dir / "epub" / toc_filename, "r+", encoding="utf-8") as file:
+			with open(work_compatible_epub_dir / "epub" / toc_filename, "r+", encoding="utf-8", newline="\n") as file:
 				dom = se.easy_xml.EasyXmlTree(file.read())
 
 				for node in dom.xpath("//ol/li/ol/li/ol"):
@@ -1364,7 +1364,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 				if not dom.xpath("/html[re:test(@epub:prefix, '[\\s\\b]se:[\\s\\b]')]/body/nav[contains(@epub:type, 'toc')]"):
 					xhtml = se.typography.hyphenate(xhtml, None, True)
 
-				with open(file_path, "w", encoding="utf-8") as file:
+				with open(file_path, "w", encoding="utf-8", newline="\n") as file:
 					file.write(se.formatting.format_xhtml(xhtml))
 
 			# Include compatibility CSS

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -102,7 +102,7 @@ def output_is_golden(out: str, golden_file: Path, update_golden: bool) ->bool:
 	__tracebackhide__ = True # pylint: disable=unused-variable
 
 	if update_golden:
-		with open(golden_file, "w") as file:
+		with open(golden_file, "w", newline="\n") as file:
 			file.write(out)
 
 	# Output of stdout should match expected output


### PR DESCRIPTION
Files are currently created with `\r\n` line endings on Windows, so this forces the use of `\n`.
No impact for other platforms as they already use `\n`.