### PR TITLE
Fix manœuvred -> maneuvered / manoeuvred

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -523,9 +523,11 @@ def modernize_spelling(xhtml: str) -> str:
 
 	# US spelling is unique
 	if language == "en-US":
+		xhtml = regex.sub(r"\b([Mm])anœuvred", r"\1aneuvered", xhtml)
 		xhtml = regex.sub(r"\b([Mm])anœuv(?:er|re)", r"\1aneuver", xhtml) # Omit last letter to catch both maneuverS and maneuverING
 		xhtml = regex.sub(r"\b([Mm])anœuvering", r"\1aneuvering", xhtml)
 	else:
+		xhtml = regex.sub(r"\b([Mm])anœuvred", r"\1anoeuvred", xhtml)
 		xhtml = regex.sub(r"\b([Mm])anœuv(?:er|re)", r"\1anoeuvre", xhtml)
 		xhtml = regex.sub(r"\b([Mm])anœuvring", r"\1anoeuvring", xhtml)
 		xhtml = regex.sub(r"\b([Mm])anoeuvreing", r"\1anoeuvring", xhtml)

--- a/tests/data/modernize-spelling/in/spelling_en_GB.xhtml
+++ b/tests/data/modernize-spelling/in/spelling_en_GB.xhtml
@@ -8,7 +8,7 @@
 	<body epub:type="bodymatter z3998:fiction">
 		<section id="chapter-1" epub:type="chapter">
 			<h2 epub:type="title">A Dreary Story</h2>
-			<p>Raffaelle expected a cosey manœuvre.</p>
+			<p>Raffaelle manœuvred to be cosey.</p>
 		</section>
 	</body>
 </html>

--- a/tests/data/modernize-spelling/out/spelling_en_GB.xhtml
+++ b/tests/data/modernize-spelling/out/spelling_en_GB.xhtml
@@ -8,7 +8,7 @@
 	<body epub:type="bodymatter z3998:fiction">
 		<section id="chapter-1" epub:type="chapter">
 			<h2 epub:type="title">A Dreary Story</h2>
-			<p>Raphael expected a cosy manoeuvre.</p>
+			<p>Raphael manoeuvred to be cosy.</p>
 		</section>
 	</body>
 </html>


### PR DESCRIPTION
I think this is the cleanest way of doing it.

There are a couple of instances of “maneuverd” in the corpus:

- https://github.com/standardebooks/henry-david-thoreau_essays/blob/f90bf024a96dcb289044357410cea3e625a5fe01/src/epub/text/chesuncook.xhtml#L72
- https://github.com/standardebooks/f-scott-fitzgerald_this-side-of-paradise/blob/c4113f15ee334f8d4c4bac5ca1be469f945421d1/src/epub/text/chapter-1-2.xhtml#L329