### PR TITLE
modernize-spelling: lagune -> lagoon

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -422,6 +422,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b([Ss])pight", r"\1pite", xhtml)				# spight -> spite
 	xhtml = regex.sub(r"\b([Ss])tedfast", r"\1teadfast", xhtml)			# stedfast -> steadfast
 	xhtml = regex.sub(r"\b([Rr])elique", r"\1elic", xhtml)				# relique -> relic
+	xhtml = regex.sub(r"\b([Ll])agune", r"\1agoon", xhtml)				# lagune -> lagoon
 
 	# Normalize some names
 	xhtml = regex.sub(r"Moliere", r"Molière", xhtml)				# Moliere -> Molière

--- a/se/spelling.py
+++ b/se/spelling.py
@@ -491,6 +491,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = xhtml.replace("Œdip", r"Oedip") # Oedipus, Oedipal
 	xhtml = regex.sub(r"\b([Pp])æan", r"\1aean", xhtml)
 	xhtml = regex.sub(r"\b([Vv])ertebræ", r"\1ertebrae", xhtml)
+	xhtml = xhtml.replace("Linnæus", r"Linnaeus")
 
 	# Remove spaces before contractions like `n’t` e.g. `is n’t` -> `isn’t`
 	xhtml = regex.sub(r" n’t\b", r"n’t", xhtml)


### PR DESCRIPTION
[MW](https://www.merriam-webster.com/dictionary/lagune) confirms that lagune is a variant spelling of "lagoon"
[ngrams](https://books.google.com/ngrams/graph?content=lagune%2Clagoon&year_start=1800&year_end=2019&corpus=26&smoothing=3) indicates that "lagune" was uncommon even in the 19th century

Also modernize use of ligature in "Linnaeus"