### PR TITLE
Bump dependencies to as far as we can go with Python 3.6

### DIFF
--- a/.github/workflows/se-test.yml
+++ b/.github/workflows/se-test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install pipx packages
       run: |
         pipx install .
-        pipx inject standardebooks pylint==2.8.2 pytest==6.2.4 mypy==0.812
+        pipx inject standardebooks pylint==2.8.2 pytest==7.0.1 mypy==0.812
     - name: Check type annotations with mypy
       run: $PIPX_HOME/venvs/standardebooks/bin/mypy
     - name: Check code with pylint

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ $HOME/.local/pipx/venvs/standardebooks/bin/pylint se
 Similar to `pylint`, the `pytest` command can be injected into the venv `pipx` created for the `standardebooks` package:
 
 ```shell
-pipx inject standardebooks pytest==6.2.4
+pipx inject standardebooks pytest==7.0.1
 ```
 
 The tests are executed by calling `pytest` from the top level or your tools repo:

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
 		"pillow==8.4.0", # Must stay at this version until the server can use Python >= 3.7
 		"psutil==5.9.4",
 		"pyphen==0.11.0", # Must stay at this version until the server can use Python >= 3.7
-		"regex==2021.08.28",
+		"regex==2022.10.31",
 		"requests==2.27.1", # Must stay at this version until the server can use Python >= 3.7
 		"rich==12.6.0", # Must stay at this version until the server can use Python >= 3.7
 		"roman==3.3.0",

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
 		"smartypants==2.0.1",
 		"tinycss2==1.1.1", # Must stay at this version until the server can use Python >= 3.7
 		"titlecase==2.3", # Must stay at this version until the server can use Python >= 3.7
-		"unidecode==1.2.0"
+		"unidecode==1.3.6"
 	],
 	include_package_data=True,
 	entry_points={

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
 	python_requires=">=3.6.*", # The latest version installed by default on Ubuntu 18.04 is 3.6.9
 	install_requires=[
 		"cairosvg==2.5.2",
-		"chardet==5.0.0", # Must stay at this version until the server can use Python >= 3.7
+		"chardet==4.0.0", # Must stay at this version until `requests` can be updated
 		"cssselect==1.1.0", # Must stay at this version until the server can use Python >= 3.7
 		"cssutils==2.3.0", # Must stay at this version until the server can use Python >= 3.7
 		"ftfy==6.0.3", # Must stay at this version until the server can use Python >= 3.7

--- a/setup.py
+++ b/setup.py
@@ -59,25 +59,25 @@ setup(
 	python_requires=">=3.6.*", # The latest version installed by default on Ubuntu 18.04 is 3.6.9
 	install_requires=[
 		"cairosvg==2.5.2",
-		"chardet==4.0.0",
-		"cssselect==1.1.0",
-		"cssutils==2.3.0",
-		"ftfy==6.0.3",
+		"chardet==5.0.0", # Must stay at this version until the server can use Python >= 3.7
+		"cssselect==1.1.0", # Must stay at this version until the server can use Python >= 3.7
+		"cssutils==2.3.0", # Must stay at this version until the server can use Python >= 3.7
+		"ftfy==6.0.3", # Must stay at this version until the server can use Python >= 3.7
 		"gitpython==3.1.11", # Must stay at this version until the server can use Python >= 3.7
 		"importlib_resources==1.0.2",
-		"lxml==4.9.1",
-		"natsort==7.1.1",
-		"pillow==8.4.0", # 9.0.0 isn't compatible with the version of Python on Ubuntu 18.04
-		"psutil==5.8.0",
-		"pyphen==0.11.0",
+		"lxml==4.9.2",
+		"natsort==7.1.1", # Can't update until we update mypy to 900+
+		"pillow==8.4.0", # Must stay at this version until the server can use Python >= 3.7
+		"psutil==5.9.4",
+		"pyphen==0.11.0", # Must stay at this version until the server can use Python >= 3.7
 		"regex==2021.08.28",
-		"requests==2.26.0",
-		"rich==10.9.0",
+		"requests==2.27.1", # Must stay at this version until the server can use Python >= 3.7
+		"rich==12.6.0", # Must stay at this version until the server can use Python >= 3.7
 		"roman==3.3.0",
-		"selenium==3.141.0",
+		"selenium==3.141.0", # Must stay at this version until the server can use Python >= 3.7
 		"smartypants==2.0.1",
-		"tinycss2==1.1.0",
-		"titlecase==2.3",
+		"tinycss2==1.1.1", # Must stay at this version until the server can use Python >= 3.7
+		"titlecase==2.3", # Must stay at this version until the server can use Python >= 3.7
 		"unidecode==1.2.0"
 	],
 	include_package_data=True,


### PR DESCRIPTION
A lot of our dependencies no longer support Python 3.6. Where this is the case, I’ve bumped them to that version and noted it with a comment. The only dependency that we can’t push to latest-or-3.6-compatible-version is chardet, where v5.0.0 isn’t compatible with the latest version of requests that we can go to.

I’ve tested these changes by running the test suite, and linting and building several productions.