### PR TITLE
Correct spelling of Michelangelo

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -440,7 +440,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"Shakspea?rean", r"Shakespearean", xhtml)			# Shaksperean -> Shakespearean
 	xhtml = regex.sub(r"Shakspea?re?’s", r"Shakespeare’s", xhtml)			# Shakspere’s -> Shakespeare’s
 	xhtml = regex.sub(r"Raffaelle", r"Raphael", xhtml)				# Raffaelle -> Raphael
-	xhtml = regex.sub(r"Michael Angelo", r"Michaelangelo", xhtml)			# Michael Angelo -> Michaelangelo
+	xhtml = regex.sub(r"Michael ?[Aa]ngelo", r"Michelangelo", xhtml)			# Michael Angelo -> Michaelangelo
 	xhtml = regex.sub(r"\bVergil", r"Virgil", xhtml)				# Vergil -> Virgil
 	xhtml = regex.sub(r"\bVishnoo", r"Vishnu", xhtml)				# Vishnoo -> Vishnu
 	xhtml = regex.sub(r"\bPekin\b", r"Peking", xhtml)				# Pekin -> Peking


### PR DESCRIPTION
We correct Michael Angelo to Michaelangelo, but Wiki, Brittanica, M-W, Oxford, Collins, et al all spell it Michelangelo. This adds a regex to correct all of the below to Michelangelo. We have around 70 occurrences of Michaelangelo in the corpus.

````
<p>Let's talk about sculptors. There's Michael Angelo, MichaelAngelo, Michael angelo, Michaelangelo, and Michelangelo.</p>
````