### PR TITLE
build-spine: Order half title page after other front matter

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -1168,10 +1168,15 @@ class SeEpub:
 		spine, frontmatter = self.__add_to_spine(spine, frontmatter, "preface")
 		spine, frontmatter = self.__add_to_spine(spine, frontmatter, "epigraph")
 		spine, frontmatter = self.__add_to_spine(spine, frontmatter, "z3998:dramatis-personae")
-		spine, frontmatter = self.__add_to_spine(spine, frontmatter, "halftitlepage")
+
+		# Extract half title page for subsequent addition
+		halftitlepage, frontmatter = self.__add_to_spine([], frontmatter, "halftitlepage")
 
 		# Add any remaining frontmatter
 		spine = spine + natsorted([file_path.name for file_path in frontmatter])
+
+		# The half title page is always the last front matter
+		spine = spine + halftitlepage
 
 		# Add bodymatter
 		spine, bodymatter = self.__add_to_spine(spine, bodymatter, "prologue")

--- a/tests/data/build-spine/in/halftitlepage.xhtml
+++ b/tests/data/build-spine/in/halftitlepage.xhtml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
+	<head>
+		<title>Unknown Novel</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="frontmatter">
+		<section id="halftitlepage" epub:type="halftitlepage">
+			<h2 epub:type="fulltitle">Unknown Novel</h2>
+		</section>
+	</body>
+</html>

--- a/tests/data/build-spine/in/misc-front.xhtml
+++ b/tests/data/build-spine/in/misc-front.xhtml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
+	<head>
+		<title>Miscellaneous Frontmatter</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="frontmatter">
+		<section id="misc-front">
+			<h2 epub:type="title">Miscellaneous Frontmatter</h2>
+		</section>
+	</body>
+</html>

--- a/tests/data/build-spine/out/content.opf
+++ b/tests/data/build-spine/out/content.opf
@@ -79,7 +79,9 @@
 		<item href="images/titlepage.svg" id="titlepage.svg" media-type="image/svg+xml"/>
 		<item href="text/chapter-1.xhtml" id="chapter-1.xhtml" media-type="application/xhtml+xml"/>
 		<item href="text/colophon.xhtml" id="colophon.xhtml" media-type="application/xhtml+xml" properties="svg"/>
+		<item href="text/halftitlepage.xhtml" id="halftitlepage.xhtml" media-type="application/xhtml+xml"/>
 		<item href="text/imprint.xhtml" id="imprint.xhtml" media-type="application/xhtml+xml" properties="svg"/>
+		<item href="text/misc-front.xhtml" id="misc-front.xhtml" media-type="application/xhtml+xml"/>
 		<item href="text/titlepage.xhtml" id="titlepage.xhtml" media-type="application/xhtml+xml" properties="svg"/>
 		<item href="text/uncopyright.xhtml" id="uncopyright.xhtml" media-type="application/xhtml+xml"/>
 		<item href="toc.xhtml" id="toc.xhtml" media-type="application/xhtml+xml" properties="nav"/>
@@ -87,6 +89,8 @@
 	<spine>
 		<itemref idref="titlepage.xhtml"/>
 		<itemref idref="imprint.xhtml"/>
+		<itemref idref="misc-front.xhtml"/>
+		<itemref idref="halftitlepage.xhtml"/>
 		<itemref idref="chapter-1.xhtml"/>
 		<itemref idref="colophon.xhtml"/>
 		<itemref idref="uncopyright.xhtml"/>

--- a/tests/data/build-spine/out/halftitlepage.xhtml
+++ b/tests/data/build-spine/out/halftitlepage.xhtml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
+	<head>
+		<title>Unknown Novel</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="frontmatter">
+		<section id="halftitlepage" epub:type="halftitlepage">
+			<h2 epub:type="fulltitle">Unknown Novel</h2>
+		</section>
+	</body>
+</html>

--- a/tests/data/build-spine/out/misc-front.xhtml
+++ b/tests/data/build-spine/out/misc-front.xhtml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
+	<head>
+		<title>Miscellaneous Frontmatter</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="frontmatter">
+		<section id="misc-front">
+			<h2 epub:type="title">Miscellaneous Frontmatter</h2>
+		</section>
+	</body>
+</html>


### PR DESCRIPTION
The existing behavior of putting all other front matter after the half title page is always wrong, per the Manual of Style.