### PR TITLE
Allow non-breaking spaces to tie together title blocks in draft creation

### DIFF
--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -94,7 +94,8 @@ def _get_word_widths(string: str, target_height: int) -> list:
 	"""
 
 	words = []
-	for word in reversed(string.split()):
+	# Forcing a split on " " means that we can use non-breaking spaces to tie together blocks (e.g. Mrs. Seacole)
+	for word in reversed(string.strip().split(" ")):
 		width = 0
 
 		for char in word:

--- a/se/formatting.py
+++ b/se/formatting.py
@@ -1128,8 +1128,8 @@ def titlecase(text: str) -> str:
 	# So, convert to all lowercase first.
 	text = text.lower()
 
-	# Replace all white space except hair space with a space character
-	text = regex.sub(fr"[^\S{se.HAIR_SPACE}]+", " ", text)
+	# Replace all white space except hair spaces and non-breaking spaces with a space character
+	text = regex.sub(fr"[^\S{se.HAIR_SPACE}{se.NO_BREAK_SPACE}]+", " ", text)
 
 	text = pip_titlecase(text)
 
@@ -1258,6 +1258,10 @@ def titlecase(text: str) -> str:
 
 	# Like `Will-o’-the-Wisp`
 	text = regex.sub(r"(?<=-)(O’|The)-", lambda result: result.group(1).lower() + "-", text)
+
+	# Fix non-breaking spaces - we can assume that they’re intentionally used in names
+	# If `titlecase` is fixed we can remove this, see https://github.com/ppannuto/python-titlecase/issues/95
+	text = regex.sub(fr"{se.NO_BREAK_SPACE}([a-z])", lambda result: " " + result.group(1).upper(), text)
 
 	return text
 


### PR DESCRIPTION
For example, this allows “Mrs. Seacole” to be entered as “Mrs. Seacole” to be kept on the same line during title generation.

As it stands, this commit changes non-breaking spaces back to normal spaces during the build process, so that they don’t show up in content.opf metadata for example. But that’s easily changed so that they’re retained.

Also, https://github.com/ppannuto/python-titlecase/issues/95 would remove the need for one of the changes, so I’ll remove it if that’s accepted.