### PR TITLE
modernize-spelling: suttee → sati

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -444,6 +444,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b([Mm])etier", r"\1étier", xhtml)				# metier -> métier
 	xhtml = regex.sub(r"\b([Cc])igaret(s?)\b", r"\1igarette\2", xhtml)		# cigaret -> cigarette
 	xhtml = regex.sub(r"\b([Dd])umbfounder", r"\1umbfound", xhtml)			# dumbfoundered -> dumbfounded
+	xhtml = regex.sub(r"\b([Ss])uttee", r"\1ati", xhtml)				# suttee -> sati
 
 
 	# Normalize some names


### PR DESCRIPTION
Merriam‐Webster considers “sati” and “suttee” to be [the same word](https://www.merriam-webster.com/dictionary/sati).

[Wikipedia uses the spelling “sati,” and says:](https://en.wikipedia.org/wiki/Sati_(practice)#Etymology_and_usage)

> Sati appears in Hindi and Sanskrit texts, where it is synonymous with "good wife"; the term suttee was commonly used by Anglo-Indian English writers.…
>
> The spelling suttee is a phonetic spelling using 19th-century English orthography. The satī transliteration uses the more modern ISO/IAST (International Alphabet of Sanskrit Transliteration), the academic standard for writing the Sanskrit language with the Latin alphabet system.

(Note: that last usage is spelled with U+012B ī, but the rest of the article uses plain old *i*.)

I count about a dozen SE works that use *suttee*. (richard-f-burton/vikram-and-the-vampire uses both spellings.)