### PR TITLE
Skip regex.sub in get_attr method when attribute is un-namespaced

### DIFF
--- a/se/easy_xml.py
+++ b/se/easy_xml.py
@@ -234,7 +234,9 @@ class EasyXmlElement:
 		epub:type -> {http://www.idpf.org/2007/ops}type
 		"""
 
-		if self.namespaces:
+		# The in check is redundant with the regex but is far more efficient
+		# when the value is un-namespaced
+		if ':' in value and self.namespaces:
 			value = regex.sub(r"^(\L<ns>):", lambda m: f"{{{self.namespaces[m[1]]}}}", value, ns=self.namespaces.keys())
 
 		return value


### PR DESCRIPTION
On my local machine this reduces the execution time of `se lint` on Don Quixote from 55 seconds to 40 seconds.

Fixes #709