### PR TITLE
Add a link to our accessibility page to the ONIX message

### DIFF
--- a/se/data/templates/content.opf
+++ b/se/data/templates/content.opf
@@ -15,7 +15,7 @@
 		<meta property="file-as" refines="#type-designer">League of Moveable Type, The</meta>
 		<meta property="se:url.homepage" refines="#type-designer">https://www.theleagueofmoveabletype.com</meta>
 		<meta property="role" refines="#type-designer" scheme="marc:relators">tyd</meta>
-		<meta property="dcterms:conformsTo" id="conformance-statement">EPUB Accessibility 1.1 - WCAG 2.2 Level AA</meta>
+		<meta id="conformance-statement" property="dcterms:conformsTo">EPUB Accessibility 1.1 - WCAG 2.2 Level AA</meta>
 		<meta property="a11y:certifiedBy" refines="#conformance-statement">Standard Ebooks</meta>
 		<meta property="schema:accessMode">textual</meta>
 		<meta property="schema:accessModeSufficient">textual</meta>

--- a/se/data/templates/onix.xml
+++ b/se/data/templates/onix.xml
@@ -54,6 +54,12 @@
 				<ProductFormFeatureValue>85</ProductFormFeatureValue>
 			</ProductFormFeature>
 			<ProductFormFeature>
+				<!--Publisher’s web page for detailed accessibility information-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>96</ProductFormFeatureValue>
+				<ProductFormFeatureDescription>https://standardebooks.org/about/accessibility</ProductFormFeatureDescription>
+			</ProductFormFeature>
+			<ProductFormFeature>
 				<!--Publisher contact for further accessibility information-->
 				<ProductFormFeatureType>09</ProductFormFeatureType>
 				<ProductFormFeatureValue>99</ProductFormFeatureValue>

--- a/tests/data/draftbook/jane-austen_draft-novel/src/epub/onix.xml
+++ b/tests/data/draftbook/jane-austen_draft-novel/src/epub/onix.xml
@@ -54,6 +54,12 @@
 				<ProductFormFeatureValue>85</ProductFormFeatureValue>
 			</ProductFormFeature>
 			<ProductFormFeature>
+				<!--Publisher’s web page for detailed accessibility information-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>96</ProductFormFeatureValue>
+				<ProductFormFeatureDescription>https://standardebooks.org/about/accessibility</ProductFormFeatureDescription>
+			</ProductFormFeature>
+			<ProductFormFeature>
 				<!--Publisher contact for further accessibility information-->
 				<ProductFormFeatureType>09</ProductFormFeatureType>
 				<ProductFormFeatureValue>99</ProductFormFeatureValue>

--- a/tests/data/testbook/jane-austen_test-novel/src/epub/onix.xml
+++ b/tests/data/testbook/jane-austen_test-novel/src/epub/onix.xml
@@ -54,6 +54,12 @@
 				<ProductFormFeatureValue>85</ProductFormFeatureValue>
 			</ProductFormFeature>
 			<ProductFormFeature>
+				<!--Publisher’s web page for detailed accessibility information-->
+				<ProductFormFeatureType>09</ProductFormFeatureType>
+				<ProductFormFeatureValue>96</ProductFormFeatureValue>
+				<ProductFormFeatureDescription>https://standardebooks.org/about/accessibility</ProductFormFeatureDescription>
+			</ProductFormFeature>
+			<ProductFormFeature>
 				<!--Publisher contact for further accessibility information-->
 				<ProductFormFeatureType>09</ProductFormFeatureType>
 				<ProductFormFeatureValue>99</ProductFormFeatureValue>


### PR DESCRIPTION
Assuming you’re happy with https://github.com/standardebooks/web/pull/352, this adds a reference to it from the ONIX file template. Once this is merged then we can roll out the changes to the corpus.

That’ll be enough to close https://github.com/standardebooks/tools/issues/683. The ebooks and site could do with an accessibility audit, but that can be a seperate project.