### PR TITLE
Changes to build-toc to address issue #628

### DIFF
--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -638,6 +638,8 @@ def evaluate_descendants(node: EasyXmlElement, toc_item: TocItem, textf: str) ->
 					# this is the only time we need to worry about the language of the title
 					if not toc_item.lang:
 						toc_item.lang = child.get_attr("xml:lang")
+
+		if toc_item.title and toc_item.subtitle:  # then we're done, get out of loop by returning
 			return toc_item
 	return toc_item
 

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -591,8 +591,6 @@ def evaluate_descendants(node: EasyXmlElement, toc_item: TocItem, textf: str) ->
 	"""
 	children = node.xpath("./p | ./h1 | ./h2 | ./h3 | ./h4 | ./h5 | ./h6")
 	for child in children:  # we expect these to be h1, h2, h3, h4 etc
-		if not toc_item.lang:
-			toc_item.lang = child.get_attr("xml:lang")
 		epub_type = child.get_attr("epub:type")
 
 		if child.get_attr("hidden"):
@@ -637,7 +635,9 @@ def evaluate_descendants(node: EasyXmlElement, toc_item: TocItem, textf: str) ->
 					toc_item.subtitle = extract_strings(child)
 				else:
 					toc_item.title = extract_strings(child)
-		if toc_item.title and toc_item.subtitle:  # then we're done
+					# this is the only time we need to worry about the language of the title
+					if not toc_item.lang:
+						toc_item.lang = child.get_attr("xml:lang")
 			return toc_item
 	return toc_item
 

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -633,9 +633,10 @@ def evaluate_descendants(node: EasyXmlElement, toc_item: TocItem, textf: str) ->
 			if "title" in epub_type:  # this allows for `fulltitle` to work here, too
 				if toc_item.title or toc_item.roman or toc_item.title_is_ordinal:  # if title already filled, must be a subtitle
 					toc_item.subtitle = extract_strings(child)
+					if toc_item.roman or toc_item.title_is_ordinal:  # in these cases, we want to check language on subtitle
+						toc_item.lang = child.get_attr("xml:lang")
 				else:
 					toc_item.title = extract_strings(child)
-					# this is the only time we need to worry about the language of the title
 					if not toc_item.lang:
 						toc_item.lang = child.get_attr("xml:lang")
 


### PR DESCRIPTION
I've altered where we check for a language tag in build-toc which seems to fix the problem in issue #628.

I've run a comparison between the results of new and old tocs and the only productions which don't match are either ones that always required a manual adjustment to the ToC or a handful of others which have unrelated issues (though some of these mean I should recheck my code in other areas.

For reference, the **non-matching** ToCs after this change to build-toc are as follows. The line numbers are in the ToC for each production.

- anatole-france_penguin-island_a-w-evans : line 132
- arthur-w-pinero_the-second-mrs-tanqueray : line 20
- friedrich-nietzsche_beyond-good-and-evil_helen-zimmern : line 236
- george-macdonald_phantastes : line 17
- honore-de-balzac_shorts-from-scenes-from-private-life_clara-bell_ellen-marriage : line 27
- james-branch-cabell_domnei : line 17
- jean-toomer_cane : line 27
- john-locke_some-thoughts-concerning-education : line 20
- ludwig-wittgenstein_tractatus-logico-philosophicus_c-k-ogden : line 32
- p-g-wodehouse_short-fiction : line 82
- t-e-lawrence_seven-pillars-of-wisdom : line 453
- wilfred-owen_poetry : line 76