### PR TITLE
Remove pointless trailing text from t-008 regex

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -3365,7 +3365,7 @@ def lint(self, skip_lint_ignore: bool, allowed_messages: Optional[List[str]] = N
 			messages.append(LintMessage("f-001", "Illegal file or directory.", se.MESSAGE_TYPE_ERROR, Path(illegal_file)))
 
 	# Check for repeated punctuation
-	nodes = self.metadata_dom.xpath("/package/metadata/*[re:test(., '[,;]{2,}.{0,20}')]")
+	nodes = self.metadata_dom.xpath("/package/metadata/*[re:test(., '[,;]{2,}')]")
 	if nodes:
 		messages.append(LintMessage("t-008", "Repeated punctuation.", se.MESSAGE_TYPE_WARNING, self.metadata_file_path, [node.to_string() for node in nodes]))
 


### PR DESCRIPTION
This regex is being used to return a set of nodes, not match substrings, so the trailing context is irrelevant. The lint messages contain the result of calling to_string on the nodes.