### PR TITLE
Remove y-023 from lint, add y-022 thru y-025 tests

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -474,9 +474,8 @@ TYPOS
 "y-019”, "Possible typo: [text]”[/] without opening [text]“[/]."
 "y-020”, "Possible typo: consecutive comma-period ([text],.[/])."
 "y-022”, "Possible typo: consecutive quotations without intervening text, e.g. [text]“…” “…”[/]."
-"y-023”, "Possible typo: two opening quotation marks in a run. Hint: Nested quotes should switch between [text]“[/] and [text]‘[/]"
 "y-024”, "Possible typo: dash before [text]the/there/is/and/they/when[/] probably should be em-dash."
-"y-025”, "Possible typo: comma without space followed by quotation mark."
+"y-025”, "Possible typo: letter/comma/quote mark/letter with no intervening space."
 "y-026”, "Possible typo: no punctuation before conjunction [text]But/And/For/Nor/Yet/Or[/]."
 "y-027”, "Possible typo: Extra [text]’[/] at end of paragraph."
 "y-028”, "Possible typo: [xhtml]<abbr>[/] directly preceded or followed by letter."
@@ -489,6 +488,7 @@ UNUSED
 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 "y-015”, "Possible typo: mis-curled [text]‘[/] or missing [text]’[/]."
 "y-021”, "Possible typo: Opening [text]‘[/] without preceding [text]“[/]."
+"y-023”, "Possible typo: two opening quotation marks in a run. Hint: Nested quotes should switch between [text]“[/] and [text]‘[/]"
 """
 
 class LintMessage:
@@ -3017,25 +3017,20 @@ def _lint_xhtml_typo_checks(filename: Path, dom: se.easy_xml.EasyXmlTree, file_c
 	if typos:
 		messages.append(LintMessage("y-020", "Possible typo: consecutive comma-period ([text],.[/]).", se.MESSAGE_TYPE_WARNING, filename, typos))
 
-	# Check for two quotations in one paragraph
+	# Check for a paragraph consisting entirely of two quotations
 	typos = [node.to_string() for node in dom.xpath("/html/body//p[re:test(., '^“[^”]+?”\\s“[^”]+?”$')]")]
 	if typos:
 		messages.append(LintMessage("y-022", "Possible typo: consecutive quotations without intervening text, e.g. [text]“…” “…”[/].", se.MESSAGE_TYPE_WARNING, filename, typos))
-
-	# Check for incorrectly nested quotation marks
-	typos = [node.to_string() for node in dom.xpath("/html/body//p[re:test(., '^“[^‘”]+“') and not(.//br)]")]
-	if typos:
-		messages.append(LintMessage("y-023", "Possible typo: two opening quotation marks in a run. Hint: Nested quotes should switch between [text]“[/] and [text]‘[/]", se.MESSAGE_TYPE_WARNING, filename, typos))
 
 	# Check for dashes instead of em-dashes
 	typos = [node.to_string() for node in dom.xpath("/html/body//p[re:test(., '\\s[a-z]+-(the|there|is|and|they|when)\\s')]")]
 	if typos:
 		messages.append(LintMessage("y-024", "Possible typo: dash before [text]the/there/is/and/they/when[/] probably should be em-dash.", se.MESSAGE_TYPE_WARNING, filename, typos))
 
-	# Check for comma not followed by space but followed by quotation mark
-	typos = [node.to_string() for node in dom.xpath("/html/body//p[re:test(., '[a-z],[“”‘’][a-z]', 'i')]")]
+	# Check for letter/comma/quote mark/letter with no intervening space (rdquo is already handled by y-012)
+	typos = [node.to_string() for node in dom.xpath("/html/body//p[re:test(., '[a-z],[“‘’][a-z]', 'i')]")]
 	if typos:
-		messages.append(LintMessage("y-025", "Possible typo: comma without space followed by quotation mark.", se.MESSAGE_TYPE_WARNING, filename, typos))
+		messages.append(LintMessage("y-025", "Possible typo: letter/comma/quote mark/letter with no intervening space.", se.MESSAGE_TYPE_WARNING, filename, typos))
 
 	# Check for punctuation missing before conjunctions. Ignore <p> with an <i> child starting in a conjunction, as those are probably book titles or non-English languages
 	typos = [node.to_string() for node in dom.xpath(f"/html/body//p[not(parent::hgroup) and re:test(., '\\b[a-z]+\\s(But|And|For|Nor|Yet|Or)\\b[^’\\.\\?\\-{se.WORD_JOINER}]') and not(./i[re:test(., '^(But|And|For|Nor|Yet|Or)\\b')])]")]

--- a/tests/lint/typos/y-022/golden/y-022-out.txt
+++ b/tests/lint/typos/y-022/golden/y-022-out.txt
@@ -1,0 +1,7 @@
+y-022 [Manual Review] chapter-1.xhtml Possible typo: consecutive quotations 
+without intervening text, e.g. `“…” “…”`.
+        <p>“A bridge is a winter's multi-hop. The rotates could be said to 
+resemble gnomic folds. Authors often misinterpret the composer as a mousey 
+repair, when in actuality it feels more like a salving brush.” “Their wheel was,
+in this moment, an outworn mole. Extending this logic, a health is the velvet of
+a step.”</p>

--- a/tests/lint/typos/y-022/in/src/epub/text/chapter-1.xhtml
+++ b/tests/lint/typos/y-022/in/src/epub/text/chapter-1.xhtml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
+	<head>
+		<title>I</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="bodymatter z3998:fiction">
+		<section id="chapter-1" epub:type="chapter">
+			<h2 epub:type="ordinal z3998:roman">I</h2>
+			<!-- EXCLUSION 1, first quote at BOL, but second not at EOL -->
+			<p>“Unfortunately, that is wrong; on the contrary, a berry is a silver's mole.” An insulation can hardly be considered a thumbless inventory without also being a quiet. “To be more specific, some posit the mettled treatment to be less than monthly.” A hamster is a laborer's rhinoceros. Though we assume the latter, one cannot separate bites from porrect dashboards.</p>
+			<!-- EXCLUSION 2, first quote not at BOL, second at EOL -->
+			<p>Though we assume the latter, a nerve is an unmaimed anime. A cicada can hardly be considered a stylish roll without also being a soybean. “We know that some umpteenth handles are thought of simply as great-grandfathers.” “A mussy creature without routes is truly a stocking of massy oysters.”</p>
+			<!-- EXCLUSION 3, first quote at BOL, second at EOL, but text in-between -->
+			<p>“Before temperatures, ceramics were only ovens.” They were lost without the collapsed sleep that composed their fisherman. A database sees a pencil as a hulky hemp. Before captions, wings were only violins. “Framed in a different way, the literature would have us believe that a foodless viola is not but a sunflower.”</p>
+			<!-- FAIL 1, first quote at BOL, second at EOL, only whitespace between -->
+			<p>“A bridge is a winter's multi-hop. The rotates could be said to resemble gnomic folds. Authors often misinterpret the composer as a mousey repair, when in actuality it feels more like a salving brush.” “Their wheel was, in this moment, an outworn mole. Extending this logic, a health is the velvet of a step.”</p>
+		</section>
+	</body>
+</html>

--- a/tests/lint/typos/y-024/golden/y-023-out.txt
+++ b/tests/lint/typos/y-024/golden/y-023-out.txt
@@ -1,0 +1,9 @@
+t-003 [Manual Review] chapter-1.xhtml `“` missing matching `”`. Note: When 
+dialog from the same speaker spans multiple `<p>` elements, it’s correct grammar
+to omit closing `”` until the last `<p>` of dialog.
+        “The horn of a brass becomes a labrid examination. “
+y-023 [Manual Review] chapter-1.xhtml Possible typo: two opening quotation marks
+in a run. Hint: Nested quotes should switch between `“` and `‘`
+        <p>“The horn of a brass becomes a labrid examination. “Extending this 
+logic, a zoology is the disgust of a permission.” Their windscreen was, in this 
+moment, a chanceless men. The unwept drug comes from a wiry software.</p>

--- a/tests/lint/typos/y-024/golden/y-024-out.txt
+++ b/tests/lint/typos/y-024/golden/y-024-out.txt
@@ -1,0 +1,10 @@
+y-024 [Manual Review] chapter-1.xhtml Possible typo: dash before 
+`the/there/is/and/they/when` probably should be em-dash.
+        <p>The cushion of-the celery becomes a clausal yak.</p>
+        <p>A desk sees-there as a patent description.</p>
+        <p>An unrhymed leopard without kittens-is truly a twist of hoven 
+chives.</p>
+        <p>The twinkling beer-and a broadband business.</p>
+        <p>A chick can hardly be considered a zesty jumbo-they have a copy.</p>
+        <p>They were lost-when the abroad minister that composed their impulse 
+went underground.</p>

--- a/tests/lint/typos/y-024/in/src/epub/text/chapter-1.xhtml
+++ b/tests/lint/typos/y-024/in/src/epub/text/chapter-1.xhtml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
+	<head>
+		<title>I</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="bodymatter z3998:fiction">
+		<section id="chapter-1" epub:type="chapter">
+			<h2 epub:type="ordinal z3998:roman">I</h2>
+			<!-- VALID 1, dash on non-targeted word -->
+			<p>One cannot separate girdles from mirthless editors. However, the literature would have us believe that an incensed light is not but an aluminum. The play-room is a satin. The strutting pea reveals itself as a playful beaver to those who look.</p>
+			<!-- EXCLUSION 1, dash on targeted word, but preceded by caps -->
+			<p>Zealous shelfs show us how desks can be plantations. Nowhere is it disputed that some yolky attentions are thought of simply as marbles. A fear of the <abbr epub:type="z3998:initialism">I.B.M.</abbr>-is assumed to be a mini structure. Extending this logic, an unburnt marble without kidneies is truly a Monday of sincere bubbles. In ancient times the gassy top comes from a faceless command.</p>
+			<!-- EXCLUSION 2, dash on targeted word, but preceding word not preceeded by whitespace. -->
+			<p>And-they be, or perhaps a horn of the seashore is assumed to be a gilded sleet.</p>
+			<!-- EXCLUSION 3, dash on targeted word, but not followed by whitespace. -->
+			<p>The first convex sweatshop is, in its own way, but-when?</p>
+			<!-- FAIL 1, dash before 'the' -->
+			<p>The cushion of-the celery becomes a clausal yak.</p>
+			<!-- FAIL 2, dash before 'there' -->
+			<p>A desk sees-there as a patent description.</p>
+			<!-- FAIL 3, dash before 'is' -->
+			<p>An unrhymed leopard without kittens-is truly a twist of hoven chives.</p>
+			<!-- FAIL 4, dash before 'and' -->
+			<p>The twinkling beer-and a broadband business.</p>
+			<!-- FAIL 5, dash before 'they' -->
+			<p>A chick can hardly be considered a zesty jumbo-they have a copy.</p>
+			<!-- FAIL 6, dasy before 'when' -->
+			<p>They were lost-when the abroad minister that composed their impulse went underground.</p>
+		</section>
+	</body>
+</html>

--- a/tests/lint/typos/y-025/golden/y-025-out.txt
+++ b/tests/lint/typos/y-025/golden/y-025-out.txt
@@ -1,0 +1,8 @@
+y-025 [Manual Review] chapter-1.xhtml Possible typo: letter/comma/quote 
+mark/letter with no intervening space.
+        <p>One cannot separate spaces from rattish trucks,“It's an undeniable 
+fact, really; a lobster sees a surfboard as a crudest colon.”</p>
+        <p>“In modern times few can name an utmost rooster,‘that’ isn't a 
+townless lunchroom.”</p>
+        <p>“We know that a stringent,’Tis without hemps is truly a pedestrian of
+yearly bengals.</p>

--- a/tests/lint/typos/y-025/in/src/epub/text/chapter-1.xhtml
+++ b/tests/lint/typos/y-025/in/src/epub/text/chapter-1.xhtml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
+	<head>
+		<title>I</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="bodymatter z3998:fiction">
+		<section id="chapter-1" epub:type="chapter">
+			<h2 epub:type="ordinal z3998:roman">I</h2>
+			<!-- VALID 1, letter/comma/ldquo/letter with intervening space -->
+			<p>A crocus is the penalty of a robert, “framed in a different way, a withdrawal of the thermometer is assumed to be a blackish washer.” A jaw is a middle's cough. Far from the truth, a welcome wheel without geographies is truly a wash of toeless bankbooks. In recent years, one cannot separate flocks from ventose mayonnaises.</p>
+			<!-- VALID 2, letter/comma/lsquo/letter with intervening space -->
+			<p>“A women sees a court as an imposed advertisement, ‘some’ wedgy tellers are thought of simply as gloves.” One cannot separate garlics from napless forks. Some assert that a xylophone is a route's tanker. The first stumpy letter is, in its own way, a seaplane.</p>
+			<!-- VALID 3, letter/comma/rsquo/letter and character with intervening space -->
+			<p>An agley ant’s hour comes with it the thought that the trendy battery is an attempt. They were lost without the mansard century, ’at composed their technician. “Outbound forecasts show us how equipment can be ‘grades,’ norwegian sees an activity as a wistful speedboat.”</p>
+			<!-- FAIL 1, letter/comma/ldquo/letter, no space -->
+			<p>One cannot separate spaces from rattish trucks,“It's an undeniable fact, really; a lobster sees a surfboard as a crudest colon.”</p>
+			<!-- FAIL 2, letter/comma/lsquo/letter, no space -->
+			<p>“In modern times few can name an utmost rooster,‘that’ isn't a townless lunchroom.”</p>
+			<!-- FAIL 3, letter/comma/rsquo/letter, no space -->
+			<p>“We know that a stringent,’Tis without hemps is truly a pedestrian of yearly bengals.</p>
+		</section>
+	</body>
+</html>


### PR DESCRIPTION
Per discussion, this removes y-023. (I've tried several ways and can't figure out the t-003 change, so I'll leave that with you; it works right now, it's just regex instead of xpath, so it's not pressing). Per another issue I opened a few minutes ago, the rdquo test in y-025 duplicates y-012 (but not vice-versa), so I removed it. I also clarified the message on y-025, because what was there did not align with what was actually being checked (I've been confused by that message on more than one occasion, and have had to look at the code each time).