### PR TITLE
Fix to build for current chapter location error affecting AZW3s on Kindle

### DIFF
--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -1093,7 +1093,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 				new_node_types = []
 
 				for node_type in ref_node.get_attr("type").split():
-					if node_type in ("acknowledgements", "bibliography", "colophon", "copyright-page", "cover", "dedication", "epigraph", "foreword", "glossary", "index", "loi", "lot", "notes", "preface", "bodymatter", "title-page", "toc"):
+					if node_type in ("acknowledgements", "bibliography", "glossary", "index", "loi", "lot", "notes", "title-page"):
 						new_node_types.append(node_type)
 					else:
 						new_node_types.append(f"other.{node_type}")

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -1093,9 +1093,11 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 				new_node_types = []
 
 				for node_type in ref_node.get_attr("type").split():
-					if node_type in ("acknowledgements", "bibliography", "glossary", "index", "loi", "lot", "notes", "title-page"):
+					if node_type in ("acknowledgements", "bibliography", "glossary", "index", "loi", "lot", "title-page"):
 						new_node_types.append(node_type)
-					else:
+					elif node_type == "endnotes":
+						new_node_types.append("notes")
+					elif node_type != "footnotes":
 						new_node_types.append(f"other.{node_type}")
 
 				ref_node.set_attr("type", " ".join(new_node_types))


### PR DESCRIPTION
Resolves part of #605

On the list it was raised that SE AZW3s do not show the correct current chapter location on Kindle. To fix this I proposed appending to the guide a reference element corresponding to the titlepage. 

Including a reference element corresponding to any text file seems to fix the Kindle issue. So given that build is already iterating through landmarks in the section edited here, another option would be just to append the bodymatter entry that’s already present in landmarks for each ebook. However, the only appropriate value of the `type` attribute for the bodymatter landmark's reference element is `text`, inclusion of which results in SE books opening at the first bodymatter file rather than at the titlepage, the latter being what we want (as far as I understand).

Therefore it seems reasonable to stay with the titlepage solution and not add the first bodymatter file to the guide. Continuing to omit it doesn't seem to affect anything on Kindle. I don't know that it was ever included, given that `bodymatter` is removed from the `type` taken from the landmark's `epub:type`.

faa1c68 removes values from the type attribute allow list that will never occur in a landmark `epub:type` and therefore cannot occur in the reference node's `type` as set a few lines above.

3941ca9 ensures that if there is an endnotes file, a reference element corresponding to it will be appended to the guide, for consistency with other backmatter.