### PR TITLE
Two CSS formatting bugs in se clean

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -864,7 +864,7 @@ def _format_css_component_list(content: list, in_selector=False, in_paren_block=
 			output += f"#{token.value}"
 
 		if token.type == "string":
-			output += f"\"{token.value}\""
+			output += token.representation
 
 		if token.type == "() block":
 			output += f"({_format_css_component_list(token.content, in_selector, True)})"

--- a/se/formatting.py
+++ b/se/formatting.py
@@ -889,7 +889,7 @@ def _format_css_component_list(content: list, in_selector=False, in_paren_block=
 	# Here we try to re-add spaces after a : if it's within a paren block.
 	# We could do this during parsing but we would need to peek ahead to the next item in the loop which
 	# is too much trouble right now.
-	output = regex.sub(r"\(([^\"\s]+?):([^\"\s]+?)", r"(\1: \2", output)
+	output = regex.sub(r"\(([^\"\s)]+?):([^\"\s]+?)", r"(\1: \2", output)
 
 	return output.strip()
 

--- a/tests/draft_commands/clean/test-2/golden/src/epub/css/local.css
+++ b/tests/draft_commands/clean/test-2/golden/src/epub/css/local.css
@@ -1,0 +1,17 @@
+p:nth-of-type(1)::before{
+	content: "test";
+}
+
+@media all and (prefers-color-scheme: dark){
+	p{
+		text-align: initial;
+	}
+}
+
+#chapter-1::after{
+	content: "test";
+}
+
+#chapter-1 tr:first-child{
+	content: "test";
+}

--- a/tests/draft_commands/clean/test-2/golden/src/epub/css/local.css
+++ b/tests/draft_commands/clean/test-2/golden/src/epub/css/local.css
@@ -15,3 +15,11 @@ p:nth-of-type(1)::before{
 #chapter-1 tr:first-child{
 	content: "test";
 }
+
+p::before{
+	content: "newlines \A \A \A quotes ' \" \"'backslash \\ letters áè";
+}
+
+p::after{
+	content: "newlines \A \A \A quotes ' \" \"'backslash \\ letters áè";
+}

--- a/tests/draft_commands/clean/test-2/in/src/epub/css/local.css
+++ b/tests/draft_commands/clean/test-2/in/src/epub/css/local.css
@@ -7,3 +7,8 @@ p:nth-of-type(1)::before{content: "test";}
 #chapter-1::after {content: "test";}
   #chapter-1 tr:first-child{
 content: "test";}
+
+p::before{
+      content: "newlines \a \A \00000A quotes ' \" \22 \27 backslash \\ letters \e1\E8";
+}
+p::after{content: 'newlines \a \A \00000A quotes \' " \22 \27 backslash \\ letters \e1\E8';}

--- a/tests/draft_commands/clean/test-2/in/src/epub/css/local.css
+++ b/tests/draft_commands/clean/test-2/in/src/epub/css/local.css
@@ -1,0 +1,9 @@
+
+
+p:nth-of-type(1)::before{content: "test";}
+    @media all    and (prefers-color-scheme:dark){p{text-align:initial;}}
+
+
+#chapter-1::after {content: "test";}
+  #chapter-1 tr:first-child{
+content: "test";}


### PR DESCRIPTION
This addresses two small issues with the CSS formatting in `se clean`.

1. An incorrect space is inserted between two `::`, if these colons follow an opening `(`.

   ```css
   p:nth-of-type(1)::before{
   ```
   is currently changed to
   ```css
   p:nth-of-type(1): :before{
   ```

   The regex responsible for this sees the opening `(` and then adds a space after the first `:` it finds. The comment in the code explains that this is to fix the colon in media queries such as `(prefers-color-scheme: dark)`, but it also affects colons outside the parentheses.

   This can be fixed by making the regex stop at the closing `)`. I think this shouldn't break anything else. The media query example still works.

2. Strings in the CSS output are not escaped. The raw string from the parser is directly written to the cleaned output.

   If the string contains any quotes or newlines, `se clean` produces invalid CSS:

   ```css
   content: "quote \" newline \A ";
   ```
   is currently changed to
   ```css
   content: "quote " newline 
   ";
   ```

   The patch uses the tinycss `token.representation`, which is a quoted and escaped version of the string.