### PR TITLE
Improve y-005

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -2839,7 +2839,7 @@ def _lint_xhtml_typo_checks(filename: Path, dom: se.easy_xml.EasyXmlTree, file_c
 
 	# Check for commas or periods following exclamation or question marks. Exclude the colophon because we may have painting names with punctuation.
 	if special_file != "colophon":
-		typos = [node.to_string() for node in dom.xpath("//p[re:test(., '[!?][\\.,][^”’]')]")]
+		typos = [node.to_string() for node in dom.xpath("//p[re:test(., '[!?][\\.,]([^”’]|$)')]")]
 		if typos:
 			messages.append(LintMessage("y-005", "Possible typo: question mark or exclamation mark followed by period or comma.", se.MESSAGE_TYPE_WARNING, filename, typos))
 


### PR DESCRIPTION
In creating the test for y-005, I had a `!.` at the end of a paragraph, and it wasn't caught. This adds an OR for EOL so that it will be.

I ran it against the corpus and didn't see that it caught anything, but I assume we _do_ want to catch it if it happened. (It's possible I could have missed something; every book failed lint because of the recent core change that hasn't been rolled out to the corpus yet.)