### PR TITLE
Add book size abbreviations to semanticate

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -105,6 +105,7 @@ def semanticate(xhtml: str) -> str:
 	xhtml = regex.sub(r"(?<!(?:\.|\B|\<abbr[^>]*?\>))\b([1-4]D)\b", r"""<abbr epub:type="z3998:initialism">\1</abbr>""", xhtml)
 	xhtml = regex.sub(r"(?<!(?:\.|\B|\<abbr[^>]*?\>))(Thos\.|Jas\.|Chas\.|Wm\.)", r"""<abbr epub:type="z3998:given-name">\1</abbr>""", xhtml)
 	xhtml = regex.sub(r"(?<!(?:\.|\B|\<abbr[^>]*?\>))([ap])\.\s?m\.", r"<abbr>\1.m.</abbr>", xhtml)
+	xhtml = regex.sub(r"(?<!(?:\.|\B|\<abbr[^>]*?\>))(4to|8vo|12mo|16mo|18mo|32mo|48mo|64mo)(?:\.(\s+\p{Lowercase_Letter}))?", r"<abbr>\1</abbr>\2", xhtml) # Book sizes
 	xhtml = regex.sub(r"(?<!(?:\.|\B|\<abbr[^>]*?\>))([0-9]{1,2})\s?[Aa]\.?\s?[Mm](?:\.|\b)", r"\1 <abbr>a.m.</abbr>", xhtml)
 	xhtml = regex.sub(r"(?<!(?:\.|\B|\<abbr[^>]*?\>))([0-9]{1,2})\s?[Pp]\.?\s?[Mm](?:\.|\b)", r"\1 <abbr>p.m.</abbr>", xhtml)
 	# this should be placed after the am/pm test, to prevent tagging just the p. in "p. m."


### PR DESCRIPTION
A simple regex, based on https://en.wikipedia.org/wiki/Book_size#United_States

This shouldn’t clash with anything else given the lack of a space between the numbers and letters. This doesn’t cope with a full stop after the abbreviation but that seems rare and easily fixable manually.

Fixes https://github.com/standardebooks/manual/issues/167 (on second thoughts I shouldn’t have filed it against https://github.com/standardebooks/manual). I’ll fix what needs doing in the corpus if you’re happy with this.