### PR TITLE
Added getting the id of a special item

### DIFF
--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -474,7 +474,7 @@ def get_toc_id_for_special_item(node: EasyXmlElement) -> str:
 		toc_id = parent.get_attr("id")
 		if toc_id:
 			return toc_id
-	return None
+	return ""
 		
 
 def get_level(node: EasyXmlElement, toc_list: list) -> int:

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -57,7 +57,7 @@ class TocItem:
 	subtitle = ""
 	title_is_ordinal = False
 	lang = ""
-	id = ""
+	toc_id = ""
 	epub_type = ""
 	division = BookDivision.NONE
 	place = Position.FRONT
@@ -427,7 +427,7 @@ def process_headings(dom: EasyXmlTree, textf: str, toc_list: list, single_file: 
 		if special_item.title is None:
 			special_item.title = "NO TITLE"
 		special_item.file_link = textf
-		special_item.id = textf.replace('.xhtml','')  # quick and dirty way of getting the id of a special item
+		special_item.toc_id = textf.replace('.xhtml','')  # quick and dirty way of getting the id of a special item
 		special_item.place = place
 		toc_list.append(special_item)
 		return
@@ -485,7 +485,7 @@ def get_level(node: EasyXmlElement, toc_list: list) -> int:
 
 	if data_parent:
 		# see if we can find it in already processed (as we should if spine is correctly ordered)
-		parent_file = [t for t in toc_list if t.id == data_parent]
+		parent_file = [t for t in toc_list if t.toc_id == data_parent]
 		if parent_file:
 			this_level = parent_file[0].level + 1
 			return this_level + depth - 1  # subtract from depth because all headings should have depth >= 1
@@ -512,14 +512,14 @@ def process_a_heading(node: EasyXmlElement, textf: str, is_toplevel: bool, singl
 
 	# is_top_level stops the first heading in a file getting an anchor id, we don't generally want that.
 	# The exceptions are things like poems within a single-file volume.
-	toc_item.id = get_parent_id(node)  # pylint: disable=invalid-name
-	if toc_item.id == "":
+	toc_item.toc_id = get_parent_id(node)  # pylint: disable=invalid-name
+	if toc_item.toc_id == "":
 		toc_item.file_link = textf
 	else:
 		if not is_toplevel:
-			toc_item.file_link = f"{textf}#{toc_item.id}"
+			toc_item.file_link = f"{textf}#{toc_item.toc_id}"
 		elif single_file:  # It IS the first heading in the file, but there's only a single content file?
-			toc_item.file_link = f"{textf}#{toc_item.id}"
+			toc_item.file_link = f"{textf}#{toc_item.toc_id}"
 		else:
 			toc_item.file_link = textf
 

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -427,6 +427,9 @@ def process_headings(dom: EasyXmlTree, textf: str, toc_list: list, single_file: 
 		if special_item.title is None:
 			special_item.title = "NO TITLE"
 		special_item.file_link = textf
+		special_item.toc_id = get_toc_id_for_special_item(content_item[0])
+		if not special_item.toc_id: # no id found, report as error
+			raise se.InvalidInputException("Couldn’t determine section or article id in file: [path][link=file://{textf}]{textf}[/][/].")
 		special_item.toc_id = textf.replace('.xhtml','')  # quick and dirty way of getting the id of a special item
 		special_item.place = place
 		toc_list.append(special_item)
@@ -461,6 +464,18 @@ def process_headings(dom: EasyXmlTree, textf: str, toc_list: list, single_file: 
 		is_toplevel = False
 		toc_list.append(toc_item)
 
+
+def get_toc_id_for_special_item(node: EasyXmlElement) -> str:
+	"""
+	Get the id for a 'special item' node
+	"""
+	parent_sections = node.xpath("./ancestor::*[name() = 'section' or name() = 'article']")
+	for parent in parent_sections:
+		toc_id = parent.get_attr("id")
+		if toc_id:
+			return toc_id
+	return None
+		
 
 def get_level(node: EasyXmlElement, toc_list: list) -> int:
 	"""

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -475,7 +475,7 @@ def get_toc_id_for_special_item(node: EasyXmlElement) -> str:
 		if toc_id:
 			return toc_id
 	return ""
-		
+
 
 def get_level(node: EasyXmlElement, toc_list: list) -> int:
 	"""

--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -427,6 +427,7 @@ def process_headings(dom: EasyXmlTree, textf: str, toc_list: list, single_file: 
 		if special_item.title is None:
 			special_item.title = "NO TITLE"
 		special_item.file_link = textf
+		special_item.id = textf.replace('.xhtml','')  # quick and dirty way of getting the id of a special item
 		special_item.place = place
 		toc_list.append(special_item)
 		return


### PR DESCRIPTION
Addresses issue #631 

In this production, part 1, part 2, part 3 etc are "special items" which we create when we find no headings. Such items were not assigned ids in the code. This meant that child items couldn't find their parent id, hence no indenting.

This pull request fixes that by assigning the file name (without the .xhtml) as the toc item id, and they are then found by child items.