### PR TITLE
Switch chapter template to defalt to en-GB

### DIFF
--- a/se/data/templates/chapter-template.xhtml
+++ b/se/data/templates/chapter-template.xhtml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-US">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
 	<head>
 		<title>NUMERAL</title>
 		<link href="../css/core.css" rel="stylesheet" type="text/css"/>


### PR DESCRIPTION
We default content.opf to en-GB, but the chapter template is en-US. I've always wondered why they're not the same.
I just checked and we have over twice as many en-GB books in the corpus as en-US, so it seems to make sense to me to default both of them to en-GB. It eliminates a step to be performed in the large majority of our books.