### PR TITLE
Fix broken overflow on wide unusual characters

### DIFF
--- a/se/commands/find_unusual_characters.py
+++ b/se/commands/find_unusual_characters.py
@@ -140,7 +140,7 @@ def find_unusual_characters(plain_output: bool) -> int:
 
 		else:
 			table = Table(show_header=False, show_lines=True, box=box.HORIZONTALS)
-			table.add_column("Character", style="bold", width=1, no_wrap=True)
+			table.add_column("Character", style="bold", no_wrap=True)
 			table.add_column("Code point", style="dim", no_wrap=True)
 			table.add_column("Name")
 			table.add_column("Count", style="dim", no_wrap=True)


### PR DESCRIPTION
Noticed that a 〃 DITTO MARK is apparently too wide for a single character, which means that the width=1 setup in rich.table converts it to an ellipsis in the Terminal. Which was confusing.

Easy fix is just to remove the width constraint.

This was added in https://github.com/standardebooks/tools/commit/000d7c04a3b6ed6a520c3ab251714e9399c65db1, but doesn’t seem to be necessary for anything else I’m missing.