### PR TITLE
Improve y-014

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -2929,7 +2929,7 @@ def _lint_xhtml_typo_checks(filename: Path, dom: se.easy_xml.EasyXmlTree, file_c
 		messages.append(LintMessage("y-013", "Possible typo: punctuation not within [text]’[/].", se.MESSAGE_TYPE_WARNING, filename, typos))
 
 	# Check for period before dialog tag; try to exclude abbrevations that close a quotation, like `“<abbr>Mr.</abbr>”`.
-	typos = [node.to_string() for node in dom.xpath("/html/body//p[(re:test(., '\\.”\\s[a-z\\s]*?(\\bsaid|[a-z]+ed)') or re:test(., '\\.”\\s(s?he|they?|and)\\b')) and not(.//abbr[following-sibling::node()[re:test(., '^”')]])]")]
+	typos = [node.to_string() for node in dom.xpath("/html/body//p[(re:test(., '\\.”\\s[a-z\\s]*?(\\bsaid|[a-z]+ed\\b)') or re:test(., '\\.”\\s(s?he|they?|we|and)\\b')) and not(.//abbr[following-sibling::node()[re:test(., '^”')]])]")]
 	if typos:
 		messages.append(LintMessage("y-014", "Possible typo: Unexpected [text].[/] at the end of quotation. Hint: If a dialog tag follows, should this be [text],[/]?", se.MESSAGE_TYPE_WARNING, filename, typos))
 


### PR DESCRIPTION
Let's try this again. I managed to insert some bad character or something in the previous one I closed.

I played with this a bit while determining what things to include in the test, and tested some xpaths in the corpus.

The first thing I noticed is that the `|[a-z]+ed` in the first test does not end in `\b`, so it will find "ed" in the middle of a word (and did in my testing), which I don't believe is what you want? That is, I'm assuming you're looking for past tense forms of various verbalization verbs, e.g. whispered, grunted, shrieked, etc., but don't want things like decidedly, dedication, shredding, etc.

Also, from the number of times it occurred in testing I think it would be worth adding "we" to the list of pronouns in the second test.

I ran the updated xpath against the corpus and did not find anything, so the additions don't add any false positives, anyway.