### PR TITLE
semanticate: i inside a tag is not a Roman numeral

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -145,7 +145,7 @@ def semanticate(xhtml: str) -> str:
 	xhtml = regex.sub(r"""([^\p{Letter}>\"])([vxVX])(\b[^\-]|st\b|nd\b|rd\b|th\b)""", r"""\1<span epub:type="z3998:roman">\2</span>\3""", xhtml)
 
 	# We can assume a lowercase i is always a Roman numeral unless followed by ’
-	xhtml = regex.sub(r"""([^\p{Letter}<>/\"])i\b(?!’)""", r"""\1<span epub:type="z3998:roman">i</span>""", xhtml)
+	xhtml = regex.sub(r"""([^\p{Letter}<>/\"])i\b(?!’)(?![^<>]+>)""", r"""\1<span epub:type="z3998:roman">i</span>""", xhtml)
 
 	# Fix obscured names starting with I, V, or X
 	xhtml = regex.sub(fr"""<span epub:type="z3998:roman">([IVX])</span>{se.WORD_JOINER}⸺""", fr"""\1{se.WORD_JOINER}⸺""", xhtml)

--- a/tests/draft_commands/semanticate/test-1/golden/semanticate.xhtml
+++ b/tests/draft_commands/semanticate/test-1/golden/semanticate.xhtml
@@ -168,6 +168,9 @@
                         <p>I gave him an <abbr epub:type="z3998:initialism" class="eoc">I.O.U.</abbr></p>
                         <p>The picture was almost <abbr epub:type="z3998:initialism" class="eoc">3D</abbr>.</p>
                         <p>His name was abbreviated <abbr epub:type="z3998:given-name" class="eoc">Chas.</abbr></p>
+                        <!-- roman / not roman -->
+                        <p>Edition <span epub:type="z3998:roman">i</span>. Pages <span epub:type="z3998:roman">i</span> and <span epub:type="z3998:roman">ii</span>. Number i’.</p>
+                        <p>See <a href="appendix-i.xhtml">Appendix</a>.</p>
                 </section>
         </body>
 </html>

--- a/tests/draft_commands/semanticate/test-1/in/semanticate.xhtml
+++ b/tests/draft_commands/semanticate/test-1/in/semanticate.xhtml
@@ -168,6 +168,9 @@
                         <p>I gave him an <abbr epub:type="z3998:initialism" class="eoc">I.O.U.</abbr></p>
                         <p>The picture was almost <abbr epub:type="z3998:initialism" class="eoc">3D</abbr>.</p>
                         <p>His name was abbreviated <abbr epub:type="z3998:given-name" class="eoc">Chas.</abbr></p>
+                        <!-- roman / not roman -->
+                        <p>Edition i. Pages i and ii. Number i’.</p>
+                        <p>See <a href="appendix-i.xhtml">Appendix</a>.</p>
                 </section>
         </body>
 </html>


### PR DESCRIPTION
`se semanticate` has a regexp that wraps lowercase `i` to a Roman numeral `<span>`. The regexp also does this to `i`s inside attributes:
```html
<a href="appendix-i.xhtml">
```
becomes
```html
<a href="appendix-<span epub:type="z3998:roman">i</span>.xhtml">
```

This patch adds a lookahead clause to check that the `i` is not inside an open tag.