### PR TITLE
Accessibility metadata enhancements

### DIFF
--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -783,10 +783,10 @@ def _create_draft(args: Namespace, plain_output: bool):
 	_copy_template_file("gitignore", repo_path / ".gitignore")
 	_copy_template_file("container.xml", content_path / "META-INF")
 	_copy_template_file("mimetype", content_path)
-	_copy_template_file("onix.xml", content_path / "epub")
 	_copy_template_file("core.css", content_path / "epub" / "css")
 
 	if args.white_label:
+		_copy_template_file("onix-white-label.xml", content_path / "epub" / "onix.xml")
 		_copy_template_file("content-white-label.opf", content_path / "epub" / "content.opf")
 		_copy_template_file("titlepage-white-label.xhtml", content_path / "epub" / "text" / "titlepage.xhtml")
 		_copy_template_file("cover.jpg", content_path / "epub" / "images")
@@ -797,6 +797,7 @@ def _create_draft(args: Namespace, plain_output: bool):
 		_copy_template_file("cover.jpg", repo_path / "images")
 		_copy_template_file("cover.svg", repo_path / "images")
 		_copy_template_file("titlepage.svg", repo_path / "images")
+		_copy_template_file("onix.xml", content_path / "epub")
 		_copy_template_file("local.css", content_path / "epub" / "css")
 		_copy_template_file("se.css", content_path / "epub" / "css")
 		_copy_template_file("logo.svg", content_path / "epub" / "images")

--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -625,7 +625,7 @@ def _create_draft(args: Namespace, plain_output: bool):
 			if not args.offline and translator["name"].lower() != "anonymous":
 				translator["wiki_url"], translator["nacoaf_uri"] = _get_wikipedia_url(translator["name"], True)
 
-		# Get data on illlustrators
+		# Get data on illustrators
 		for _, illustrator in enumerate(illustrators):
 			if not args.offline and illustrator["name"].lower() != "anonymous":
 				illustrator["wiki_url"], illustrator["nacoaf_uri"] = _get_wikipedia_url(illustrator["name"], True)

--- a/se/data/templates/content.opf
+++ b/se/data/templates/content.opf
@@ -15,8 +15,8 @@
 		<meta property="file-as" refines="#type-designer">League of Moveable Type, The</meta>
 		<meta property="se:url.homepage" refines="#type-designer">https://www.theleagueofmoveabletype.com</meta>
 		<meta property="role" refines="#type-designer" scheme="marc:relators">tyd</meta>
-		<link href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa" rel="dcterms:conformsTo"/>
-		<meta property="a11y:certifiedBy">Standard Ebooks</meta>
+		<meta property="dcterms:conformsTo" id="conformance-statement">EPUB Accessibility 1.1 - WCAG 2.2 Level AA</meta>
+		<meta property="a11y:certifiedBy" refines="#conformance-statement">Standard Ebooks</meta>
 		<meta property="schema:accessMode">textual</meta>
 		<meta property="schema:accessModeSufficient">textual</meta>
 		<meta property="schema:accessibilityFeature">readingOrder</meta>

--- a/se/data/templates/onix-white-label.xml
+++ b/se/data/templates/onix-white-label.xml
@@ -2,7 +2,7 @@
 <ONIXMessage xmlns="http://ns.editeur.org/onix/3.1/reference" release="3.1">
 	<Header>
 		<Sender>
-			<SenderName>Standard Ebooks</SenderName>
+			<SenderName>Publisher Name</SenderName>
 		</Sender>
 		<SentDateTime>2014-05-25T00:00:00Z</SentDateTime>
 	</Header>
@@ -52,12 +52,6 @@
 				<!--WCAG level AA-->
 				<ProductFormFeatureType>09</ProductFormFeatureType>
 				<ProductFormFeatureValue>85</ProductFormFeatureValue>
-			</ProductFormFeature>
-			<ProductFormFeature>
-				<!--Publisher contact for further accessibility information-->
-				<ProductFormFeatureType>09</ProductFormFeatureType>
-				<ProductFormFeatureValue>99</ProductFormFeatureValue>
-				<ProductFormFeatureDescription>standardebooks@googlegroups.com</ProductFormFeatureDescription>
 			</ProductFormFeature>
 		</DescriptiveDetail>
 	</Product>

--- a/se/data/templates/onix-white-label.xml
+++ b/se/data/templates/onix-white-label.xml
@@ -2,57 +2,11 @@
 <ONIXMessage xmlns="http://ns.editeur.org/onix/3.1/reference" release="3.1">
 	<Header>
 		<Sender>
-			<SenderName>Publisher Name</SenderName>
+			<SenderName></SenderName>
 		</Sender>
 		<SentDateTime>2014-05-25T00:00:00Z</SentDateTime>
 	</Header>
 	<Product>
-		<DescriptiveDetail>
-			<ProductFormFeature>
-				<!--Compliant with ePub Accessibility Spec v1.1-->
-				<ProductFormFeatureType>09</ProductFormFeatureType>
-				<ProductFormFeatureValue>04</ProductFormFeatureValue>
-			</ProductFormFeature>
-			<ProductFormFeature>
-				<!--No reading system accessibility options disabled-->
-				<ProductFormFeatureType>09</ProductFormFeatureType>
-				<ProductFormFeatureValue>10</ProductFormFeatureValue>
-			</ProductFormFeature>
-			<ProductFormFeature>
-				<!--Table of contents navigation-->
-				<ProductFormFeatureType>09</ProductFormFeatureType>
-				<ProductFormFeatureValue>11</ProductFormFeatureValue>
-			</ProductFormFeature>
-			<ProductFormFeature>
-				<!--Reading order-->
-				<ProductFormFeatureType>09</ProductFormFeatureType>
-				<ProductFormFeatureValue>13</ProductFormFeatureValue>
-			</ProductFormFeature>
-			<ProductFormFeature>
-				<!--Short alternative descriptions-->
-				<ProductFormFeatureType>09</ProductFormFeatureType>
-				<ProductFormFeatureValue>14</ProductFormFeatureValue>
-			</ProductFormFeature>
-			<ProductFormFeature>
-				<!--Language tagging provided-->
-				<ProductFormFeatureType>09</ProductFormFeatureType>
-				<ProductFormFeatureValue>22</ProductFormFeatureValue>
-			</ProductFormFeature>
-			<ProductFormFeature>
-				<!--All non-decorative content supports reading without sight-->
-				<ProductFormFeatureType>09</ProductFormFeatureType>
-				<ProductFormFeatureValue>52</ProductFormFeatureValue>
-			</ProductFormFeature>
-			<ProductFormFeature>
-				<!--WCAG v2.2-->
-				<ProductFormFeatureType>09</ProductFormFeatureType>
-				<ProductFormFeatureValue>82</ProductFormFeatureValue>
-			</ProductFormFeature>
-			<ProductFormFeature>
-				<!--WCAG level AA-->
-				<ProductFormFeatureType>09</ProductFormFeatureType>
-				<ProductFormFeatureValue>85</ProductFormFeatureValue>
-			</ProductFormFeature>
-		</DescriptiveDetail>
+		<DescriptiveDetail></DescriptiveDetail>
 	</Product>
 </ONIXMessage>

--- a/se/data/templates/onix.xml
+++ b/se/data/templates/onix.xml
@@ -9,6 +9,11 @@
 	<Product>
 		<DescriptiveDetail>
 			<ProductFormFeature>
+				<!--Compliant with ePub Accessibility Spec v1.1-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>04</ProductFormFeatureValue>
+			</ProductFormFeature>
+			<ProductFormFeature>
 				<!--No reading system accessibility options disabled-->
 				<ProductFormFeatureType>09</ProductFormFeatureType>
 				<ProductFormFeatureValue>10</ProductFormFeatureValue>
@@ -32,6 +37,21 @@
 				<!--Language tagging provided-->
 				<ProductFormFeatureType>09</ProductFormFeatureType>
 				<ProductFormFeatureValue>22</ProductFormFeatureValue>
+			</ProductFormFeature>
+			<ProductFormFeature>
+				<!--All non-decorative content supports reading without sight-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>52</ProductFormFeatureValue>
+			</ProductFormFeature>
+			<ProductFormFeature>
+				<!--WCAG v2.2-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>82</ProductFormFeatureValue>
+			</ProductFormFeature>
+			<ProductFormFeature>
+				<!--WCAG level AA-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>85</ProductFormFeatureValue>
 			</ProductFormFeature>
 		</DescriptiveDetail>
 	</Product>

--- a/se/data/templates/onix.xml
+++ b/se/data/templates/onix.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ONIXMessage xmlns="http://ns.editeur.org/onix/3.0/reference" release="3.0">
+<ONIXMessage xmlns="http://ns.editeur.org/onix/3.1/reference" release="3.1">
 	<Header>
 		<Sender>
 			<SenderName>Standard Ebooks</SenderName>

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -69,7 +69,7 @@ class SeEpub:
 	content_path: Path = Path() # The path to the epub content base, i.e. self.epub_root_path / epub
 	metadata_file_path: Path = Path() # The path to the metadata file, i.e. self.content_path / content.opf
 	onix_path: Path = Path() # The path to the ONIX file, i.e. self.content_path / onix.xml
-	toc_path: Path = Path()  # The path to the metadata file, i.e. self.content_path / toc.xhtml
+	toc_path: Path = Path()  # The path to the ToC file, i.e. self.content_path / toc.xhtml
 	glossary_search_key_map_path = None # The path to the glossary search key map, or None
 	local_css = ""
 	is_se_ebook = True
@@ -224,7 +224,7 @@ class SeEpub:
 		"""
 		Accessor
 
-		Generate an SE identifer based on the metadata in the metadata file.
+		Generate an SE identifier based on the metadata in the metadata file.
 		"""
 
 		if not self._generated_identifier:

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -68,6 +68,7 @@ class SeEpub:
 	epub_root_path = Path() # The path to the epub source root, i.e. self.path / src
 	content_path: Path = Path() # The path to the epub content base, i.e. self.epub_root_path / epub
 	metadata_file_path: Path = Path() # The path to the metadata file, i.e. self.content_path / content.opf
+	onix_path: Path = Path() # The path to the ONIX file, i.e. self.content_path / onix.xml
 	toc_path: Path = Path()  # The path to the metadata file, i.e. self.content_path / toc.xhtml
 	glossary_search_key_map_path = None # The path to the glossary search key map, or None
 	local_css = ""
@@ -110,11 +111,18 @@ class SeEpub:
 			raise se.InvalidSeEbookException("Target doesn’t appear to be an epub: no [path]container.xml[/] or no metadata file.") from ex
 
 		self.content_path = self.metadata_file_path.parent
+		self.onix_path = self.content_path / "onix.xml"
 
 		try:
 			self.metadata_dom = self.get_dom(self.metadata_file_path)
 		except Exception as ex:
 			raise se.InvalidXmlException(f"Couldn’t parse [path][link=file://{self.metadata_file_path}]{self.metadata_file_path}[/][/]. Exception: {ex}") from ex
+
+		try:
+			self.onix_path = self.content_path / "onix.xml"
+			self.onix_dom = self.get_dom(self.onix_path)
+		except Exception as ex:
+			raise se.InvalidXmlException(f"Couldn’t parse [path][link=file://{self.onix_path}]{self.onix_path}[/][/]. Exception: {ex}") from ex
 
 		toc_href = self.metadata_dom.xpath("/package/manifest/item[contains(@properties, 'nav')]/@href", True)
 		if toc_href:

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -1020,7 +1020,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 
 							mathml_count = mathml_count + 1
 
-					# Do we still have mathml in this file?. If not, remove the namespace and also the `mathml` propery from the metadata file.
+					# Do we still have MathML in this file? If not, remove the namespace and also the `mathml` property from the metadata file.
 					if not dom.xpath("/html/body//*[namespace-uri()='http://www.w3.org/1998/Math/MathML']"):
 						# Remove unused namespaces, e.g. mathml
 						etree.cleanup_namespaces(dom.etree)

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -244,6 +244,7 @@ METADATA
 "m-075", "Multiple page scans found in metadata, but no link to [text]EBOOK_URL#page-scans[/]."
 "m-076", "gutenberg.net.au URL should not have leading [text]www.[/]."
 "m-077", "MathML found in ebook, but no [attr]schema:accessibilityFeature[/] properties set to [val]MathML[/] and [val]describedMath[/] in metadata."
+"m-078", "MathML found in ebook, but no MathML accessibility [xml]<ProductFormFeatureValue>17</ProductFormFeatureValue>[/] set in ONIX data."
 
 SEMANTICS & CONTENT
 "s-001", "Illegal numeric entity (like [xhtml]&#913;[/])."
@@ -2195,6 +2196,10 @@ def _lint_xhtml_syntax_checks(self, filename: Path, dom: se.easy_xml.EasyXmlTree
 	nodes = dom.xpath("/html/body//m:math")
 	if nodes and len(self.metadata_dom.xpath("/package/metadata/meta[@property='schema:accessibilityFeature' and text() = 'describedMath']")) == 0:
 		messages.append(LintMessage("m-077", "MathML found in ebook, but no [attr]schema:accessibilityFeature[/] properties set to [val]MathML[/] and [val]describedMath[/] in metadata.", se.MESSAGE_TYPE_ERROR, filename, [node.to_string() for node in nodes]))
+
+	# …and no ONIX MathML feature
+	if nodes and len(self.onix_dom.xpath("//ProductFormFeatureType[text()='09']/following-sibling::ProductFormFeatureValue[text()='17']")) == 0:
+		messages.append(LintMessage("m-078", "MathML found in ebook, but no MathML accessibility [xml]<ProductFormFeatureValue>17</ProductFormFeatureValue>[/] set in ONIX data.", se.MESSAGE_TYPE_ERROR, filename, [node.to_string() for node in nodes]))
 
 	# Check for common errors in language tags
 	# `gr` is often used instead of `el`, `sp` instead of `es`, and `ge` instead of `de` (`ge` is the Georgian geographic region subtag but not a language subtag itself)

--- a/tests/data/draftbook/jane-austen_draft-novel/src/epub/onix.xml
+++ b/tests/data/draftbook/jane-austen_draft-novel/src/epub/onix.xml
@@ -9,6 +9,11 @@
 	<Product>
 		<DescriptiveDetail>
 			<ProductFormFeature>
+				<!--Compliant with ePub Accessibility Spec v1.1-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>04</ProductFormFeatureValue>
+			</ProductFormFeature>
+			<ProductFormFeature>
 				<!--No reading system accessibility options disabled-->
 				<ProductFormFeatureType>09</ProductFormFeatureType>
 				<ProductFormFeatureValue>10</ProductFormFeatureValue>
@@ -32,6 +37,21 @@
 				<!--Language tagging provided-->
 				<ProductFormFeatureType>09</ProductFormFeatureType>
 				<ProductFormFeatureValue>22</ProductFormFeatureValue>
+			</ProductFormFeature>
+			<ProductFormFeature>
+				<!--All non-decorative content supports reading without sight-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>52</ProductFormFeatureValue>
+			</ProductFormFeature>
+			<ProductFormFeature>
+				<!--WCAG v2.2-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>82</ProductFormFeatureValue>
+			</ProductFormFeature>
+			<ProductFormFeature>
+				<!--WCAG level AA-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>85</ProductFormFeatureValue>
 			</ProductFormFeature>
 		</DescriptiveDetail>
 	</Product>

--- a/tests/data/draftbook/jane-austen_draft-novel/src/epub/onix.xml
+++ b/tests/data/draftbook/jane-austen_draft-novel/src/epub/onix.xml
@@ -53,6 +53,12 @@
 				<ProductFormFeatureType>09</ProductFormFeatureType>
 				<ProductFormFeatureValue>85</ProductFormFeatureValue>
 			</ProductFormFeature>
+			<ProductFormFeature>
+				<!--Publisher contact for further accessibility information-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>99</ProductFormFeatureValue>
+				<ProductFormFeatureDescription>standardebooks@googlegroups.com</ProductFormFeatureDescription>
+			</ProductFormFeature>
 		</DescriptiveDetail>
 	</Product>
 </ONIXMessage>

--- a/tests/data/draftbook/jane-austen_draft-novel/src/epub/onix.xml
+++ b/tests/data/draftbook/jane-austen_draft-novel/src/epub/onix.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ONIXMessage xmlns="http://ns.editeur.org/onix/3.0/reference" release="3.0">
+<ONIXMessage xmlns="http://ns.editeur.org/onix/3.1/reference" release="3.1">
 	<Header>
 		<Sender>
 			<SenderName>Standard Ebooks</SenderName>

--- a/tests/data/testbook/jane-austen_test-novel/src/epub/onix.xml
+++ b/tests/data/testbook/jane-austen_test-novel/src/epub/onix.xml
@@ -9,6 +9,11 @@
 	<Product>
 		<DescriptiveDetail>
 			<ProductFormFeature>
+				<!--Compliant with ePub Accessibility Spec v1.1-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>04</ProductFormFeatureValue>
+			</ProductFormFeature>
+			<ProductFormFeature>
 				<!--No reading system accessibility options disabled-->
 				<ProductFormFeatureType>09</ProductFormFeatureType>
 				<ProductFormFeatureValue>10</ProductFormFeatureValue>
@@ -32,6 +37,21 @@
 				<!--Language tagging provided-->
 				<ProductFormFeatureType>09</ProductFormFeatureType>
 				<ProductFormFeatureValue>22</ProductFormFeatureValue>
+			</ProductFormFeature>
+			<ProductFormFeature>
+				<!--All non-decorative content supports reading without sight-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>52</ProductFormFeatureValue>
+			</ProductFormFeature>
+			<ProductFormFeature>
+				<!--WCAG v2.2-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>82</ProductFormFeatureValue>
+			</ProductFormFeature>
+			<ProductFormFeature>
+				<!--WCAG level AA-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>85</ProductFormFeatureValue>
 			</ProductFormFeature>
 		</DescriptiveDetail>
 	</Product>

--- a/tests/data/testbook/jane-austen_test-novel/src/epub/onix.xml
+++ b/tests/data/testbook/jane-austen_test-novel/src/epub/onix.xml
@@ -53,6 +53,12 @@
 				<ProductFormFeatureType>09</ProductFormFeatureType>
 				<ProductFormFeatureValue>85</ProductFormFeatureValue>
 			</ProductFormFeature>
+			<ProductFormFeature>
+				<!--Publisher contact for further accessibility information-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>99</ProductFormFeatureValue>
+				<ProductFormFeatureDescription>standardebooks@googlegroups.com</ProductFormFeatureDescription>
+			</ProductFormFeature>
 		</DescriptiveDetail>
 	</Product>
 </ONIXMessage>

--- a/tests/data/testbook/jane-austen_test-novel/src/epub/onix.xml
+++ b/tests/data/testbook/jane-austen_test-novel/src/epub/onix.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ONIXMessage xmlns="http://ns.editeur.org/onix/3.0/reference" release="3.0">
+<ONIXMessage xmlns="http://ns.editeur.org/onix/3.1/reference" release="3.1">
 	<Header>
 		<Sender>
 			<SenderName>Standard Ebooks</SenderName>


### PR DESCRIPTION
This is a first set of accessibility metadata enhancements, after a review of ePub Accessibility 1.1 and ONIX 3.1. There are potentially more to follow, but those can be discussed in the accessibility metadata issue. Broadly, these:

- Update the default ONIX file to the latest spec and a more correct set of accessibility claims
- Update content.opf to claim support for the latest standard
- Add lint and build support for ONIX MathML feature claim
- Add a white label ONIX file that doesn’t link to SE’s group and doesn’t have SE set as the publisher

Fallout from this for the corpus:

- All books will need to be updated to the latest `onix.xml`
- All books will need the accessibility data updated in content.opf (easy find and replace)
- Books with MathML will need the additional MathML feature added to their onix.xml