### PR TITLE
Fix typo in t-074

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -2750,7 +2750,7 @@ def _lint_xhtml_typography_checks(filename: Path, dom: se.easy_xml.EasyXmlTree, 
 
 	# Check for hyphen-minus instead of non-breaking hyphen in sounds.
 	# Ignore very long <i> as they are more likely to be a sentence containing a dash, than a sound
-	nodes = dom.xpath("/html/body//*[(name() = 'i' or name() = 'em') and not(@epub:type) and not(xml:lang) and re:test(., '-[A-Za-z]-') and string-length(.) < 50]")
+	nodes = dom.xpath("/html/body//*[(name() = 'i' or name() = 'em') and not(@epub:type) and not(@xml:lang) and re:test(., '-[A-Za-z]-') and string-length(.) < 50]")
 	if nodes:
 		messages.append(LintMessage("t-074", "Extended sound using hyphen-minus [text]-[/] instead of non-breaking hyphen [text]‑[/].", se.MESSAGE_TYPE_WARNING, filename, [node.to_string() for node in nodes]))
 


### PR DESCRIPTION
I was running a lint on the corpus to investigate something with the test I'm working on, and noticed that t-074 wasn't ignoring italics with a language tag like it was supposed to. I looked up what the `@` did in xpath, and then added it and tested some of the ones that were failing before, and they don't now, so I'm hopeful this is the correct fix.

Do you want help fixing the t-074's in the corpus?