### PR TITLE
Fix mypy on Macs

### DIFF
--- a/.github/workflows/se-test.yml
+++ b/.github/workflows/se-test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install pipx packages
       run: |
         pipx install .
-        pipx inject standardebooks pylint==2.8.2 pytest==7.0.1 mypy==0.812
+        pipx inject standardebooks pylint==2.17.3 pytest==7.3.1 mypy==1.2.0 types-requests==2.28.11.17 types-setuptools==67.7.0.0
     - name: Check type annotations with mypy
       run: $PIPX_HOME/venvs/standardebooks/bin/mypy
     - name: Check code with pylint

--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ We export `COLUMNS` because `se lint` needs to know the width of the terminal so
 
 ### Linting with `pylint` and `mypy`
 
-Before we can use `pylint` or `mypy` on the toolset source, we have to inject them into the venv `pipx` created for the `standardebooks` package:
+Before we can use `pylint` or `mypy` on the toolset source, we have to inject them (and additional typings) into the venv `pipx` created for the `standardebooks` package:
 
 ```shell
-pipx inject standardebooks pylint==2.8.2 mypy==0.812
+pipx inject standardebooks pylint==2.17.3 mypy==1.2.0 types-requests==2.28.11.17 types-setuptools==67.7.0.0
 ```
 
 Then make sure to call the `pylint` and `mypy` binaries that `pipx` installed in the `standardebooks` venv, *not* any other globally-installed binaries:
@@ -173,7 +173,7 @@ $HOME/.local/pipx/venvs/standardebooks/bin/pylint se
 Similar to `pylint`, the `pytest` command can be injected into the venv `pipx` created for the `standardebooks` package:
 
 ```shell
-pipx inject standardebooks pytest==7.0.1
+pipx inject standardebooks pytest==7.3.1
 ```
 
 The tests are executed by calling `pytest` from the top level or your tools repo:

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Then make sure to call the `pylint` and `mypy` binaries that `pipx` installed in
 
 ```shell
 cd /path/to/tools/repo
-$HOME/.local/pipx/venvs/standardebooks/bin/pylint se
+$HOME/.local/pipx/venvs/standardebooks/bin/pylint tests/*.py se
 ```
 
 ### Testing with `pytest`

--- a/pylintrc
+++ b/pylintrc
@@ -6,7 +6,7 @@ ignore=vendor
 extension-pkg-whitelist=lxml,math,unicodedata
 
 [MESSAGES CONTROL]
-disable=line-too-long,too-many-nested-blocks,too-many-branches,too-many-statements,too-many-boolean-expressions,too-many-lines,too-many-locals,broad-except,bare-except,too-few-public-methods,too-many-arguments,too-many-instance-attributes,bad-continuation,too-many-public-methods,duplicate-code,no-member
+disable=line-too-long,too-many-nested-blocks,too-many-branches,too-many-statements,too-many-boolean-expressions,too-many-lines,too-many-locals,broad-except,bare-except,too-few-public-methods,too-many-arguments,too-many-instance-attributes,too-many-public-methods,duplicate-code,no-member
 
 [FORMAT]
 indent-string=\t

--- a/se/__init__.py
+++ b/se/__init__.py
@@ -7,7 +7,7 @@ import argparse
 import os
 import sys
 from pathlib import Path
-from typing import Union, List, Tuple
+from typing import Union, List, Tuple, Optional
 
 from rich.console import Console
 from rich.theme import Theme
@@ -116,7 +116,7 @@ class BuildFailedException(SeException):
 	""" Build failed """
 	code = 17
 
-	def __init__(self, message, messages: List = None):
+	def __init__(self, message, messages: Optional[List] = None):
 		super().__init__(message)
 		self.messages = messages if messages else []
 

--- a/se/commands/compare_versions.py
+++ b/se/commands/compare_versions.py
@@ -3,7 +3,7 @@ This module implements the `se compare-versions` command.
 """
 
 import argparse
-from distutils.dir_util import copy_tree
+from distutils.dir_util import copy_tree # pylint: disable=deprecated-module
 import shutil
 import tempfile
 from pathlib import Path
@@ -188,7 +188,7 @@ def compare_versions(plain_output: bool) -> int:
 						with importlib_resources.open_text("se.data.templates", "diff-template.html", encoding="utf-8") as file:
 							html = file.read().replace("<!--se:sections-->", html.strip())
 
-						with open(output_directory / "diff.html", "w") as file:
+						with open(output_directory / "diff.html", "w", encoding="utf-8") as file:
 							file.write(html)
 	except KeyboardInterrupt as ex:
 		# Bubble the exception up, but proceed to `finally` so we quit the driver

--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -373,7 +373,7 @@ def _get_wikipedia_url(string: str, get_nacoaf_uri: bool) -> Tuple[Optional[str]
 	# returns HTTP 200, then we didn't find a direct match and return nothing.
 
 	try:
-		response = requests.get("https://en.wikipedia.org/wiki/Special:Search", params={"search": string, "go": "Go", "ns0": "1"}, allow_redirects=False)
+		response = requests.get("https://en.wikipedia.org/wiki/Special:Search", params={"search": string, "go": "Go", "ns0": "1"}, allow_redirects=False, timeout=60)
 	except Exception as ex:
 		raise se.RemoteCommandErrorException(f"Couldn’t contact Wikipedia. Exception: {ex}") from ex
 
@@ -386,7 +386,7 @@ def _get_wikipedia_url(string: str, get_nacoaf_uri: bool) -> Tuple[Optional[str]
 
 		if get_nacoaf_uri:
 			try:
-				response = requests.get(wiki_url)
+				response = requests.get(wiki_url, timeout=60)
 			except Exception as ex:
 				raise se.RemoteCommandErrorException(f"Couldn’t contact Wikipedia. Exception: {ex}") from ex
 
@@ -633,7 +633,7 @@ def _create_draft(args: Namespace):
 
 		# Get the ebook metadata
 		try:
-			response = requests.get(pg_url)
+			response = requests.get(pg_url, timeout=60)
 			pg_metadata_html = response.text
 		except Exception as ex:
 			raise se.RemoteCommandErrorException(f"Couldn’t download Project Gutenberg ebook metadata page. Exception: {ex}") from ex
@@ -664,7 +664,7 @@ def _create_draft(args: Namespace):
 
 		# Get the actual ebook URL
 		try:
-			response = requests.get(pg_ebook_url)
+			response = requests.get(pg_ebook_url, timeout=60)
 			pg_ebook_html = response.text
 		except Exception as ex:
 			raise se.RemoteCommandErrorException(f"Couldn’t download Project Gutenberg ebook HTML. Exception: {ex}") from ex
@@ -963,12 +963,12 @@ def _create_draft(args: Namespace):
 						record_link = "<a title=\"Click to view record\" href=\"/authorities/{}/([^\"]+?)\">" + regex.escape(subject.replace(' -- ', '--')) + "</a>"
 						loc_id = "Unknown"
 
-						response = requests.get(search_url.format("subjects"))
+						response = requests.get(search_url.format("subjects"), timeout=60)
 						result = regex.search(record_link.format("subjects"), response.text)
 
 						# If Subject authority does not exist we can also check the Names authority
 						if result is None:
-							response = requests.get(search_url.format("names"))
+							response = requests.get(search_url.format("names"), timeout=60)
 							result = regex.search(record_link.format("names"), response.text)
 						else:
 							try:

--- a/se/commands/find_unusual_characters.py
+++ b/se/commands/find_unusual_characters.py
@@ -124,8 +124,8 @@ def find_unusual_characters(plain_output: bool) -> int:
 	# Sort and prepare the output
 	lines = []
 
-	for unusual_character, _ in unusual_characters.items():
-		lines.append((unusual_character, unusual_characters[unusual_character]))
+	for unusual_character, count in unusual_characters.items():
+		lines.append((unusual_character, count))
 
 	lines.sort()
 

--- a/se/commands/interactive_replace.py
+++ b/se/commands/interactive_replace.py
@@ -347,7 +347,7 @@ def interactive_replace(plain_output: bool) -> int: # pylint: disable=unused-arg
 
 					# Throw a blank exception so that we break out of the loop
 					# and disinitialize curses in `finally`
-					raise Exception
+					raise Exception # pylint: disable=broad-exception-raised
 
 				if curses.keyname(char) in (b"y", b"Y"):
 					# Do the replacement, but starting from the beginning of the match in case we

--- a/se/commands/unicode_names.py
+++ b/se/commands/unicode_names.py
@@ -35,7 +35,7 @@ def unicode_names(plain_output: bool) -> int:
 	if plain_output:
 		for line in lines:
 			for character in line:
-				console.print(character, "\tU+{:04X}".format(ord(character)), "\t", unicodedata.name(character))
+				console.print(character, "\tU+{:04X}".format(ord(character)), "\t", unicodedata.name(character)) # pylint: disable=consider-using-f-string
 	else:
 		table = Table(show_header=False, show_lines=True, box=box.HORIZONTALS)
 		table.add_column("Character", style="bold", width=1, no_wrap=True)
@@ -47,9 +47,9 @@ def unicode_names(plain_output: bool) -> int:
 			for character in line:
 				try:
 					character_name = unicodedata.name(character)
-					table.add_row(character, "U+{:04X}".format(ord(character)), character_name, f"[link=https://util.unicode.org/UnicodeJsps/character.jsp?a={urllib.parse.quote_plus(character)}]Properties page[/]")
+					table.add_row(character, "U+{:04X}".format(ord(character)), character_name, f"[link=https://util.unicode.org/UnicodeJsps/character.jsp?a={urllib.parse.quote_plus(character)}]Properties page[/]") # pylint: disable=consider-using-f-string
 				except Exception:
-					table.add_row("[white on red bold]?[/]", "U+{:04X}".format(ord(character)), "[white on red bold]Unrecognized[/]", "")
+					table.add_row("[white on red bold]?[/]", "U+{:04X}".format(ord(character)), "[white on red bold]Unrecognized[/]", "") # pylint: disable=consider-using-f-string
 
 		console.print(table)
 

--- a/se/easy_xml.py
+++ b/se/easy_xml.py
@@ -5,7 +5,7 @@ The class exposes some helpful functions like css_select() and xpath().
 """
 
 from html import unescape
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 import unicodedata
 
 import regex
@@ -140,7 +140,7 @@ class EasyXmlTree:
 				node.set_attr(f"data-css-{declaration.name}", declaration.value)
 				node.set_attr(f"data-css-{declaration.name}-specificity", str(specificity_number))
 
-	def apply_css(self, css: str, filename: str=None):
+	def apply_css(self, css: str, filename: Optional[str] = None):
 		"""
 		Apply a CSS stylesheet to an XHTML tree.
 		The application is naive and should not be expected to be browser-grade.

--- a/se/formatting.py
+++ b/se/formatting.py
@@ -821,9 +821,9 @@ def _format_css_component_list(content: list, in_selector=False, in_paren_block=
 					output += " " + token.value + " "
 				else:
 					output += token.value
-			elif token.value == "<" or token.value == ">" or token.value == "+" or token.value == "-" or token.value == "/":
+			elif token.value in ("<", ">", "+", "-", "/"):
 				output += " " + token.value + " "
-			elif token.value == "|" or token.value == "|=" or token.value == "^=" or token.value == "~=" or token.value == "*=" or token.value == "||":
+			elif token.value in ("|", "|=", "^=", "~=", "*=", "||"):
 				output = output.rstrip() + token.value
 			else:
 				output += token.value
@@ -1110,7 +1110,7 @@ def get_ordinal(number: str) -> str:
 	"""
 
 	value = int(number)
-	return "%d%s" % (value, "tsnrhtdd"[(math.floor(value / 10) % 10 != 1) * (value % 10 < 4) * value % 10::4])
+	return "%d%s" % (value, "tsnrhtdd"[(math.floor(value / 10) % 10 != 1) * (value % 10 < 4) * value % 10::4]) # pylint: disable=consider-using-f-string
 
 def titlecase(text: str) -> str:
 	"""

--- a/se/formatting.py
+++ b/se/formatting.py
@@ -10,7 +10,7 @@ import math
 import string
 import unicodedata
 from pathlib import Path
-from typing import Dict, Union, List, Tuple
+from typing import Dict, Union, List, Tuple, Optional
 
 import regex
 import roman
@@ -596,7 +596,7 @@ def _format_xml_str(xml: str) -> etree.ElementTree:
 
 	return tree
 
-def _xml_tree_to_string(tree: etree.ElementTree, doctype: str = None) -> str:
+def _xml_tree_to_string(tree: etree.ElementTree, doctype: Optional[str] = None) -> str:
 	"""
 	Given an XML etree, return a string representing the etree's XML.
 

--- a/se/images.py
+++ b/se/images.py
@@ -214,7 +214,7 @@ def remove_image_metadata(filename: Path) -> None:
 	None.
 	"""
 
-	if filename.suffix == ".xcf" or filename.suffix == ".svg":
+	if filename.suffix in (".xcf", ".svg"):
 		# Skip GIMP XCF and SVG files
 		return
 
@@ -369,7 +369,7 @@ def svg_text_to_paths(in_svg: Path, out_svg: Path, remove_style=True) -> None:
 	xmlstr = etree.tostring(xml, pretty_print=True).decode("UTF-8")
 	result_all_text = xmlstr.replace("ns0:", "").replace(":ns0", "")
 	result_all_text = se.formatting.format_xml(result_all_text)
-	with open(out_svg, "wt") as output:
+	with open(out_svg, "wt", encoding="utf-8") as output:
 		output.write(result_all_text)
 
 def _apply_css(elem: etree.Element, css_text: str) -> dict:
@@ -441,7 +441,7 @@ def _add_font_to_properties(properties: Dict, fonts: List) -> None:
 		return # One chunk of text can only have one font/variant
 
 def _float_to_str(float_value: float) -> str:
-	return "{0:.2f}".format(round(float_value, 2))
+	return "{0:.2f}".format(round(float_value, 2)) # pylint: disable=consider-using-f-string
 
 def _add_svg_paths_to_group(g_elem: etree.Element, text_properties: Dict) -> None:
 	# Required properties to make any progress
@@ -608,7 +608,7 @@ def _d_apply_matrix(d_attrib: str, matrix: List) -> str:
 	return " ".join(shapes).strip()
 
 def _parse_font(font_path: Path) -> dict:
-	with open(font_path, "rt") as font_svg_raw:
+	with open(font_path, "rt", encoding="utf-8") as font_svg_raw:
 		xml = etree.fromstring(str.encode(font_svg_raw.read()))
 	font: Dict = {"glyphs": {}, "hkern": {}, "meta": {}}
 	glyphs = font["glyphs"]

--- a/se/main.py
+++ b/se/main.py
@@ -17,7 +17,7 @@ def get_commands() -> List[str]:
 	"""
 
 	commands = []
-	for module_info in pkgutil.iter_modules(se.commands.__path__): # type: ignore # mypy issue 1422
+	for module_info in pkgutil.iter_modules(se.commands.__path__):
 		command = module_info.name.replace("_", "-")
 		if command != "version":
 			commands.append(command)

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -89,7 +89,7 @@ class SeEpub:
 			self.path = Path(epub_root_directory).resolve()
 
 			if not self.path.is_dir():
-				raise Exception
+				raise NotADirectoryError
 
 		except Exception as ex:
 			raise se.InvalidSeEbookException(f"Not a directory: [path][link=file://{self.path}]{self.path}[/][/].") from ex
@@ -1352,7 +1352,7 @@ class SeEpub:
 
 				current_note_number += 1
 
-			with open(file_path, "w") as file:
+			with open(file_path, "w", encoding="utf-8") as file:
 				file.write(dom.to_string())
 
 		# Renumber all endnotes starting from 1
@@ -1366,7 +1366,7 @@ class SeEpub:
 
 			current_note_number += 1
 
-		with open(self.endnotes_path, "w") as file:
+		with open(self.endnotes_path, "w", encoding="utf-8") as file:
 			file.write(endnotes_dom.to_string())
 
 	def generate_endnotes(self) -> Tuple[int, int, list]:
@@ -1405,7 +1405,7 @@ class SeEpub:
 
 			# If we need to write back the body text file
 			if needs_rewrite:
-				with open(file_path, "w") as file:
+				with open(file_path, "w", encoding="utf-8") as file:
 					file.write(se.formatting.format_xhtml(dom.to_string()))
 
 		# Now process any endnotes WITHIN the endnotes
@@ -1437,7 +1437,7 @@ class SeEpub:
 
 						ol_node.append(endnote.node)
 
-			with open(self.endnotes_path, "w") as file:
+			with open(self.endnotes_path, "w", encoding="utf-8") as file:
 				file.write(se.formatting.format_xhtml(endnotes_dom.to_string()))
 
 			# now trawl through the body files to locate any direct links to endnotes (not in an actual endnote reference)
@@ -1449,7 +1449,7 @@ class SeEpub:
 				for link in dom.xpath("/html/body//a[contains(@href, 'endnotes.xhtml#note-')]"):
 					needs_rewrite = self.__process_direct_link(change_list, link)
 				if needs_rewrite:
-					with open(file_path, "w") as file:
+					with open(file_path, "w", encoding="utf-8") as file:
 						file.write(se.formatting.format_xhtml(dom.to_string()))
 
 		return current_note_number - 1, notes_changed, change_list

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -1245,7 +1245,7 @@ class SeEpub:
 
 		return self.metadata_dom.xpath("/package/metadata/dc:title/text()", True) or "WORK_TITLE"
 
-	def lint(self, skip_lint_ignore: bool, allowed_messages: List[str] = None) -> list:
+	def lint(self, skip_lint_ignore: bool, allowed_messages: Optional[List[str]] = None) -> list:
 		"""
 		The lint() function is very big so for readability and maintainability
 		it's broken out to a separate file. Strictly speaking that file can be inlined
@@ -1309,7 +1309,7 @@ class SeEpub:
 						anchor = href[hash_position:]
 				references.append(anchor)  # keep these for later reverse check
 				# Now try to find anchor in endnotes
-				matches = list(filter(lambda x, old=anchor: x.anchor == old, self.endnotes)) # type: ignore [misc]
+				matches = list(filter(lambda x, old=anchor: x.anchor == old, self.endnotes)) # type: ignore [arg-type]
 				if not matches:
 					missing.append(anchor)
 				if len(matches) > 1:
@@ -1502,7 +1502,7 @@ class SeEpub:
 			link.lxml_element.text = str(current_note_number)
 			needs_rewrite = True
 		# Now try to find this in endnotes
-		matches = list(filter(lambda x, old=old_anchor: x.anchor == old, self.endnotes)) # type: ignore [misc]
+		matches = list(filter(lambda x, old=old_anchor: x.anchor == old, self.endnotes)) # type: ignore [arg-type]
 		if not matches:
 			raise se.InvalidInputException(f"Couldn’t find endnote with anchor [attr]{old_anchor}[/].")
 		if len(matches) > 1:

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -11,7 +11,7 @@ import os
 import shutil
 import subprocess
 import tempfile
-from distutils.dir_util import copy_tree
+from distutils.dir_util import copy_tree # pylint: disable=deprecated-module
 from copy import deepcopy
 from hashlib import sha1
 from html import unescape
@@ -320,8 +320,8 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 		if cover_local_path:
 			cover_work_path = work_compatible_epub_dir / "epub" / cover_local_path
 
-			if cover_work_path.suffix == ".svg" or cover_work_path.suffix == ".png":
-				# If the cover is SVG, conver to PNG first
+			if cover_work_path.suffix in (".svg", ".png"):
+				# If the cover is SVG, convert to PNG first
 				if cover_work_path.suffix == ".svg":
 					svg2png(url=str(cover_work_path), write_to=str(work_dir / "cover.png"))
 

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -16,7 +16,7 @@ from copy import deepcopy
 from hashlib import sha1
 from html import unescape
 from pathlib import Path
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple, List, Optional
 import importlib_resources
 
 from cairosvg import svg2png
@@ -52,7 +52,7 @@ class BuildMessage:
 	Contains information like message text, severity, and the epub filename that generated the message.
 	"""
 
-	def __init__(self, source: str, code: str, text: str, filename: Path = None, line: int = None, col: int = None, submessages: List = None):
+	def __init__(self, source: str, code: str, text: str, filename: Optional[Path] = None, line: Optional[int] = None, col: Optional[int] = None, submessages: Optional[List] = None):
 		self.source = source
 		self.code = code
 		self.text = text.strip()

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -720,7 +720,7 @@ def process_all_content(self, file_list: list) -> Tuple[list, list]:
 
 	# Now we test to see if there is only one body item
 	body_items = [item for item in landmarks if item.place == Position.BODY]
-	single_file = (len(body_items) == 1)
+	single_file = len(body_items) == 1
 	single_file_without_headers = False
 
 	# If there's only one body item, does that item have a header?

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -3148,7 +3148,7 @@ def lint(self, skip_lint_ignore: bool, allowed_messages: Optional[List[str]] = N
 		# Href links are mostly found in endnotes, so if there's an endnotes file process it first
 		# to try to speed things up a little
 		for file_path in self.content_path.glob("**/*"):
-			if file_path.suffix == ".xhtml" or file_path.suffix == ".xml":
+			if file_path.suffix in (".xhtml", ".xml"):
 				dom = self.get_dom(file_path)
 				if dom.xpath("/html/body/section[contains(@epub:type, 'glossary') or contains(@epub:type, 'endnotes')]") or dom.xpath("/search-key-map"):
 					sorted_filenames.insert(0, file_path)

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -13,7 +13,7 @@ from fnmatch import translate
 import io
 import os
 from pathlib import Path
-from typing import Dict, List, Set, Union
+from typing import Dict, List, Set, Union, Optional
 import importlib_resources
 
 import cssutils
@@ -395,7 +395,7 @@ class LintMessage:
 	Contains information like message text, severity, and the epub filename that generated the message.
 	"""
 
-	def __init__(self, code: str, text: str, message_type=se.MESSAGE_TYPE_WARNING, filename: Path = None, submessages: Union[List[str], Set[str]] = None):
+	def __init__(self, code: str, text: str, message_type=se.MESSAGE_TYPE_WARNING, filename: Optional[Path] = None, submessages: Optional[Union[List[str], Set[str]]] = None):
 		self.code = code
 		self.text = text.strip()
 		self.filename = filename
@@ -604,7 +604,7 @@ def files_not_in_spine(self) -> set:
 	spine_files = set(self.spine_file_paths + [self.toc_path])
 	return xhtml_files.difference(spine_files)
 
-def lint(self, skip_lint_ignore: bool, allowed_messages: List[str] = None) -> list:
+def lint(self, skip_lint_ignore: bool, allowed_messages: Optional[List[str]] = None) -> list:
 	"""
 	Check this ebook for some common SE style errors.
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -77,23 +77,23 @@ def files_are_golden(in_dir: Path, text_dir: Path, golden_dir: Path, update_gold
 	# If there are mismatches, do an assert on the text of the files
 	# so that we get a nice context diff from pytest.
 	for mismatch in mismatches:
-		with open(golden_dir / mismatch) as file:
+		with open(golden_dir / mismatch, encoding="utf-8") as file:
 			golden_text = file.read()
-		with open(text_dir / mismatch) as file:
+		with open(text_dir / mismatch, encoding="utf-8") as file:
 			test_text = file.read()
 		assert test_text == golden_text
 
 	if check_content_opf:
-		with open(golden_dir / "content.opf") as file:
+		with open(golden_dir / "content.opf", encoding="utf-8") as file:
 			golden_text = file.read()
-		with open(content_opf_out) as file:
+		with open(content_opf_out, encoding="utf-8") as file:
 			test_text = file.read()
 		assert test_text == golden_text
 
 	# Do a redundant check in case there is no text diff for some reason
-	assert mismatches == []
+	assert not mismatches
 	# Fail on any other errors
-	assert errors == []
+	assert not errors
 
 	return True
 
@@ -102,11 +102,11 @@ def output_is_golden(out: str, golden_file: Path, update_golden: bool) ->bool:
 	__tracebackhide__ = True # pylint: disable=unused-variable
 
 	if update_golden:
-		with open(golden_file, "w") as file:
+		with open(golden_file, "w", encoding="utf-8") as file:
 			file.write(out)
 
 	# Output of stdout should match expected output
-	with open(golden_file) as file:
+	with open(golden_file, encoding="utf-8") as file:
 		assert file.read() == out
 
 	return True

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -35,13 +35,13 @@ def assert_match(data_dir: Path, test_name: str):
 	infile = f"{data_dir}/formatting/in/{test_name}.xhtml"
 	outfile = f"{data_dir}/formatting/out/{test_name}.xhtml"
 
-	with open(infile, "r") as file:
+	with open(infile, "r", encoding="utf-8") as file:
 		xml = file.read()
 
 	result = format_xml(xml)
 	print(result)
 
-	with open(outfile, "r") as file:
+	with open(outfile, "r", encoding="utf-8") as file:
 		assert file.read() == result
 
 


### PR DESCRIPTION
mypy has been broken on Macs for at least a couple of OS versions. Historically we haven’t wanted to upgrade to version 900 or beyond, partially because of the version of Python on the server, but partially because of the fact that typings are now modular.

Having investigated, I’m not too worried about the second point. To cover our needs, we need two additional packages: [types-requests](https://pypi.org/project/types-requests/) and [types-setuptools](https://pypi.org/project/types-setuptools/). I’ve added these to the readme and the Github action, but not to setup.py. They will never download automatically: that requires the `--non-interactive` flag when executing.

Having updated mypy it felt worth it to also update pylint. And once I’d bumped both of those, it turned out that there were some new changes / fixes to make. So one commit for the mypy changes, and one for the pylint changes.