### PR TITLE
Lint: checks and test for missing CSS

### DIFF
--- a/tests/data/lint/c-006-out.txt
+++ b/tests/data/lint/c-006-out.txt
@@ -1,0 +1,64 @@
+s-033 [Manual Review] chapter-1.xhtml File language is `en-GB`, but 
+`content.opf` language is `LANG`.
+m-036 [Error] colophon.xhtml Variable not replaced with value.
+        PG_URL
+        IA_URL
+        COVER_ARTIST
+        COVER_ARTIST_WIKI_URL
+        PRODUCER
+        PRODUCER_URL
+        YEAR
+        PG_YEAR
+        TRANSCRIBER_1
+        TRANSCRIBER_2
+        PAINTING
+t-064 [Manual Review] colophon.xhtml Title not correctly titlecased. Hint: 
+Non-English titles should have an `xml:lang` attribute as they have different 
+titlecasing rules.
+        <i epub:type="se:name.visual-art.painting">PAINTING</i>
+m-036 [Error] content.opf Variable not replaced with value.
+        SUBJECT_1
+        SUBJECT_2
+        LCSH_ID_1
+        LCSH_ID_2
+        TAG
+        DESCRIPTION
+        LONG_DESCRIPTION
+        LANG
+        PG_URL
+        PRODUCTION_NOTES
+        EBOOK_WIKI_URL
+        AUTHOR_SORT
+        AUTHOR_FULL_NAME
+        COVER_ARTIST
+        COVER_ARTIST_SORT
+        COVER_ARTIST_WIKI_URL
+        COVER_ARTIST_NACOAF_URI
+        TRANSCRIBER
+        TRANSCRIBER_SORT
+        TRANSCRIBER_URL
+        PRODUCER
+        PRODUCER_SORT
+        PRODUCER_URL
+s-020 [Error] content.opf Frontmatter found, but no half title page. Half title 
+page is required when frontmatter is present.
+m-063 [Error] cover.svg Cover image has not been built.
+s-033 [Manual Review] dedication.xhtml File language is `en-GB`, but 
+`content.opf` language is `LANG`.
+s-033 [Manual Review] epigraph.xhtml File language is `en-US`, but `content.opf`
+language is `LANG`.
+m-036 [Error] imprint.xhtml Variable not replaced with value.
+        PG_URL
+        IA_URL
+c-006 [Error] local.css Semantic found, but missing corresponding style in 
+`local.css`.
+        <abbr epub:type="se:era">
+        <abbr epub:type="se:temperature">
+        <abbr epub:type="z3998:acronym">
+        <blockquote epub:type="z3998:hymn">
+        <blockquote epub:type="z3998:lyrics">
+        <blockquote epub:type="z3998:poem">
+        <blockquote epub:type="z3998:verse">
+        <section id="dedication" epub:type="dedication">
+        <section id="epigraph" epub:type="epigraph">
+        <span class="elision">

--- a/tests/data/lint/c-006/chapter-1.xhtml
+++ b/tests/data/lint/c-006/chapter-1.xhtml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
+	<head>
+		<title>I</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="bodymatter z3998:fiction">
+		<section id="chapter-1" epub:type="chapter">
+			<h2 epub:type="ordinal z3998:roman">I</h2>
+			<p>The following abbreviations need CSS styles: <abbr epub:type="se:era">AD</abbr>, <abbr epub:type="se:temperature">C</abbr>, <abbr epub:type="z3998:acronym">A.B.C.</abbr>.</p>
+			<blockquote epub:type="z3998:hymn">
+				<p>
+					<span>Line 1</span>
+					<br/>
+					<span class="elision">⋮</span>
+					<br/>
+					<span>Line 2</span>
+				</p>
+			</blockquote>
+			<blockquote epub:type="z3998:lyrics">
+				<p>
+					<span>Line 1</span>
+					<br/>
+					<span>Line 2</span>
+				</p>
+			</blockquote>
+			<blockquote epub:type="z3998:poem">
+				<p>
+					<span>Line 1</span>
+					<br/>
+					<span>Line 2</span>
+				</p>
+			</blockquote>
+			<blockquote epub:type="z3998:verse">
+				<p>
+					<span>Line 1</span>
+					<br/>
+					<span>Line 2</span>
+				</p>
+			</blockquote>
+		</section>
+	</body>
+</html>

--- a/tests/data/lint/c-006/dedication.xhtml
+++ b/tests/data/lint/c-006/dedication.xhtml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
+	<head>
+		<title>Dedication</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="frontmatter z3998:non-fiction">
+		<section id="dedication" epub:type="dedication">
+			<p>Dedication.</p>
+		</section>
+	</body>
+</html>

--- a/tests/data/lint/c-006/epigraph.xhtml
+++ b/tests/data/lint/c-006/epigraph.xhtml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-US">
+	<head>
+		<title>Epigraph</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="frontmatter">
+		<section id="epigraph" epub:type="epigraph">
+			<blockquote>
+				<p>Quotation</p>
+				<cite>Author</cite>
+			</blockquote>
+		</section>
+	</body>
+</html>

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -7,7 +7,7 @@ import pytest
 from helpers import assemble_book, run, output_is_golden
 
 
-@pytest.mark.parametrize("test_name", ["clean", "content", "s-058", "glossaries", "elements"])
+@pytest.mark.parametrize("test_name", ["c-006", "clean", "content", "s-058", "glossaries", "elements"])
 def test_lint(data_dir: Path, draft_dir: Path, work_dir: Path, capfd, test_name: str, update_golden: bool):
 	"""Run lint command on several books with different expected lint output:
 		clean   - No errors expected


### PR DESCRIPTION
Added checks to se_epub_lint.py for missing dedication and epigraph CSS. These are placed close to the checks for missing poetry CSS, after what seemed to be the end of the poetry-related checks.

Added test data, test name, and output/golden file for missing dedication and epigraph CSS as well as all the other missing styles that lint checks for (span.elision; abbreviations with se:era, se:temperature, and z3998:acronym epub:type attributes; and elements with z3998:poem, :hymn, :verse, :lyrics epub:type attributes).

Closes #612.