### PR TITLE
build-loi: Remove links and noterefs from figcaption

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -962,6 +962,15 @@ class SeEpub:
 						if not has_block:
 							entry = deepcopy(figcaption[0])
 
+						if isinstance(entry, se.easy_xml.EasyXmlElement):
+							# Remove endnote references.
+							for noteref in entry.xpath("a[contains(@epub:type, 'noteref')]"):
+								noteref.remove()
+
+							# For other links, keep only the contents.
+							for a in entry.xpath("a"):
+								a.unwrap()
+
 				a = se.easy_xml.EasyXmlElement("<a/>")
 				a.set_attr("href", f"{file_path.name}#{figure_id}")
 

--- a/tests/draft_commands/build-loi/test-1/golden/src/epub/text/chapter-1.xhtml
+++ b/tests/draft_commands/build-loi/test-1/golden/src/epub/text/chapter-1.xhtml
@@ -51,6 +51,16 @@
 				<img alt="Alt is preferred over figcaption with block element."/>
 				<figcaption><h1>Figure 9</h1></figcaption>
 			</figure>
+
+			<figure id="f-10">
+				<img/>
+				<figcaption>Endnote references in figcaption are removed.<a href="endnotes.xhtml#note-8" id="noteref-8" epub:type="noteref">8</a></figcaption>
+			</figure>
+
+			<figure id="f-11">
+				<img/>
+				<figcaption>Other hyperlinks are converted to text. <a href="chapter-2.xhtml">See Chapter 2.</a></figcaption>
+			</figure>
 		</section>
 	</body>
 </html>

--- a/tests/draft_commands/build-loi/test-1/golden/src/epub/text/loi.xhtml
+++ b/tests/draft_commands/build-loi/test-1/golden/src/epub/text/loi.xhtml
@@ -52,6 +52,16 @@
 				</li>
 				<li>
 					<p>
+						<a href="chapter-1.xhtml#f-10">Endnote references in figcaption are removed.</a>
+					</p>
+				</li>
+				<li>
+					<p>
+						<a href="chapter-1.xhtml#f-11">Other hyperlinks are converted to text. See Chapter 2.</a>
+					</p>
+				</li>
+				<li>
+					<p>
 						<a href="chapter-2.xhtml#f-0">Unable to auto-generate LoI text for #f-0.</a>
 					</p>
 				</li>

--- a/tests/draft_commands/build-loi/test-1/in/src/epub/text/chapter-1.xhtml
+++ b/tests/draft_commands/build-loi/test-1/in/src/epub/text/chapter-1.xhtml
@@ -51,6 +51,16 @@
 				<img alt="Alt is preferred over figcaption with block element."/>
 				<figcaption><h1>Figure 9</h1></figcaption>
 			</figure>
+
+			<figure id="f-10">
+				<img/>
+				<figcaption>Endnote references in figcaption are removed.<a href="endnotes.xhtml#note-8" id="noteref-8" epub:type="noteref">8</a></figcaption>
+			</figure>
+
+			<figure id="f-11">
+				<img/>
+				<figcaption>Other hyperlinks are converted to text. <a href="chapter-2.xhtml">See Chapter 2.</a></figcaption>
+			</figure>
 		</section>
 	</body>
 </html>


### PR DESCRIPTION
`se build-loi` copies non-block-level elements from the `<figcaption>` to the LoI. If the caption contains an `<a>` tag, such as an endnote reference, this creates a nested `<a>`:

```html
<a href="chapter-1.xhtml#f-10">Figure.<a href="endnotes.xhtml#note-8" id="noteref-8" epub:type="noteref">8</a></a>
```

This patch:
* removes noteref `<a>`s entirely;
* removes other `<a>` tags as well, but keeps their contents.