### PR TITLE
Use explicit margins to center imprint text

### DIFF
--- a/se/data/templates/se.css
+++ b/se/data/templates/se.css
@@ -39,14 +39,21 @@ img[epub|type~="z3998:publisher-logo"]{
 
 section[epub|type~="colophon"] p,
 section[epub|type~="imprint"] p{
-	margin: 1em auto 0 auto;
+	margin-top: 1em;
+	margin-bottom: 0;
 	text-indent: 0;
+}
+
+section[epub|type~="colophon"] p{
+	margin-left: 0;
+	margin-right: 0;
 }
 
 section[epub|type~="imprint"] p{
 	font-size: .75em;
+	margin-left: 12.5%;
+	margin-right: 12.5%;
 	text-align: justify;
-	width: 75%;
 }
 
 section[epub|type~="colophon"] p + p::before{


### PR DESCRIPTION
Despite Standard Ebooks providing azw3 files I still prefer to send epubs to my Kindle via 'Send to Kindle' for the ease of use and file syncing benefits. The conversion under-the-hood actually works well for most of Standard Ebooks' ebooks, with the exception of the imprint page which doesn't center correctly.

This tweak to the CSS fixes the centering issue without affecting how it should look for other readers, so could allow people to send epubs to their kindles more reliably (at least until hell freezes over and Amazon allows azw3 files to be sent instead).