### PR TITLE
Update mypy / pylint / pytest and make everything work on latest Pythons

### DIFF
--- a/.github/workflows/se-test.yml
+++ b/.github/workflows/se-test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install pipx packages
       run: |
         pipx install .
-        pipx inject standardebooks pylint==2.17.3 pytest==7.3.1 mypy==1.2.0 types-requests==2.28.11.17 types-setuptools==67.7.0.0 types-Pillow==10.2.0.20240331
+        pipx inject standardebooks pytest==8.2.2 pylint==3.2.2 mypy==1.10.0 types-requests==2.32.0.20240602 types-setuptools==70.0.0.20240524 types-Pillow==10.2.0.20240520
     - name: Check type annotations with mypy
       run: $PIPX_HOME/venvs/standardebooks/bin/mypy
     - name: Check code with pylint

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ We export `COLUMNS` because `se lint` needs to know the width of the terminal so
 Before we can use `pylint` or `mypy` on the toolset source, we have to inject them (and additional typings) into the venv `pipx` created for the `standardebooks` package:
 
 ```shell
-pipx inject standardebooks pylint==2.17.3 mypy==1.2.0 types-requests==2.28.11.17 types-setuptools==67.7.0.0 types-Pillow==10.2.0.20240331
+pipx inject standardebooks pylint==3.2.2 mypy==1.10.0 types-requests==2.32.0.20240602 types-setuptools==70.0.0.20240524 types-Pillow==10.2.0.20240520
 ```
 
 Then make sure to call the `pylint` and `mypy` binaries that `pipx` installed in the `standardebooks` venv, *not* any other globally-installed binaries:

--- a/pylintrc
+++ b/pylintrc
@@ -6,7 +6,7 @@ ignore=vendor
 extension-pkg-whitelist=lxml,math,unicodedata
 
 [MESSAGES CONTROL]
-disable=line-too-long,too-many-nested-blocks,too-many-branches,too-many-statements,too-many-boolean-expressions,too-many-lines,too-many-locals,broad-except,too-few-public-methods,too-many-arguments,too-many-instance-attributes,too-many-public-methods,duplicate-code
+disable=line-too-long,too-many-nested-blocks,too-many-branches,too-many-statements,too-many-boolean-expressions,too-many-lines,too-many-locals,broad-except,too-few-public-methods,too-many-arguments,too-many-instance-attributes,too-many-public-methods,duplicate-code,deprecated-method
 
 [FORMAT]
 indent-string=\t

--- a/pylintrc
+++ b/pylintrc
@@ -6,7 +6,7 @@ ignore=vendor
 extension-pkg-whitelist=lxml,math,unicodedata
 
 [MESSAGES CONTROL]
-disable=line-too-long,too-many-nested-blocks,too-many-branches,too-many-statements,too-many-boolean-expressions,too-many-lines,too-many-locals,broad-except,bare-except,too-few-public-methods,too-many-arguments,too-many-instance-attributes,too-many-public-methods,duplicate-code,no-member
+disable=line-too-long,too-many-nested-blocks,too-many-branches,too-many-statements,too-many-boolean-expressions,too-many-lines,too-many-locals,broad-except,too-few-public-methods,too-many-arguments,too-many-instance-attributes,too-many-public-methods,duplicate-code
 
 [FORMAT]
 indent-string=\t

--- a/se/commands/interactive_replace.py
+++ b/se/commands/interactive_replace.py
@@ -37,8 +37,7 @@ def _get_text_dimensions(text: str) -> Tuple[int, int]:
 			else:
 				line_length = line_length + 1
 
-		if line_length > text_width:
-			text_width = line_length
+		text_width = max(text_width, line_length)
 
 	return (text_height + 1, text_width + 1)
 

--- a/se/commands/word_count.py
+++ b/se/commands/word_count.py
@@ -75,6 +75,8 @@ def word_count(plain_output: bool) -> int:
 			se.print_error(f"Couldn’t open file: [path][link=file://{filename}]{filename}[/][/].", plain_output=plain_output)
 			return se.InvalidInputException.code
 
+	category = ""
+
 	if args.categorize:
 		category = "se:short-story"
 		if NOVELLA_MIN_WORD_COUNT <= total_word_count < NOVEL_MIN_WORD_COUNT:
@@ -82,6 +84,6 @@ def word_count(plain_output: bool) -> int:
 		elif total_word_count >= NOVEL_MIN_WORD_COUNT:
 			category = "se:novel"
 
-	print(f"{total_word_count}\t{category if args.categorize else ''}")
+	print(f"{total_word_count}\t{category}")
 
 	return 0

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -1328,7 +1328,7 @@ class SeEpub:
 						anchor = href[hash_position:]
 				references.append(anchor)  # keep these for later reverse check
 				# Now try to find anchor in endnotes
-				matches = list(filter(lambda x, old=anchor: x.anchor == old, self.endnotes)) # type: ignore [arg-type]
+				matches = list(filter(lambda x, old=anchor: x.anchor == old, self.endnotes)) # type: ignore [arg-type, var-annotated]
 				if not matches:
 					missing.append(anchor)
 				if len(matches) > 1:
@@ -1521,7 +1521,7 @@ class SeEpub:
 			link.lxml_element.text = str(current_note_number)
 			needs_rewrite = True
 		# Now try to find this in endnotes
-		matches = list(filter(lambda x, old=old_anchor: x.anchor == old, self.endnotes)) # type: ignore [arg-type]
+		matches = list(filter(lambda x, old=old_anchor: x.anchor == old, self.endnotes)) # type: ignore [arg-type, var-annotated]
 		if not matches:
 			raise se.InvalidInputException(f"Couldn’t find endnote with anchor [attr]{old_anchor}[/].")
 		if len(matches) > 1:

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -510,8 +510,7 @@ class LintMessage:
 			for submessage in submessages:
 				# Try to flatten leading indentation
 				for indent in regex.findall(r"^\t+(?=<)", submessage, flags=regex.MULTILINE):
-					if len(indent) < smallest_indent:
-						smallest_indent = len(indent)
+					smallest_indent = min(smallest_indent, len(indent))
 
 			if smallest_indent == 1000:
 				smallest_indent = 0
@@ -1505,6 +1504,7 @@ def _lint_special_file_checks(self, filename: Path, dom: se.easy_xml.EasyXmlTree
 		for node in dom.xpath("/html/body/nav[contains(@epub:type, 'loi')]//li//a"):
 			figure_ref = node.get_attr("href").split("#")[1]
 			chapter_ref = regex.findall(r"(.*?)#.*", node.get_attr("href"))[0]
+			figure_img_alt = ""
 			figcaption_text = ""
 			loi_text = node.inner_text()
 			file_dom = self.get_dom(self.content_path / "text" / chapter_ref)

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,7 +3,7 @@
 Similar to `pylint`, the `pytest` command can be injected into the venv `pipx` created for the `standardebooks` package:
 
 ```shell
-pipx inject standardebooks pytest==7.3.1
+pipx inject standardebooks pytest==8.2.2
 ```
 
 The tests are executed by calling `pytest` from the top level of your tools repo:


### PR DESCRIPTION
With the current version, pylint on Python 3.12 throws a bunch of errors. Updating it to version 3+ fixes the majority of these issues. I’ve also fixed the other outstanding ones, removed a couple of now-empty ignores from pylintrc, and updated one ignore to work with the latest mypy.

I’ve added `deprecated-method` to pylintrc to silence issues with importlib_resources. As that module is no longer necessary now that the Python we require is >3.6 (see description at https://pypi.org/project/importlib-resources/1.0.2/) I’ll follow this PR up with a PR that updates the codebase to importlib.resources instead. We can remove `deprecated-method` as part of that.