### PR TITLE
Simplify and improve regex for checking punctuation inside em tags

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -1537,9 +1537,8 @@ def lint(self, skip_lint_ignore: bool, allowed_messages: List[str] = None) -> li
 
 					# ...and also check for ending punctuation inside em tags, if it looks like a *part* of a clause
 					# instead of a whole clause. If the <em> is preceded by an em dash or quotes, or if there's punctuation
-					# and a space bofore it, then it's presumed to be a whole clause.
-					# We can't use xpath for this one because xpath's regex engine doesn't seem to work with {1,2}
-					matches = matches + [match.strip() for match in regex.findall(r"(?<!.[—“‘>]|[!\.\?…;:]\s)<em>(?:\w+?\s*)+[\.,\!\?;]</em>", file_contents) if match.islower()]
+					# and a space before it, then it's presumed to be a whole clause.
+					matches = matches + [match.strip() for match in regex.findall(r"(?<!.[—“‘>]|[!\.\?…;:]\s)<em>(?:\w+.*?)[\.,\!\?;]</em>", file_contents) if match.islower()]
 
 					if matches:
 						messages.append(LintMessage("t-017", "Ending punctuation inside formatting like bold, small caps, or italics. Ending punctuation is only allowed within formatting if the phrase is an independent clause.", se.MESSAGE_TYPE_WARNING, filename, list(set(matches))))


### PR DESCRIPTION
François ran into an issue with lint running extremely long (he killed it after 10 minutes) when a long (45-50 characters) made-up word was wrapped in an `<em>` tag. It ran fine if it was an `<i>` tag.

Robin and I looked into it independently, and both confirmed that it was the regex that was checking for punctuation inside an `<em>` tag that was the problem, and the problem was due to insane amounts of recursion in the `(?:\w+?\s*)+` part of the regex. Robin found that lint choked after 26 characters inside the tag; I tested it in my text editor and it choked after 24. (My editor's limit is 10,000,000 recursions; that's what I mean by "insane".)

After looking at what the regex is doing (or at least what I think it's doing), this is what I wrote on the email thread:
>The zero or more spaces means we want to allow spaces, not just \w characters, but we don’t care if we don’t have one (as in the problem-causing word). What if we unwind it a bit? look just for a string of w+; what’s after that we really don’t care about.

>And I really don’t think we care, i.e. we’re currently checking only for word characters and spaces, but I don’t think we should be. Why wouldn’t we allow em-dashes or regular dashes (hyphens), and so on? IOW, if `<em>A hyphenated-word and other words,</em>` was the string, the regex doesn't match, but I believe it should. (That comma should not be inside the `</em>`.)

>So, I think the regex can be something like `(?:\w+.*?)` Essentially, we want some word characters (and I don’t see a need for a limiter there, i.e. a question-mark), but we don’t care what else is in there. (In this case I’m assuming we want it to start with word characters, which seems reasonable, given that we’ve already eliminated ones that start with quotes, etc.) The last question-mark should keep it from eating the punctuation characters we’re looking for at the end, i.e. what’s in the character class that follows this subexpression. That regex works with the problem word, with or without a comma at the end, and with or without em-dashes and word-joiners and other regularly-found characters within the string.

I ran a parallel `se lint` on the corpus; it did not get through the entire corpus, but it finished a couple of hundred before it ran out of file handles. There were no false positives, and it did find a few that the old regex did not find for the reasons stated above, e.g. `<em>don’t!</em>` and `<em>not less than five-and-twenty degrees!</em>`.

So, I _believe_ this is a good fix for the recursion problem, as well as making it more robust.