### PR TITLE
typogrify: Do not remove space between a comma and a fraction

### DIFF
--- a/se/typography.py
+++ b/se/typography.py
@@ -318,7 +318,7 @@ def typogrify(xhtml: str, smart_quotes: bool = True) -> str:
 	xhtml = regex.sub(r"\b(?<!/)([0-9]{1,3}|[0-9]{5,})/\b([0-9]{1,3}|[0-9]{5,})(?!/)\b", lambda result: _number_to_fraction(result.group(0)), xhtml)
 
 	# Remove spaces between whole numbers and fractions
-	xhtml = regex.sub(r"([0-9,]+)\s+([¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]|[⁰¹²³⁴⁵⁶⁷⁸⁹]+⁄[₀₁₂₃₄₅₆₇₈₉]+)", r"\1\2", xhtml)
+	xhtml = regex.sub(r"([0-9])\s+([¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]|[⁰¹²³⁴⁵⁶⁷⁸⁹]+⁄[₀₁₂₃₄₅₆₇₈₉]+)", r"\1\2", xhtml)
 
 	# Use the Unicode Minus glyph (U+2212) for negative numbers
 	xhtml = regex.sub(r"([\s>])\-([0-9,]+)", r"\1−\2", xhtml)

--- a/tests/draft_commands/typogrify/test-1/golden/typogrify.xhtml
+++ b/tests/draft_commands/typogrify/test-1/golden/typogrify.xhtml
@@ -40,6 +40,8 @@
 				<li>123¾</li>
 				<li>123⅚</li>
 				<li>123¹⁄₈₀₀</li>
+				<li>1,234¼</li>
+				<li>keep space after comma, ¹⁄₈₀₀</li>
 			</ul>
 		</section>
 	</body>

--- a/tests/draft_commands/typogrify/test-1/golden/typogrify.xhtml
+++ b/tests/draft_commands/typogrify/test-1/golden/typogrify.xhtml
@@ -34,6 +34,13 @@
 				<li>“ ’tis</li>
 				<li>“ ’Tis</li>
 			</ul>
+			<!-- Remove space between number and fraction -->
+			<ul>
+				<li>123½</li>
+				<li>123¾</li>
+				<li>123⅚</li>
+				<li>123¹⁄₈₀₀</li>
+			</ul>
 		</section>
 	</body>
 </html>

--- a/tests/draft_commands/typogrify/test-1/in/typogrify.xhtml
+++ b/tests/draft_commands/typogrify/test-1/in/typogrify.xhtml
@@ -40,6 +40,8 @@
 				<li>123  ¾</li>
 				<li>123⅚</li>
 				<li>123¹⁄₈₀₀</li>
+				<li>1,234 ¼</li>
+				<li>keep space after comma, ¹⁄₈₀₀</li>
 			</ul>
 		</section>
 	</body>

--- a/tests/draft_commands/typogrify/test-1/in/typogrify.xhtml
+++ b/tests/draft_commands/typogrify/test-1/in/typogrify.xhtml
@@ -34,6 +34,13 @@
 				<li>“’tis</li>
 				<li>“’Tis</li>
 			</ul>
+			<!-- Remove space between number and fraction -->
+			<ul>
+				<li>123 ½</li>
+				<li>123  ¾</li>
+				<li>123⅚</li>
+				<li>123¹⁄₈₀₀</li>
+			</ul>
 		</section>
 	</body>
 </html>


### PR DESCRIPTION
Typogrify removes the space between a whole numbers and a fraction, but it currently also removes the space after a comma. Since the comment only mentions "whole numbers", the regexp probably shouldn't include commas.