### PR TITLE
Show the problematic heading on roman error

### DIFF
--- a/se/se_epub_generate_toc.py
+++ b/se/se_epub_generate_toc.py
@@ -564,7 +564,7 @@ def process_a_heading(node: EasyXmlElement, textf: str, is_toplevel: bool, singl
 			try:
 				roman.fromRoman(toc_item.roman)
 			except roman.InvalidRomanNumeralError as err:
-				raise se.InvalidInputException(f"Heading tagged as roman numeral is invalid: [path][link=file://{textf}]{textf}[/][/].") from err
+				raise se.InvalidInputException(f"Heading tagged as roman numeral is invalid: {toc_item.roman} in [path][link=file://{textf}]{textf}[/][/].") from err
 			toc_item.title = f"<span epub:type=\"z3998:roman\">{toc_item.roman}</span>"
 			return toc_item
 		if "ordinal" in epub_type:  # but not a roman numeral (eg in Nietzche's Beyond Good and Evil)
@@ -639,7 +639,7 @@ def evaluate_descendants(node: EasyXmlElement, toc_item: TocItem, textf: str) ->
 			try:
 				roman.fromRoman(toc_item.roman)
 			except roman.InvalidRomanNumeralError as err:
-				raise se.InvalidInputException(f"Heading tagged as roman numeral is invalid: [path][link=file://{textf}]{textf}[/][/].") from err
+				raise se.InvalidInputException(f"Heading tagged as roman numeral is invalid: {toc_item.roman} in [path][link=file://{textf}]{textf}[/][/].") from err
 			if not toc_item.title:
 				toc_item.title = f"<span epub:type=\"z3998:roman\">{toc_item.roman}</span>"
 		elif "ordinal" in epub_type:  # but not a roman numeral or a labelled item, cases caught caught above


### PR DESCRIPTION
Previously it just gave a file reference, which doesn’t help much in poetry compilations for example. This bit me on the Mina Loy compilation.

Before:
```
Error  Heading tagged as roman numeral is invalid: poetry.xhtml.
```

After:
```
 Error  Heading tagged as roman numeral is invalid: XVIX in poetry.xhtml.
```