### PR TITLE
Use compiled CSS selectors instead of reparsing their XPath

### DIFF
--- a/se/easy_xml.py
+++ b/se/easy_xml.py
@@ -87,7 +87,7 @@ class EasyXmlTree:
 				sel = cssselect.CSSSelector(selector, translator="xhtml", namespaces=self.namespaces)
 				CSS_SELECTOR_CACHE[selector] = sel
 
-			return self.xpath(sel.path)
+			return [EasyXmlElement(element, self.namespaces) for element in sel(self.etree)]
 		except parser.SelectorSyntaxError as ex:
 			raise se.InvalidCssException(f"Invalid selector: [css]{selector}[/]") from ex
 


### PR DESCRIPTION
https://lxml.de/cssselect.html#the-cssselector-class

These selectors can only return elements, so there is no need to go through the result processing performed in the xpath method.

Fixes #711