### PR TITLE
Add a few missing SE variables to lint

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -29,7 +29,62 @@ import se.formatting
 import se.images
 import se.typography
 
-SE_VARIABLES = ["SE_IDENTIFIER", "TITLE", "TITLE_SORT", "SUBJECT_1", "SUBJECT_2", "LCSH_ID_1", "LCSH_ID_2", "TAG", "DESCRIPTION", "LONG_DESCRIPTION", "LANG", "PG_URL", "PRODUCTION_NOTES", "IA_URL", "EBOOK_WIKI_URL", "VCS_IDENTIFIER", "YEAR", "AUTHOR_WIKI_URL", "AUTHOR", "AUTHOR_SORT", "AUTHOR_FULL_NAME", "AUTHOR_NACOAF_URI", "TRANSLATOR", "TRANSLATOR_SORT", "TRANSLATOR_WIKI_URL", "TRANSLATOR_NACOAF_URI", "COVER_ARTIST", "COVER_ARTIST_SORT", "COVER_ARTIST_WIKI_URL", "COVER_ARTIST_NACOAF_URI", "ILLUSTRATOR", "ILLUSTRATOR_SORT", "ILLUSTRATOR_WIKI_URL", "ILLUSTRATOR_NACOAF_URI", "TRANSCRIBER", "TRANSCRIBER_SORT", "TRANSCRIBER_URL", "PRODUCER_URL", "PRODUCER", "PRODUCER_SORT", "PG_YEAR", "TRANSCRIBER_1", "TRANSCRIBER_2", "PAINTING", "ORIGINAL_LANGUAGE", "TRANSLATION_YEAR", "CONTRIBUTOR_FULL_NAME"]
+SE_VARIABLES = [
+	"SE_IDENTIFIER",
+	"TITLE",
+	"TITLE_SORT",
+	"SUBJECT_1",
+	"SUBJECT_2",
+	"LCSH_ID_1",
+	"LCSH_ID_2",
+	"TAG",
+	"DESCRIPTION",
+	"LONG_DESCRIPTION",
+	"LANG",
+	"PG_URL",
+	"IA_URL",
+	"PRODUCTION_NOTES",
+	"EBOOK_WIKI_URL",
+	"VCS_IDENTIFIER",
+	"AUTHOR",
+	"AUTHOR_SORT",
+	"AUTHOR_FULL_NAME",
+	"AUTHOR_WIKI_URL",
+	"AUTHOR_NACOAF_URI",
+	"TRANSLATOR",
+	"TRANSLATOR_SORT",
+	"TRANSLATOR_WIKI_URL",
+	"TRANSLATOR_NACOAF_URI",
+	"COVER_ARTIST",
+	"COVER_ARTIST_SORT",
+	"COVER_ARTIST_WIKI_URL",
+	"COVER_ARTIST_NACOAF_URI",
+	"ILLUSTRATOR",
+	"ILLUSTRATOR_SORT",
+	"ILLUSTRATOR_WIKI_URL",
+	"ILLUSTRATOR_NACOAF_URI",
+	"TRANSCRIBER",
+	"TRANSCRIBER_SORT",
+	"TRANSCRIBER_URL",
+	"PRODUCER",
+	"PRODUCER_URL",
+	"PRODUCER_SORT",
+	"CONTRIBUTOR_ID",
+	"CONTRIBUTOR_NAME",
+	"CONTRIBUTOR_SORT",
+	"CONTRIBUTOR_FULL_NAME",
+	"CONTRIBUTOR_WIKI_URL",
+	"CONTRIBUTOR_NACOAF_URI",
+	"CONTRIBUTOR_MARC",
+	# colophon-specific
+	"YEAR",
+	"ORIGINAL_LANGUAGE",
+	"TRANSLATION_YEAR",
+	"PG_YEAR",
+	"TRANSCRIBER_1",
+	"TRANSCRIBER_2",
+	"PAINTING"
+]
 
 # See https://idpf.github.io/epub-vocabs/structure/
 EPUB_SEMANTIC_VOCABULARY = ["abstract", "acknowledgments", "afterword", "answer", "answers", "appendix", "aside", "assessment", "assessments", "backlink", "backmatter", "balloon", "biblioentry", "bibliography", "biblioref", "bodymatter", "bridgehead", "case-study", "chapter", "colophon", "concluding-sentence", "conclusion", "contributors", "copyright-page", "cover", "covertitle", "credit", "credits", "dedication", "division", "endnote", "endnotes", "epigraph", "epilogue", "errata", "feedback", "figure", "fill-in-the-blank-problem", "footnote", "footnotes", "foreword", "frontmatter", "fulltitle", "general-problem", "glossary", "glossdef", "glossref", "glossterm", "halftitle", "halftitlepage", "imprimatur", "imprint", "index", "index-editor-note", "index-entry", "index-entry-list", "index-group", "index-headnotes", "index-legend", "index-locator", "index-locator-list", "index-locator-range", "index-term", "index-term-categories", "index-term-category", "index-xref-preferred", "index-xref-related", "introduction", "keyword", "keywords", "label", "landmarks", "learning-objective", "learning-objectives", "learning-outcome", "learning-outcomes", "learning-resource", "learning-resources", "learning-standard", "learning-standards", "list", "list-item", "loa", "loi", "lot", "lov", "match-problem", "multiple-choice-problem", "noteref", "notice", "ordinal", "other-credits", "pagebreak", "page-list", "panel", "panel-group", "part", "practice", "practices", "preamble", "preface", "prologue", "pullquote", "qna", "question", "revision-history", "seriespage", "sound-area", "subtitle", "table", "table-cell", "table-row", "text-area", "tip", "title", "titlepage", "toc", "toc-brief", "topic-sentence", "true-false-problem", "volume"]

--- a/tests/data/lint/content-out.txt
+++ b/tests/data/lint/content-out.txt
@@ -3,11 +3,11 @@ s-033 [Manual Review] chapter-1.xhtml File language is `en-GB`, but
 m-036 [Error] colophon.xhtml Variable not replaced with value.
         PG_URL
         IA_URL
-        YEAR
         COVER_ARTIST
         COVER_ARTIST_WIKI_URL
-        PRODUCER_URL
         PRODUCER
+        PRODUCER_URL
+        YEAR
         PG_YEAR
         TRANSCRIBER_1
         TRANSCRIBER_2


### PR DESCRIPTION
They are:

- `CONTRIBUTOR_ID`
- `CONTRIBUTOR_MARC`
- `CONTRIBUTOR_NACOAF_URI`
- `CONTRIBUTOR_NAME`
- `CONTRIBUTOR_SORT`
- `CONTRIBUTOR_WIKI_URL`

Found when reviewing a production where one of them had snuck through. I took the opportunity to sort the list in the order they appear in content.opf, and to add a secondary section for the colophon variables.