### PR TITLE
Simplify inner_text implementation using lxml's text method

### DIFF
--- a/se/easy_xml.py
+++ b/se/easy_xml.py
@@ -4,7 +4,6 @@ Defines the EasyXmlTree class, which is a convenience wrapper around etree.
 The class exposes some helpful functions like css_select() and xpath().
 """
 
-from html import unescape
 from typing import Dict, List, Union, Optional
 import unicodedata
 
@@ -414,7 +413,8 @@ class EasyXmlElement:
 		`<p>Hello there, <abbr>Mr.</abbr> Smith!</p>` -> `Hello there, Mr. Smith!`
 		"""
 
-		return unescape(regex.sub(r"<[^>]+?>", "", self.inner_xml().strip()))
+		text = etree.tostring(self.lxml_element, encoding=str, method="text", with_tail=False)
+		return text.strip()
 
 	def remove(self) -> None:
 		"""

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -34,3 +34,14 @@ def test_add_landmark_with_title():
 	add_landmark(dom, "file", landmarks)
 
 	assert landmarks[0].title == "Bar"
+
+def test_inner_text():
+	"""
+	Verify that inner_text strips leading and trailing whitespace from the root
+	element, retains interior whitespace, excludes all tags and attributes, and
+	returns both named and numeric entities as their corresponding characters.
+	"""
+	dom = se.easy_xml.EasyXmlTree('<?xml version="1.0" encoding="utf-8"?>\n<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en-US"><body><p epub:type="foo"> a <i>&lt;</i>b <span epub:type="bar">\t&#913; </span>c<br/>\nd </p>e</body></html>')
+	p = dom.xpath("//p")[0]
+
+	assert p.inner_text() == "a <b \tΑ c\nd"


### PR DESCRIPTION
Rather than using regex to remove tags and attributes after the fact.

https://lxml.de/api/lxml.etree-module.html#tostring

This also eliminates the need to perform HTML unescaping.

On my local machine, this reduces the time spent in the inner_text method on Don Quixote from 1.5 seconds to 0.04 seconds.

We add a basic test for the inner_text method in a preliminary commit to demonstrate that the behavior of the new implementation is equivalent.