### PR TITLE
Remove dependency on distutils

### DIFF
--- a/se/commands/compare_versions.py
+++ b/se/commands/compare_versions.py
@@ -3,7 +3,6 @@ This module implements the `se compare-versions` command.
 """
 
 import argparse
-from distutils.dir_util import copy_tree # pylint: disable=deprecated-module
 import shutil
 import tempfile
 from pathlib import Path
@@ -64,10 +63,7 @@ def compare_versions(plain_output: bool) -> int:
 
 			with tempfile.TemporaryDirectory() as work_directory_name:
 				# Copy the Git repo to a temp folder, so we can stash and pop with impunity.
-				# If we work directly on the real repo, ctrl + c may leave it in a stashed state unexpectedly.
-				# We have to use this function instead of shutil.copytree because shutil.copytree
-				# raises an error if the directory exists, in Python 3.6. Python 3.8+ has an option to ignore that.
-				copy_tree(target, work_directory_name)
+				shutil.copytree(target, work_directory_name, dirs_exist_ok=True)
 
 				target_filenames = set()
 

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -11,7 +11,6 @@ import os
 import shutil
 import subprocess
 import tempfile
-from distutils.dir_util import copy_tree # pylint: disable=deprecated-module
 from copy import deepcopy
 from hashlib import sha1
 from html import unescape
@@ -162,7 +161,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 		work_dir = Path(temp_dir)
 		work_compatible_epub_dir = work_dir / self.path.name
 
-		copy_tree(self.epub_root_path, str(work_compatible_epub_dir))
+		shutil.copytree(self.epub_root_path, str(work_compatible_epub_dir), dirs_exist_ok=True)
 
 		shutil.rmtree(work_compatible_epub_dir / ".git", ignore_errors=True)
 
@@ -676,7 +675,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 
 		if build_kobo:
 			work_kepub_dir = Path(work_dir / (work_compatible_epub_dir.name + ".kepub"))
-			copy_tree(work_compatible_epub_dir, str(work_kepub_dir))
+			shutil.copytree(work_compatible_epub_dir, str(work_kepub_dir), dirs_exist_ok=True)
 
 			for file_path in work_kepub_dir.glob("**/*"):
 				# Add a note to the metadata file indicating this is a transform build


### PR DESCRIPTION
Use the `shutil.copytree` function as a direct replacement for `distutils.dir_util.copy_tree`. It offers a more straightforward interface and is well-supported in modern Python versions.

I noticed in a mailing list [thread](https://groups.google.com/g/standardebooks/c/63Sd9mLnfT4/m/Rucf1m3jAQAJ), that folks were getting stuck on this. It might also simplify installation instead of needed to pin the Python version to 3.11

I havent tested this yet, because the change itself was pretty straightforward and I was able to do it using Github's web interface. But if this sounds like a good idea, I am happy to setup the toolchain on my desktop and perform some tests.