### PR TITLE
Preserve vh/vw units in compatibility CSS

### DIFF
--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -843,10 +843,6 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 				processed_css = regex.sub(r"^\s*hyphens\s*:\s*(.+)", "\thyphens: \\1\n\tadobe-hyphenate: \\1\n\t-webkit-hyphens: \\1\n\t-moz-hyphens: \\1", processed_css, flags=regex.MULTILINE)
 				processed_css = regex.sub(r"^\s*hyphens\s*:\s*none;", "\thyphens: none;\n\tadobe-text-layout: optimizeSpeed; /* For Nook */", processed_css, flags=regex.MULTILINE)
 
-				# We add a 20vh margin to sections without heading elements to drop them down on the page a little.
-				# As of 01-2021 the vh unit is not supported on Nook or Kindle (but is on kepub and ibooks).
-				processed_css = regex.sub(r"^(\s*)margin-top\s*:\s*20vh;", r"\1margin-top: 5em;", processed_css, flags=regex.MULTILINE)
-
 				# We converted svgs to pngs, so replace references
 				processed_css = regex.sub(r"""url\("(.*?)\.svg"\)""", r"""url("\1.png")""", processed_css)
 

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -561,7 +561,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 					processed_css = regex.sub(r"(\s+)page-break-(before|after):\s+page;", "\\1page-break-\\2: always;", processed_css)
 
 					# Replace `vw` or `vh` units with percent, a reasonable approximation
-					processed_css = regex.sub(r"([0-9\.]+\s*)v(w|h);", r"\1%;", processed_css)
+					processed_css = regex.sub(r"^(.+?:\s*[0-9\.]+\s*)(v(w|h));", r"\1%;\n\1\2;", processed_css, flags=regex.MULTILINE)
 
 					if processed_css != css:
 						file.seek(0)

--- a/tests/ebook_commands/build/test-1/build-command
+++ b/tests/ebook_commands/build/test-1/build-command
@@ -1,0 +1,2 @@
+build --output {book_directory}/dist {book_directory}
+extract-ebook --output {book_directory}/extracted {book_directory}/dist/jane-austen_unknown-novel.epub

--- a/tests/ebook_commands/build/test-1/golden/extracted/epub/css/local.css
+++ b/tests/ebook_commands/build/test-1/golden/extracted/epub/css/local.css
@@ -3,17 +3,22 @@
 
 figure.full-page{
 	max-height: 100%;
+	max-height: 100vh;
 }
 
 section.epub-type-preface{
 	margin-top: 20%;
+	margin-top: 20vh;
 }
 
 p{
 	margin-top: 20%;
+	margin-top: 20vh;
 	margin-right: 10%;
 	margin-bottom: 10px;
 	margin-left: 10em;
 	width: 5%;
+	width: 5vw;
 	max-width: 12.5%;
+	max-width: 12.5vh;
 }

--- a/tests/ebook_commands/build/test-1/golden/extracted/epub/css/local.css
+++ b/tests/ebook_commands/build/test-1/golden/extracted/epub/css/local.css
@@ -1,0 +1,19 @@
+@charset "utf-8";
+@namespace epub "http://www.idpf.org/2007/ops";
+
+figure.full-page{
+	max-height: 100%;
+}
+
+section.epub-type-preface{
+	margin-top: 20%;
+}
+
+p{
+	margin-top: 20%;
+	margin-right: 10%;
+	margin-bottom: 10px;
+	margin-left: 10em;
+	width: 5%;
+	max-width: 12.5%;
+}

--- a/tests/ebook_commands/build/test-1/in/src/epub/css/local.css
+++ b/tests/ebook_commands/build/test-1/in/src/epub/css/local.css
@@ -1,0 +1,16 @@
+@charset "utf-8";
+@namespace epub "http://www.idpf.org/2007/ops";
+
+figure.full-page{
+	max-height: 100vh;
+}
+
+section[epub|type~="preface"]{
+	margin-top: 20vh;
+}
+
+p{
+	margin: 20vh 10% 10px 10em;
+	width: 5vw;
+	max-width: 12.5vh;
+}


### PR DESCRIPTION
In the Apple Books app on iOS, full-page images are often spread over multiple pages:

Example from [How the other half lives](https://standardebooks.org/ebooks/jacob-riis/how-the-other-half-lives):
![before 1](https://github.com/user-attachments/assets/7881e51b-57d7-4b72-b8d0-584beec42088) ![before 2](https://github.com/user-attachments/assets/88e732a4-128a-43cc-a66a-2cca064be471) ![before 3](https://github.com/user-attachments/assets/9e2ed002-6ffe-4ec8-94b3-d5d9d8d49c94)

The full-page figures are styled with `max-height: 100vh` (see [CSS from the book](https://github.com/standardebooks/jacob-riis_how-the-other-half-lives/blob/d2abddbfcc1cb6c4d406ec7dcfd28b1b4a68fa16/src/epub/css/local.css#L106-L112)), but the compatibility code in `se build` converts the `vh` units to percentages. Apparently this doesn't work for full-page images in Apple Books. (Cantook on iOS doesn't have this problem: it show the images on a single page.)

This patch changes the compatibility code so that it still adds the percentages, but also keeps the `vh` and `vm` units for readers that support this (such as the Apple Books app):
```css
	max-height: 100%;
	max-height: 100vh;
```

This fixes the problem, see this image from the Books app:
![after](https://github.com/user-attachments/assets/37c34d43-5831-4ddb-aefb-11adec3e9877)

-----

The change itself is quite small, but testing it is a bit more involved. This is the first test using `se build`, as far as I can see. The test actually runs two commands: `se build` to build the epub, followed by `se extract-ebook` to extract the files that can be compared against the golden version.

(I'd be happy to submit a patch without the test, if the test framework is out of scope for this PR.)

-----

The third change (the middle commit) removes an unused compatibility rule that is supposed to replace `margin-top: 20vh` with `margin-top: 5em`. As far as I can see, this doesn't currently do anything, because the `20vh` is changed to `20%` before this rule is reached. For an input of:
```css
	max-height: 20vh;
```
the current rules generate CSS:
```css
	max-height: 20%;
```

However, now that the main change in this PR preserves the `vh`, it would generate this:
```css
	max-height: 20%;
	max-height: 5em;
```
so I think it is better to remove the old rule. The result would then be:
```css
	max-height: 20%;
	max-height: 20vh;
```