### PR TITLE
Fix m-070 and add tests

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -3619,7 +3619,7 @@ def lint(self, skip_lint_ignore: bool, allowed_messages: Optional[List[str]] = N
 						nodes = dom.xpath("/html/body//dd[contains(@epub:type, 'glossdef')]")
 						source_text = " ".join([node.inner_text() for node in nodes])
 					for glossary_index, glossary_value in enumerate(glossary_usage):
-						if glossary_value[1] is False and regex.search(r"\b\L<val>\b", source_text, flags=regex.IGNORECASE, val=[glossary_value[0]]):
+						if glossary_value[1] is False and regex.search(r"(?<!\w)\L<val>(?!\w)", source_text, flags=regex.IGNORECASE, val=[glossary_value[0]]):
 							glossary_usage[glossary_index] = (glossary_value[0], True)
 
 				# Test against word boundaries to not match `halftitlepage`

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -3619,7 +3619,7 @@ def lint(self, skip_lint_ignore: bool, allowed_messages: Optional[List[str]] = N
 						nodes = dom.xpath("/html/body//dd[contains(@epub:type, 'glossdef')]")
 						source_text = " ".join([node.inner_text() for node in nodes])
 					for glossary_index, glossary_value in enumerate(glossary_usage):
-						if glossary_value[1] is False and regex.search(glossary_value[0], source_text, flags=regex.IGNORECASE):
+						if glossary_value[1] is False and regex.search(r"\b\L<val>\b", source_text, flags=regex.IGNORECASE, val=[glossary_value[0]]):
 							glossary_usage[glossary_index] = (glossary_value[0], True)
 
 				# Test against word boundaries to not match `halftitlepage`

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -3515,7 +3515,15 @@ def lint(self, skip_lint_ignore: bool, allowed_messages: Optional[List[str]] = N
 				if filename.name == "glossary-search-key-map.xml":
 					ebook_flags["has_glossary_search_key_map"] = True
 					# Map the glossary to tuples of the values and whether they’re used (initially false)
-					glossary_usage = list(map(lambda node: (node.get_attr("value"), False), xml_dom.xpath(".//*[@value]")))
+					# If a <match> has no <value> children, its @value must appear in the text
+					# Otherwise, each of its <value> children's @value must appear
+					for match in xml_dom.xpath("/search-key-map/search-key-group/match[@value]"):
+						values = match.xpath("./value[@value]")
+						if not values:
+							glossary_usage.append((match.get_attr("value"), False))
+						else:
+							for value in values:
+								glossary_usage.append((value.get_attr("value"), False))
 
 			if filename.suffix == ".xhtml":
 				# Read file contents into a DOM for querying

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -3614,9 +3614,14 @@ def lint(self, skip_lint_ignore: bool, allowed_messages: Optional[List[str]] = N
 
 				# Check and log missing glossary keys
 				if ebook_flags["has_glossary_search_key_map"] and filename.name not in IGNORED_FILENAMES:
-					source_text = dom.xpath("/html/body")[0].inner_text()
+					# Remove all noterefs, as their anchor text will otherwise immediately follow a potential glossary term, defeating the below regex.
+					dom_copy = deepcopy(dom)
+					for node in dom_copy.xpath(".//a[contains(@epub:type, 'noteref')]"):
+						node.remove()
+
+					source_text = dom_copy.xpath("/html/body")[0].inner_text()
 					if dom.xpath("/html/body//section[contains(@epub:type, 'glossary')]"):
-						nodes = dom.xpath("/html/body//dd[contains(@epub:type, 'glossdef')]")
+						nodes = dom_copy.xpath("/html/body//dd[contains(@epub:type, 'glossdef')]")
 						source_text = " ".join([node.inner_text() for node in nodes])
 					for glossary_index, glossary_value in enumerate(glossary_usage):
 						if glossary_value[1] is False and regex.search(r"(?<!\w)\L<val>(?!\w)", source_text, flags=regex.IGNORECASE, val=[glossary_value[0]]):

--- a/tests/lint/metadata/m-070/golden/m-070-out.txt
+++ b/tests/lint/metadata/m-070/golden/m-070-out.txt
@@ -1,0 +1,2 @@
+m-070 [Error] glossary-search-key-map.xml Glossary entry not found in the text.
+        R+L=J

--- a/tests/lint/metadata/m-070/golden/m-070-out.txt
+++ b/tests/lint/metadata/m-070/golden/m-070-out.txt
@@ -1,2 +1,2 @@
 m-070 [Error] glossary-search-key-map.xml Glossary entry not found in the text.
-        R+L=J
+        foo

--- a/tests/lint/metadata/m-070/golden/m-070-out.txt
+++ b/tests/lint/metadata/m-070/golden/m-070-out.txt
@@ -1,2 +1,3 @@
 m-070 [Error] glossary-search-key-map.xml Glossary entry not found in the text.
         foo
+        pariahsss

--- a/tests/lint/metadata/m-070/in/src/epub/glossary-search-key-map.xml
+++ b/tests/lint/metadata/m-070/in/src/epub/glossary-search-key-map.xml
@@ -6,4 +6,10 @@
 	<search-key-group href="text/glossary.xhtml#bar">
 		<match value="R+L=J"/>
 	</search-key-group>
+	<search-key-group href="text/glossary.xhtml#xyz">
+		<match value="M.O."/>
+	</search-key-group>
+	<search-key-group href="text/glossary.xhtml#abc">
+		<match value="’versal"/>
+	</search-key-group>
 </search-key-map>

--- a/tests/lint/metadata/m-070/in/src/epub/glossary-search-key-map.xml
+++ b/tests/lint/metadata/m-070/in/src/epub/glossary-search-key-map.xml
@@ -15,4 +15,10 @@
 	<search-key-group href="text/glossary.xhtml#def">
 		<match value="unsiker"/>
 	</search-key-group>
+	<search-key-group href="text/glossary.xhtml#ghi">
+		<match value="pariah">
+			<value value="pariahs"/>
+			<value value="pariahsss"/>
+		</match>
+	</search-key-group>
 </search-key-map>

--- a/tests/lint/metadata/m-070/in/src/epub/glossary-search-key-map.xml
+++ b/tests/lint/metadata/m-070/in/src/epub/glossary-search-key-map.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<search-key-map xmlns="http://www.idpf.org/2007/ops" xml:lang="en">
+	<search-key-group href="text/glossary.xhtml#foo">
+		<match value="foo"/>
+	</search-key-group>
+	<search-key-group href="text/glossary.xhtml#bar">
+		<match value="R+L=J"/>
+	</search-key-group>
+</search-key-map>

--- a/tests/lint/metadata/m-070/in/src/epub/glossary-search-key-map.xml
+++ b/tests/lint/metadata/m-070/in/src/epub/glossary-search-key-map.xml
@@ -12,4 +12,7 @@
 	<search-key-group href="text/glossary.xhtml#abc">
 		<match value="’versal"/>
 	</search-key-group>
+	<search-key-group href="text/glossary.xhtml#def">
+		<match value="unsiker"/>
+	</search-key-group>
 </search-key-map>

--- a/tests/lint/metadata/m-070/in/src/epub/text/chapter-1.xhtml
+++ b/tests/lint/metadata/m-070/in/src/epub/text/chapter-1.xhtml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
+	<head>
+		<title>I</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="bodymatter z3998:fiction">
+		<section id="chapter-1" epub:type="chapter">
+			<h2 epub:type="ordinal z3998:roman">I</h2>
+			<!-- erroneously considered to match the glossary term "foo" -->
+			<p>He ate some food.</p>
+			<!-- erroneously unmatched due to treatment of glossary term as a regex -->
+			<p>A common theory was R+L=J.</p>
+		</section>
+	</body>
+</html>

--- a/tests/lint/metadata/m-070/in/src/epub/text/chapter-1.xhtml
+++ b/tests/lint/metadata/m-070/in/src/epub/text/chapter-1.xhtml
@@ -13,6 +13,7 @@
 			<p>A ’versal truth.</p>
 			<p>An unknown M.O.</p>
 			<p>Unsiker<a href="endnotes.xhtml#note-1" epub:type="noteref">1</a> is an unusual term.</p>
+			<p>Pariahs is plural, but should match.</p>
 		</section>
 	</body>
 </html>

--- a/tests/lint/metadata/m-070/in/src/epub/text/chapter-1.xhtml
+++ b/tests/lint/metadata/m-070/in/src/epub/text/chapter-1.xhtml
@@ -10,6 +10,8 @@
 			<h2 epub:type="ordinal z3998:roman">I</h2>
 			<p>He ate some food.</p>
 			<p>A common theory was R+L=J.</p>
+			<p>A ’versal truth.</p>
+			<p>An unknown M.O.</p>
 		</section>
 	</body>
 </html>

--- a/tests/lint/metadata/m-070/in/src/epub/text/chapter-1.xhtml
+++ b/tests/lint/metadata/m-070/in/src/epub/text/chapter-1.xhtml
@@ -12,6 +12,7 @@
 			<p>A common theory was R+L=J.</p>
 			<p>A ’versal truth.</p>
 			<p>An unknown M.O.</p>
+			<p>Unsiker<a href="endnotes.xhtml#note-1" epub:type="noteref">1</a> is an unusual term.</p>
 		</section>
 	</body>
 </html>

--- a/tests/lint/metadata/m-070/in/src/epub/text/chapter-1.xhtml
+++ b/tests/lint/metadata/m-070/in/src/epub/text/chapter-1.xhtml
@@ -8,9 +8,7 @@
 	<body epub:type="bodymatter z3998:fiction">
 		<section id="chapter-1" epub:type="chapter">
 			<h2 epub:type="ordinal z3998:roman">I</h2>
-			<!-- erroneously considered to match the glossary term "foo" -->
 			<p>He ate some food.</p>
-			<!-- erroneously unmatched due to treatment of glossary term as a regex -->
 			<p>A common theory was R+L=J.</p>
 		</section>
 	</body>


### PR DESCRIPTION
I ran the updated lint against the corpus entries that contain a glossary, and [it revealed a large number of unused entries](https://gist.github.com/apasel422/0fcaebed784fbc7fa45282cb1bbbe037). Some of these are typos (e.g. `Ygdrasil` as the glossary term vs `Ygdrasill` appearing in the text of Bulfinch's _Mythology_), while others are a singular/plural form that doesn't appear in that inflected form in the text (e.g. `trilobite` vs `trilobites` in _The Origin of Species_).

Fixes #731