### PR TITLE
Improve t-074 and its test

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -2745,7 +2745,7 @@ def _lint_xhtml_typography_checks(filename: Path, dom: se.easy_xml.EasyXmlTree, 
 
 	# Check for hyphen-minus instead of non-breaking hyphen in sounds.
 	# Ignore very long <i> as they are more likely to be a sentence containing a dash, than a sound
-	nodes = dom.xpath("/html/body//*[(name() = 'i' or name() = 'em') and not(@epub:type) and not(@xml:lang) and re:test(., '-[A-Za-z]-') and string-length(.) < 50]")
+	nodes = dom.xpath("/html/body//*[(name() = 'i' or name() = 'em') and not(@epub:type) and not(@xml:lang) and re:test(., '-[A-Za-z]-[A-Za-z]-')]")
 	if nodes:
 		messages.append(LintMessage("t-074", "Extended sound using hyphen-minus [text]-[/] instead of non-breaking hyphen [text]‑[/].", se.MESSAGE_TYPE_WARNING, filename, [node.to_string() for node in nodes]))
 

--- a/tests/lint/typography/t-074/golden/t-074-out.txt
+++ b/tests/lint/typography/t-074/golden/t-074-out.txt
@@ -1,7 +1,4 @@
 t-074 [Manual Review] chapter-1.xhtml Extended sound using hyphen-minus `-` 
 instead of non-breaking hyphen `‑`.
         <i>Bor-r-r-r-n!</i>
-        <em>Ow-w-w!</em>
-y-003 [Manual Review] chapter-1.xhtml Possible typo: paragraph missing ending 
-punctuation.
-        <p><i xml:lang="fr">X-x-x-x</i></p>
+        <em>Ow-w-w-w!</em>

--- a/tests/lint/typography/t-074/in/src/epub/text/chapter-1.xhtml
+++ b/tests/lint/typography/t-074/in/src/epub/text/chapter-1.xhtml
@@ -8,14 +8,22 @@
 	<body epub:type="bodymatter z3998:fiction">
 		<section id="chapter-1" epub:type="chapter">
 			<h2 epub:type="ordinal z3998:roman">I</h2>
-			<!-- Ignore, not a sound -->
-			<p><i>Bon-bon.</i></p>
+			<!-- VALID 1, italic -->
+			<p><i>C‑r‑a‑c‑k!</i> A sound with non-breaking hyphen.</p>
+			<!-- VALID 2, emphasis -->
+			<p>He’s <em>out‑t‑t‑t‑a</em> here!</p>
+			<!-- EXCLUSION 1, has an epub:type -->
+			<p>This is <i epub:type="se:name.publication.book">A Book Title with a S-S-S-Sound in It</i>.</p>
+			<!-- EXCLUSION 2, has a language tag -->
+			<p>He threw back his head, <i xml:lang="es">Anoche-e-e</i>!</p>
+			<!-- EXCLUSION 3a, more than one character between the dashes -->
+			<p><i>Bu-bu-bu-but what now?</i></p>
+			<!-- EXCLUSION 3b, only one instance of a single character in dashes -->
+			<p><i>Stay-a-day away!</i></p>
+			<!-- FAIL 1, italic -->
 			<p><i>Bor-r-r-r-n!</i></p>
-			<p><em>Ow-w-w!</em></p>
-			<!-- Ignore, language -->
-			<p><i xml:lang="fr">X-x-x-x</i></p>
-			<!-- Ignore, too long -->
-			<p><i>Can this be the Seigneur du Vallon de Bracieux de Pierrefonds? Well-a-day! how he has shrunk since he gave up the name of Porthos!</i></p>
+			<!-- FAIL 2, emphasis -->
+			<p><em>Ow-w-w-w!</em></p>
 		</section>
 	</body>
 </html>


### PR DESCRIPTION
This changes the t-074 test to look for two consecutive single characters surrounded by dashes. As detailed in our discussion on the other PR, a single character between dashes finds more false positives than using two characters misses (e.g. this will allow to get rid of five ignore files that had to be created today).

I also got rid of the length limit, on the presumption that at least two characters is pretty likely to be a valid hit wherever it's found. (A run on the corpus turned up no false positives.)

(I had already done all this before I tried to pull the PR and saw you had made further changes to the test. Since I had covered more exclusions and had valid entries as well, I went ahead and left my test as it was. It covers everything yours did and more.)

I think a search for a "word" entirely consisting of single-characters and dashes is still something lint can try to catch, but I need to do some more testing before I propose anything. One of the problems is that what's found could be either an unitalicized sound (O-w-w-w-w) or a spelled-out word (w-o-r-d) without grapheme/phoneme tags on the letters, so the message will need to be ambiguous.