### PR TITLE
modernize-spelling: Chili -> Chile

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -482,6 +482,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"[YJ]edd?o\b", r"Edo", xhtml)				# Yeddo/Jeddo -> Edo
 	xhtml = regex.sub(r"Pesth\b", r"Pest", xhtml)					# Pesth -> Pest, i.e. Buda-Pest
 	xhtml = regex.sub(r"Buda-Pest\b", r"Budapest", xhtml)				# Buda-Pest -> Budapest
+	xhtml = regex.sub(r"Chili(\b|an\b)\b", r"Chile\1", xhtml)				# Chili -> Chile
 
 	# Remove archaic diphthongs
 	xhtml = regex.sub(r"\b([Mm])edi(æ|ae)val", r"\1edieval", xhtml)


### PR DESCRIPTION
Also Chilian -> Chilean. Fixes https://github.com/standardebooks/tools/issues/573.