### PR TITLE
Fix cover building as only a black image

### DIFF
--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -323,7 +323,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 			if cover_work_path.suffix in (".svg", ".png"):
 				# If the cover is SVG, convert to PNG first
 				if cover_work_path.suffix == ".svg":
-					svg2png(url=str(cover_work_path), write_to=str(work_dir / "cover.png"))
+					svg2png(url=str(cover_work_path), unsafe=True, write_to=str(work_dir / "cover.png")) # remove unsafe flag when cairosvg > 2.7.0
 
 				# Now convert PNG to JPG
 				cover = Image.open(work_dir / "cover.png")


### PR DESCRIPTION
Looks like cairosvg 2.7.0 broke loading data URLs in source SVGs in “safe mode”, which causes the produced PNG to have a transparent background and the rendered JPG to end up with an all-black background. This was fixed in April (https://github.com/Kozea/CairoSVG/commit/2cbe3066e604af67c31d6651aa3acafe4ae0749d) but the latest 2.7.0 release was in March.

In the meantime, we can pass an unsafe flag through to svg2png which allows it to complete successfully. I don’t think this is a problem as we control the repos that build this data.

(I’m guessing this doesn’t affect the server as it’s obviously not producing black covers, but I’m unable to build an epub with a working cover locally on my mac.)