### PR TITLE
Add a verbose switch to create-draft

### DIFF
--- a/se/completions/bash/se
+++ b/se/completions/bash/se
@@ -54,7 +54,7 @@ _se(){
 				COMPREPLY+=($(compgen -d -X ".*" -- "${cur}"))
 				;;
 			create-draft)
-				COMPREPLY+=($(compgen -W "-a --author -e --email -h --help -i --illustrator -o --offline -p --pg-id -r --translator -t --title -w --white-label" -- "${cur}"))
+				COMPREPLY+=($(compgen -W "-a --author -e --email -h --help -i --illustrator -o --offline -p --pg-id -r --translator -t --title -w --white-label -v --verbose" -- "${cur}"))
 				;;
 			css-select)
 				COMPREPLY+=($(compgen -W "-h --help -f --only-filenames" -- "${cur}"))

--- a/se/completions/fish/se.fish
+++ b/se/completions/fish/se.fish
@@ -54,6 +54,7 @@ complete -c se -A -n "__fish_seen_subcommand_from create-draft" -s o -l offline 
 complete -c se -A -n "__fish_seen_subcommand_from create-draft" -s r -l translator -d "the translator of the ebook"
 complete -c se -A -n "__fish_seen_subcommand_from create-draft" -s t -l title -d "the title of the ebook"
 complete -c se -A -n "__fish_seen_subcommand_from create-draft" -s w -l white-label -d "create a generic epub skeleton without S.E. branding"
+complete -c se -A -n "__fish_seen_subcommand_from create-draft" -s v -l verbose -d "increase output verbosity"
 
 complete -c se -n "__fish_se_no_subcommand" -a css-select -d "Print the results of a CSS selector evaluated against a set of XHTML files."
 complete -c se -A -n "__fish_seen_subcommand_from css-select" -s f -l only-files -x -d "only output filenames of files that contain matches, not the matches themselves"

--- a/se/completions/zsh/_se
+++ b/se/completions/zsh/_se
@@ -132,7 +132,8 @@ case $state in
 					{-p,--pg-id}'[the Project Gutenberg ID number of the ebook to download]' \
 					{-r,--translator}'[the translator of the ebook]' \
 					{-t,--title}'[the title of the ebook]' \
-					{-w,--white-label}'[create a generic epub skeleton without S.E. branding]'
+					{-w,--white-label}'[create a generic epub skeleton without S.E. branding]' \
+					{-v,--verbose}'[increase output verbosity]'
 				;;
 			css-select)
 				_arguments -s \


### PR DESCRIPTION
Sometimes it’s nice to know what’s happening in `create-draft` as it’s working.

Potentially this should maybe be the default? Depends on how Unixy one feels I guess.

Example output:
```
~/C/s/corpus $ se create-draft -t "Test" -a "Test" -p 64384 -v
Creating ebook directory at /Users/robin/Code/standardebooks/corpus/test_test ...
Downloading ebook metadata from https://www.gutenberg.org/ebooks/64384 ...
Downloading ebook transcription from https://www.gutenberg.org/ebooks/64384.html.images ...
Building ebook structure in /Users/robin/Code/standardebooks/corpus/test_test ...
Cleaning transcription ...
Copying in standard files ...
Setting up ebook metadata ...
Initialising git repository ...
```