### PR TITLE
Add filesize check for the cover JPG

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -1200,9 +1200,8 @@ def _lint_image_checks(self, filename: Path) -> list:
 			if image.size != (se.COVER_WIDTH, se.COVER_HEIGHT):
 				messages.append(LintMessage("f-017", f"[path][link=file://{self.path / 'images/cover.jpg'}]cover.jpg[/][/] must be exactly {se.COVER_WIDTH} × {se.COVER_HEIGHT}.", se.MESSAGE_TYPE_ERROR, filename))
 
-		# Run some tests on distributable images in ./src/epub/images/
-		# Once we reach Python 3.9 we can use path.is_relative_to() instead of this string comparison
-		if str(filename).startswith(str(self.content_path / "images")):
+		# Run some tests on distributable images in ./src/epub/images/ and the cover
+		if filename.is_relative_to(self.content_path / "images") or (self.path / "images" / "cover.jpg" == filename):
 			if os.path.getsize(filename) > 1500000: # 1.5MB
 				messages.append(LintMessage("f-016", "Image more than 1.5MB in size.", se.MESSAGE_TYPE_ERROR, filename))
 


### PR DESCRIPTION
The built cover is an SVG so isn’t being checked by `_lint_image_checks`, but the unbuilt cover image isn’t in src/epub/images so is also missing the file size check. This adds images/cover.jpg into those checks.

Images that are currently over 1500000 bytes (the lint threshold):

| Size | Project |
| ---- | ------- |
| 1516511 | [edgar-wallace_blue-hand](https://github.com/standardebooks/edgar-wallace_blue-hand) |
| 1560960 | [agatha-christie_the-mystery-of-the-blue-train](https://github.com/standardebooks/agatha-christie_the-mystery-of-the-blue-train) |
| 1623928 | [a-w-tozer_the-pursuit-of-god](https://github.com/standardebooks/a-w-tozer_the-pursuit-of-god) |
| 1657597 | [john-g-neihardt_a-cycle-of-the-west](https://github.com/standardebooks/john-g-neihardt_a-cycle-of-the-west) |
| 1691183 | [bertha-von-suttner_lay-down-your-arms_t-holmes](https://github.com/standardebooks/bertha-von-suttner_lay-down-your-arms_t-holmes) |
| 1695800 | [edgar-wallace_the-secret-house](https://github.com/standardebooks/edgar-wallace_the-secret-house) |
| 1731432 | [earl-derr-biggers_the-chinese-parrot](https://github.com/standardebooks/earl-derr-biggers_the-chinese-parrot) |
| 1757310 | [boethius_the-consolation-of-philosophy_h-r-james](https://github.com/standardebooks/boethius_the-consolation-of-philosophy_h-r-james) |
| 1773649 | [p-g-wodehouse_the-gold-bat](https://github.com/standardebooks/p-g-wodehouse_the-gold-bat) |
| 1804434 | [james-branch-cabell_the-cords-of-vanity](https://github.com/standardebooks/james-branch-cabell_the-cords-of-vanity) |
| 1821971 | [edgar-wallace_the-mind-of-mr-j-g-reeder](https://github.com/standardebooks/edgar-wallace_the-mind-of-mr-j-g-reeder) |
| 1830667 | [edgar-wallace_room-13](https://github.com/standardebooks/edgar-wallace_room-13) |
| 1837330 | [mark-twain_puddnhead-wilson](https://github.com/standardebooks/mark-twain_puddnhead-wilson) |
| 1848617 | [edgar-wallace_the-clue-of-the-twisted-candle](https://github.com/standardebooks/edgar-wallace_the-clue-of-the-twisted-candle) |
| 1851785 | [edgar-wallace_the-door-with-seven-locks](https://github.com/standardebooks/edgar-wallace_the-door-with-seven-locks) |
| 1880548 | [virgil_the-georgics_john-dryden](https://github.com/standardebooks/virgil_the-georgics_john-dryden) |
| 1890051 | [richard-henry-dana-jr_two-years-before-the-mast](https://github.com/standardebooks/richard-henry-dana-jr_two-years-before-the-mast) |
| 1917592 | [agatha-christie_the-big-four](https://github.com/standardebooks/agatha-christie_the-big-four) |
| 1991225 | [p-g-wodehouse_the-coming-of-bill](https://github.com/standardebooks/p-g-wodehouse_the-coming-of-bill) |
| 2054310 | [thiruvalluvar_the-kural_v-v-s-aiyar](https://github.com/standardebooks/thiruvalluvar_the-kural_v-v-s-aiyar) |
| 2065365 | [louis-bromfield_early-autumn](https://github.com/standardebooks/louis-bromfield_early-autumn) |
| 2131900 | [edgar-wallace_the-man-who-knew](https://github.com/standardebooks/edgar-wallace_the-man-who-knew) |
| 2141653 | [edgar-rice-burroughs_tarzan-and-the-jewels-of-opar](https://github.com/standardebooks/edgar-rice-burroughs_tarzan-and-the-jewels-of-opar) |
| 2165015 | [william-shakespeare_john-fletcher_the-two-noble-kinsmen](https://github.com/standardebooks/william-shakespeare_john-fletcher_the-two-noble-kinsmen) |
| 2188126 | [edgar-wallace_the-law-of-the-four-just-men](https://github.com/standardebooks/edgar-wallace_the-law-of-the-four-just-men) |
| 2189172 | [herodotus_histories_g-c-macaulay](https://github.com/standardebooks/herodotus_histories_g-c-macaulay) |
| 2215027 | [edgar-wallace_the-three-just-men](https://github.com/standardebooks/edgar-wallace_the-three-just-men) |
| 2227811 | [edgar-wallace_the-clue-of-the-new-pin](https://github.com/standardebooks/edgar-wallace_the-clue-of-the-new-pin) |
| 2381190 | [elizabeth-von-arnim_the-enchanted-april](https://github.com/standardebooks/elizabeth-von-arnim_the-enchanted-april) |
| 2416951 | [virginia-woolf_to-the-lighthouse](https://github.com/standardebooks/virginia-woolf_to-the-lighthouse) |
| 2455658 | [edgar-wallace_the-just-men-of-cordova](https://github.com/standardebooks/edgar-wallace_the-just-men-of-cordova) |
| 2464705 | [virgil_the-eclogues_john-dryden](https://github.com/standardebooks/virgil_the-eclogues_john-dryden) |
| 2471118 | [edgar-rice-burroughs_the-mucker](https://github.com/standardebooks/edgar-rice-burroughs_the-mucker) |
| 2493467 | [s-s-van-dine_the-benson-murder-case](https://github.com/standardebooks/s-s-van-dine_the-benson-murder-case) |
| 2549150 | [earl-derr-biggers_behind-that-curtain](https://github.com/standardebooks/earl-derr-biggers_behind-that-curtain) |
| 2628727 | [theodore-roosevelt_an-autobiography](https://github.com/standardebooks/theodore-roosevelt_an-autobiography) |
| 2647399 | [andre-norton_key-out-of-time](https://github.com/standardebooks/andre-norton_key-out-of-time) |
| 2673621 | [edgar-rice-burroughs_tarzan-the-terrible](https://github.com/standardebooks/edgar-rice-burroughs_tarzan-the-terrible) |
| 2737742 | [frederik-pohl_plague-of-pythons](https://github.com/standardebooks/frederik-pohl_plague-of-pythons) |
| 2749933 | [thea-von-harbou_metropolis_the-readers-library](https://github.com/standardebooks/thea-von-harbou_metropolis_the-readers-library) |
| 2758686 | [herman-melville_typee](https://github.com/standardebooks/herman-melville_typee) |
| 2776802 | [baroness-orczy_the-old-man-in-the-corner](https://github.com/standardebooks/baroness-orczy_the-old-man-in-the-corner) |
| 2865898 | [paul-laurence-dunbar_the-uncalled](https://github.com/standardebooks/paul-laurence-dunbar_the-uncalled) |
| 2873309 | [archibald-alexander_a-day-at-a-time](https://github.com/standardebooks/archibald-alexander_a-day-at-a-time) |
| 3111430 | [georgette-heyer_the-transformation-of-philip-jettan](https://github.com/standardebooks/georgette-heyer_the-transformation-of-philip-jettan) |
| 3139597 | [charles-w-chesnutt_the-marrow-of-tradition](https://github.com/standardebooks/charles-w-chesnutt_the-marrow-of-tradition) |
| 3158610 | [barbara-newhall-follett_the-house-without-windows](https://github.com/standardebooks/barbara-newhall-follett_the-house-without-windows) |
| 3198501 | [richard-henry-dana-jr_to-cuba-and-back](https://github.com/standardebooks/richard-henry-dana-jr_to-cuba-and-back) |
| 3338186 | [william-dean-howells_the-rise-of-silas-lapham](https://github.com/standardebooks/william-dean-howells_the-rise-of-silas-lapham) |
| 3352950 | [jack-london_before-adam](https://github.com/standardebooks/jack-london_before-adam) |
| 3424947 | [felix-salten_bambi_whittaker-chambers](https://github.com/standardebooks/felix-salten_bambi_whittaker-chambers) |
| 3452356 | [william-craft_ellen-craft_running-a-thousand-miles-for-freedom](https://github.com/standardebooks/william-craft_ellen-craft_running-a-thousand-miles-for-freedom) |
| 3504300 | [lewis-carroll_sylvie-and-bruno](https://github.com/standardebooks/lewis-carroll_sylvie-and-bruno) |
| 3591039 | [rafael-sabatini_the-sea-hawk](https://github.com/standardebooks/rafael-sabatini_the-sea-hawk) |
| 3639464 | [edgar-wallace_the-council-of-justice](https://github.com/standardebooks/edgar-wallace_the-council-of-justice) |
| 3729929 | [ann-radcliffe_the-mysteries-of-udolpho](https://github.com/standardebooks/ann-radcliffe_the-mysteries-of-udolpho) |
| 3812499 | [edgar-rice-burroughs_tarzan-the-untamed](https://github.com/standardebooks/edgar-rice-burroughs_tarzan-the-untamed) |
| 3978950 | [l-m-montgomery_emily-of-new-moon](https://github.com/standardebooks/l-m-montgomery_emily-of-new-moon) |
| 4083336 | [elizabeth-von-arnim_elizabeth-and-her-german-garden](https://github.com/standardebooks/elizabeth-von-arnim_elizabeth-and-her-german-garden) |
| 4495240 | [theodore-roosevelt_through-the-brazilian-wilderness](https://github.com/standardebooks/theodore-roosevelt_through-the-brazilian-wilderness) |