### PR TITLE
Update "Inclose"

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -220,8 +220,8 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b([Uu])nburthen", r"\1nburden", xhtml)			# unburthen -> unburden
 	xhtml = regex.sub(r"\b[EÉ]lys[eé]e", r"Élysée", xhtml)				# Elysee -> Élysée
 	xhtml = regex.sub(r"\b([Ll])aw suit", r"\1awsuit", xhtml)			# law suit -> lawsuit
-	xhtml = regex.sub(r"\bIncase", r"Encase", xhtml)				# Incase -> Encase
-	xhtml = regex.sub(r"\bincase", r"encase", xhtml)				# incase -> encase
+	xhtml = regex.sub(r"\bIncas(es?|ed|ing)", r"Encase", xhtml)			# Incase -> Encase
+	xhtml = regex.sub(r"\bincas(es?|ed|ing)", r"encase", xhtml)			# incase -> encase
 	xhtml = regex.sub(r"\bInclos(es?|ed?|ures?|ing)\b", r"Enclos\1", xhtml)		# Inclose -> Enclose
 	xhtml = regex.sub(r"\binclos(es?|ed?|ures?|ing)\b", r"enclos\1", xhtml)		# inclose -> enclose
 	xhtml = regex.sub(r"\b([Cc])ocoa[ -]?nut", r"\1oconut", xhtml)			# cocoanut / cocoa-nut -> coconut

--- a/se/spelling.py
+++ b/se/spelling.py
@@ -220,8 +220,8 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b([Uu])nburthen", r"\1nburden", xhtml)			# unburthen -> unburden
 	xhtml = regex.sub(r"\b[EÉ]lys[eé]e", r"Élysée", xhtml)				# Elysee -> Élysée
 	xhtml = regex.sub(r"\b([Ll])aw suit", r"\1awsuit", xhtml)			# law suit -> lawsuit
-	xhtml = regex.sub(r"\bIncas(es?|ed|ing)", r"Encase", xhtml)			# Incase -> Encase
-	xhtml = regex.sub(r"\bincas(es?|ed|ing)", r"encase", xhtml)			# incase -> encase
+	xhtml = regex.sub(r"\bIncas(es?|ed|ing)", r"Encas\1", xhtml)			# Incase -> Encase
+	xhtml = regex.sub(r"\bincas(es?|ed|ing)", r"encas\1", xhtml)			# incase -> encase
 	xhtml = regex.sub(r"\bInclos(es?|ed?|ures?|ing)\b", r"Enclos\1", xhtml)		# Inclose -> Enclose
 	xhtml = regex.sub(r"\binclos(es?|ed?|ures?|ing)\b", r"enclos\1", xhtml)		# inclose -> enclose
 	xhtml = regex.sub(r"\b([Cc])ocoa[ -]?nut", r"\1oconut", xhtml)			# cocoanut / cocoa-nut -> coconut

--- a/se/spelling.py
+++ b/se/spelling.py
@@ -222,8 +222,8 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b([Ll])aw suit", r"\1awsuit", xhtml)			# law suit -> lawsuit
 	xhtml = regex.sub(r"\bIncase", r"Encase", xhtml)				# Incase -> Encase
 	xhtml = regex.sub(r"\bincase", r"encase", xhtml)				# incase -> encase
-	xhtml = regex.sub(r"\bInclose", r"Enclose", xhtml)				# Inclose -> Enclose
-	xhtml = regex.sub(r"\binclose", r"enclose", xhtml)				# inclose -> enclose
+	xhtml = regex.sub(r"\bInclos(es?|ed?|ures?|ing)\b", r"Enclos\1", xhtml)		# Inclose -> Enclose
+	xhtml = regex.sub(r"\binclos(es?|ed?|ures?|ing)\b", r"enclos\1", xhtml)		# inclose -> enclose
 	xhtml = regex.sub(r"\b([Cc])ocoa[ -]?nut", r"\1oconut", xhtml)			# cocoanut / cocoa-nut -> coconut
 	xhtml = regex.sub(r"\b([Ww])aggon", r"\1agon", xhtml)				# waggon -> wagon
 	xhtml = regex.sub(r"\b([Ss])wop", r"\1wap", xhtml)				# swop -> swap


### PR DESCRIPTION
Currently 'Inclose' creates inconsistencies after modernizing spelling - A text will get updated to 'enclose' but still have 'inclosure'.

Modified the regex to capture the -ure, -ures, and -ing forms of the word (making sure the standard and -ed and -es forms still work)