### PR TITLE
Use time markup in colophon

### DIFF
--- a/se/data/templates/colophon.xhtml
+++ b/se/data/templates/colophon.xhtml
@@ -12,13 +12,13 @@
 				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">TITLE</i><br/>
-			was published in YEAR by<br/>
+			was published in <time>YEAR</time> by<br/>
 			<a href="AUTHOR_WIKI_URL">AUTHOR</a>.</p>
 			<p>This ebook was produced for<br/>
 			<a href="https://standardebooks.org">Standard Ebooks</a><br/>
 			by<br/>
 			<a href="PRODUCER_URL">PRODUCER</a>,<br/>
-			and is based on a transcription produced in PG_YEAR by<br/>
+			and is based on a transcription produced in <time>PG_YEAR</time> by<br/>
 			<b epub:type="z3998:personal-name">TRANSCRIBER_1</b>, <b epub:type="z3998:personal-name">TRANSCRIBER_2</b>, and <a href="https://www.pgdp.net">The Online Distributed Proofreading Team</a><br/>
 			for<br/>
 			<a href="PG_URL">Project Gutenberg</a><br/>
@@ -26,14 +26,14 @@
 			<a href="IA_URL">Internet Archive</a>.</p>
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">PAINTING</i>,<br/>
-			a painting completed in YEAR by<br/>
+			a painting completed in <time>YEAR</time> by<br/>
 			<a href="COVER_ARTIST_WIKI_URL">COVER_ARTIST</a>.<br/>
 			The cover and title pages feature the<br/>
 			<b epub:type="se:name.visual-art.typeface">League Spartan</b> and <b epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</b><br/>
-			typefaces created in 2014 and 2009 by<br/>
+			typefaces created in <time>2014</time> and <time>2009</time> by<br/>
 			<a href="https://www.theleagueofmoveabletype.com">The League of Moveable Type</a>.</p>
 			<p>The first edition of this ebook was released on<br/>
-			<b>January 1, 1900, 12:00 <abbr class="eoc">a.m.</abbr></b><br/>
+			<b><time datetime="1900-01-01T00:00:00Z">January 1, 1900, 12:00 <abbr class="eoc">a.m.</abbr></time></b><br/>
 			You can check for updates to this ebook, view its revision history, or download it for different ereading systems at<br/>
 			<a href="https://standardebooks.org/ebooks/SE_IDENTIFIER">standardebooks.org/ebooks/SE_IDENTIFIER</a>.</p>
 			<p>The volunteer-driven Standard Ebooks project relies on readers like you to submit typos, corrections, and other improvements. Anyone can contribute at <a href="https://standardebooks.org">standardebooks.org</a>.</p>

--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -1014,8 +1014,8 @@ class SeEpub:
 				dom = self.get_dom(file_path)
 
 				if dom.xpath("/html/body/section[contains(@epub:type, 'colophon')]"):
-					for node in dom.xpath("/html/body/section[contains(@epub:type, 'colophon')]//b[contains(text(), 'January 1, 1900')]"):
-						node.replace_with(se.easy_xml.EasyXmlElement(etree.fromstring(str.encode("<b>" + now_friendly + "</b>"))))
+					for node in dom.xpath("/html/body/section[contains(@epub:type, 'colophon')]//time[contains(text(), 'January 1, 1900')]"):
+						node.replace_with(se.easy_xml.EasyXmlElement(etree.fromstring(str.encode("<time datetime=\"" + now_iso + "\">" + now_friendly + "</time>"))))
 
 					with open(file_path, "w", encoding="utf-8") as file:
 						file.write(dom.to_string())

--- a/tests/data/draftbook/jane-austen_draft-novel/src/epub/text/colophon.xhtml
+++ b/tests/data/draftbook/jane-austen_draft-novel/src/epub/text/colophon.xhtml
@@ -12,13 +12,13 @@
 				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">Unknown Novel</i><br/>
-			was published in 1810 by<br/>
+			was published in <time>1810</time> by<br/>
 			<a href="https://en.wikipedia.org/wiki/Jane_Austen">Jane Austen</a>.</p>
 			<p>This ebook was produced for<br/>
 			<a href="https://standardebooks.org">Standard Ebooks</a><br/>
 			by<br/>
 			<b>An Anonymous Volunteer</b>,<br/>
-			and is based on a transcription produced in 2010 by<br/>
+			and is based on a transcription produced in <time>2010</time> by<br/>
 			<b class="name">An Anonymous Volunteer</b><br/>
 			for<br/>
 			<a href="https://www.gutenberg.org/ebooks/161">Project Gutenberg</a><br/>
@@ -26,14 +26,14 @@
 			<a href="https://archive.org/details/bub_gb_RtT0OLKFMHsC">Internet Archive</a>.</p>
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">At the Mirror</i>,<br/>
-			a painting completed in 1827 by<br/>
+			a painting completed in <time>1827</time> by<br/>
 			<a href="https://en.wikipedia.org/wiki/Georg_Friedrich_Kersting">Georg Friedrich Kersting</a>.<br/>
 			The cover and title pages feature the<br/>
 			<b epub:type="se:name.visual-art.typeface">League Spartan</b> and <b epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</b><br/>
-			typefaces created in 2014 and 2009 by<br/>
+			typefaces created in <time>2014</time> and <time>2009</time> by<br/>
 			<a href="https://www.theleagueofmoveabletype.com">The League of Moveable Type</a>.</p>
 			<p>The first edition of this ebook was released on<br/>
-			<b>January 1, 1900, 12:00 <abbr class="eoc">a.m.</abbr></b><br/>
+			<b><time datetime="1900-01-01T00:00:00Z">January 1, 1900, 12:00 <abbr class="eoc">a.m.</abbr></time></b><br/>
 			You can check for updates to this ebook, view its revision history, or download it for different ereading systems at<br/>
 			<a href="https://standardebooks.org/ebooks/jane-austen/unknown-novel">standardebooks.org/ebooks/jane-austen/unknown-novel</a>.</p>
 			<p>The volunteer-driven Standard Ebooks project relies on readers like you to submit typos, corrections, and other improvements. Anyone can contribute at <a href="https://standardebooks.org">standardebooks.org</a>.</p>

--- a/tests/data/testbook/jane-austen_test-novel/src/epub/text/colophon.xhtml
+++ b/tests/data/testbook/jane-austen_test-novel/src/epub/text/colophon.xhtml
@@ -12,13 +12,13 @@
 				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">Unknown Novel</i><br/>
-			was published in 1810 by<br/>
+			was published in <time>1810</time> by<br/>
 			<a href="https://en.wikipedia.org/wiki/Jane_Austen">Jane Austen</a>.</p>
 			<p>This ebook was produced for<br/>
 			<a href="https://standardebooks.org">Standard Ebooks</a><br/>
 			by<br/>
 			<b>An Anonymous Volunteer</b>,<br/>
-			and is based on a transcription produced in 2010 by<br/>
+			and is based on a transcription produced in <time>2010</time> by<br/>
 			<b class="name">An Anonymous Volunteer</b><br/>
 			for<br/>
 			<a href="https://www.gutenberg.org/ebooks/161">Project Gutenberg</a><br/>
@@ -26,14 +26,14 @@
 			<a href="https://archive.org/details/bub_gb_RtT0OLKFMHsC">Internet Archive</a>.</p>
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">At the Mirror</i>,<br/>
-			a painting completed in 1827 by<br/>
+			a painting completed in <time>1827</time> by<br/>
 			<a href="https://en.wikipedia.org/wiki/Georg_Friedrich_Kersting">Georg Friedrich Kersting</a>.<br/>
 			The cover and title pages feature the<br/>
 			<b epub:type="se:name.visual-art.typeface">League Spartan</b> and <b epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</b><br/>
-			typefaces created in 2014 and 2009 by<br/>
+			typefaces created in <time>2014</time> and <time>2009</time> by<br/>
 			<a href="https://www.theleagueofmoveabletype.com">The League of Moveable Type</a>.</p>
 			<p>The first edition of this ebook was released on<br/>
-			<b>January 1, 1900, 12:00 <abbr class="eoc">a.m.</abbr></b><br/>
+			<b><time datetime="1900-01-01T00:00:00Z">January 1, 1900, 12:00 <abbr class="eoc">a.m.</abbr></time></b><br/>
 			You can check for updates to this ebook, view its revision history, or download it for different ereading systems at<br/>
 			<a href="https://standardebooks.org/ebooks/jane-austen/unknown-novel">standardebooks.org/ebooks/jane-austen/unknown-novel</a>.</p>
 			<p>The volunteer-driven Standard Ebooks project relies on readers like you to submit typos, corrections, and other improvements. Anyone can contribute at <a href="https://standardebooks.org">standardebooks.org</a>.</p>

--- a/tests/draft_commands/clean/test-1/golden/src/epub/text/colophon.xhtml
+++ b/tests/draft_commands/clean/test-1/golden/src/epub/text/colophon.xhtml
@@ -12,13 +12,13 @@
 				<img alt="The Standard Ebooks logo" src="../images/logo.svg" epub:type="z3998:publisher-logo"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">Great Expectations</i><br/>
-			was published in 1861 by<br/>
+			was published in <time>1861</time> by<br/>
 			<a href="https://en.wikipedia.org/wiki/Charles_Dickens">Charles Dickens</a>.</p>
 			<p>This ebook was produced for the<br/>
 			<a href="https://standardebooks.org">Standard Ebooks project</a><br/>
 			by<br/>
 			<a href="https://lauraklappenbach.com">Laura Klappenbach</a>,<br/>
-			and is based on a transcription produced in 1998 by<br/>
+			and is based on a transcription produced in <time>1998</time> by<br/>
 			<b epub:type="z3998:personal-name">An Anonymous Volunteer</b> and <b epub:type="z3998:personal-name">David Widger</b><br/>
 			for<br/>
 			<a href="https://www.gutenberg.org/ebooks/1400">Project Gutenberg</a><br/>
@@ -26,14 +26,14 @@
 			<a href="https://catalog.hathitrust.org/Record/011405484">HathiTrust Digital Library</a>.</p>
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">Self-Portrait</i>,<br/>
-			a painting completed in 1812 by<br/>
+			a painting completed in <time>1812</time> by<br/>
 			<a href="https://en.wikipedia.org/wiki/Joseph_Paelinck">Joseph Paelinck</a>.<br/>
 			The cover and title pages feature the<br/>
 			<b epub:type="se:name.visual-art.typeface">League Spartan</b> and <b epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</b><br/>
-			typefaces created in 2014 and 2009 by<br/>
+			typefaces created in <time>2014</time> and <time>2009</time> by<br/>
 			<a href="https://www.theleagueofmoveabletype.com">The League of Moveable Type</a>.</p>
 			<p>The first edition of this ebook was released on<br/>
-			<b>December 23, 2019, 10:06 <abbr class="eoc">p.m.</abbr></b><br/>
+			<b><time datetime="2019-12-23T22:06:00Z">December 23, 2019, 10:06 <abbr class="eoc">p.m.</abbr></time></b><br/>
 			You can check for updates to this ebook, view its revision history, or download it for different ereading systems at<br/>
 			<a href="https://standardebooks.org/ebooks/charles-dickens/great-expectations">standardebooks.org/ebooks/charles-dickens/great-expectations</a>.</p>
 			<p>The volunteer-driven Standard Ebooks project relies on readers like you to submit typos, corrections, and other improvements. Anyone can contribute at <a href="https://standardebooks.org">standardebooks.org</a>.</p>

--- a/tests/draft_commands/clean/test-1/in/src/epub/text/colophon.xhtml
+++ b/tests/draft_commands/clean/test-1/in/src/epub/text/colophon.xhtml
@@ -13,7 +13,7 @@
 			</header>
 			<p><i epub:type="se:name.publication.book">Great Expectations</i><br/>
 			
-			was published in 1861 by<br/>
+			was published in <time>1861</time> by<br/>
 			
 			<a href="https://en.wikipedia.org/wiki/Charles_Dickens">Charles Dickens</a>.</p>
 			<p>This ebook was produced for the<br/>
@@ -24,7 +24,7 @@
 			
 			<a href="https://lauraklappenbach.com">Laura Klappenbach</a>,<br/>
 			
-			and is based on a transcription produced in 1998 by<br/>
+			and is based on a transcription produced in <time>1998</time> by<br/>
 			
 			<b epub:type="z3998:personal-name">An Anonymous Volunteer</b> and <b epub:type="z3998:personal-name">David Widger</b><br/>
 			
@@ -39,7 +39,7 @@
 			
 			<i epub:type="se:name.visual-art.painting">Self-Portrait</i>,<br/>
 			
-			a painting completed in 1812 by<br/>
+			a painting completed in <time>1812</time> by<br/>
 			
 			<a href="https://en.wikipedia.org/wiki/Joseph_Paelinck">Joseph Paelinck</a>.<br/>
 			
@@ -47,12 +47,12 @@
 			
 			<b epub:type="se:name.visual-art.typeface">League Spartan</b> and <b epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</b><br/>
 			
-			typefaces created in 2014 and 2009 by<br/>
+			typefaces created in <time>2014</time> and <time>2009</time> by<br/>
 			
 			<a href="https://www.theleagueofmoveabletype.com">The League of Moveable Type</a>.</p>
 			<p>The first edition of this ebook was released on<br/>
 			
-			<b>December 23, 2019, 10:06 <abbr class="eoc">p.m.</abbr>
+			<b><time datetime="2019-12-23T22:06:00Z">December 23, 2019, 10:06 <abbr class="eoc">p.m.</abbr></time>
 				</b><br/>
 			
 			You can check for updates to this ebook, view its revision history, or download it for different ereading systems at<br/>

--- a/tests/lint/semantic/s-041/in/src/epub/text/colophon.xhtml
+++ b/tests/lint/semantic/s-041/in/src/epub/text/colophon.xhtml
@@ -12,13 +12,13 @@
 				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">Unknown Novel</i><br/>
-			was published in 1810 by<br/>
+			was published in <time>1810</time> by<br/>
 			<a href="https://en.wikipedia.org/wiki/Jane_Austen">Jane Austen</a>.</p>
 			<p>This ebook was produced for<br/>
 			<a href="https://standardebooks.org">Standard Ebooks</a><br/>
 			by<br/>
 			<b>An Anonymous Volunteer</b>,<br/>
-			and is based on a transcription produced in 2010 by<br/>
+			and is based on a transcription produced in <time>2010</time> by<br/>
 			<b class="name">An Anonymous Volunteer</b><br/>
 			for<br/>
 			<a href="https://www.gutenberg.org/ebooks/161">Project Gutenberg</a><br/>
@@ -26,14 +26,14 @@
 			<a href="https://archive.org/details/bub_gb_RtT0OLKFMHsC">Internet Archive</a>.</p>
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">At the Mirror</i>,<br/>
-			a painting completed in 1827 by<br/>
+			a painting completed in <time>1827</time> by<br/>
 			<a href="https://en.wikipedia.org/wiki/Georg_Friedrich_Kersting">Georg Friedrich Kersting</a>.<br/>
 			The cover and title pages feature the<br/>
 			<b epub:type="se:name.visual-art.typeface">League Spartan</b> and <b epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</b><br/>
-			typefaces created in 2014 and 2009 by<br/>
+			typefaces created in <time>2014</time> and <time>2009</time> by<br/>
 			<a href="https://www.theleagueofmoveabletype.com">The League of Moveable Type</a>.</p>
 			<p>The first edition of this ebook was released on<br/>
-			<b>January 1, 1900, 12:00 <abbr class="eoc">a.m.</abbr></b><br/>
+			<b><time datetime="1900-01-01T00:00:00Z">January 1, 1900, 12:00 <abbr class="eoc">a.m.</abbr></time></b><br/>
 			You can check for updates to this ebook, view its revision history, or download it for different ereading systems at<br/>
 			<a href="https://standardebooks.org/ebooks/jane-austen/unknown-novel/john-doe">standardebooks.org/ebooks/jane-austen/unknown-novel/john-doe</a>.</p>
 			<p>The volunteer-driven Standard Ebooks project relies on readers like you to submit typos, corrections, and other improvements. Anyone can contribute at <a href="https://standardebooks.org">standardebooks.org</a>.</p>

--- a/tests/lint/semantic/s-056/in/src/epub/text/colophon.xhtml
+++ b/tests/lint/semantic/s-056/in/src/epub/text/colophon.xhtml
@@ -12,13 +12,13 @@
 				<img alt="The Standard Ebooks logo" src="../images/logo.svg" epub:type="z3998:publisher-logo"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">Unknown Novel</i><br/>
-			was published in 1900 by<br/>
+			was published in <time>1900</time> by<br/>
 			<a href="https://en.wikipedia.org/wiki/Jane_Austen">Jane Austen</a>.</p>
 			<p>This ebook was produced for the<br/>
 			<a href="https://standardebooks.org">Standard Ebooks project</a><br/>
 			by<br/>
 			<a href="https://producer.example.com">A. Producer</a>,<br/>
-			and is based on a transcription produced in 2000 by<br/>
+			and is based on a transcription produced in <time>2000</time> by<br/>
 			<b epub:type="z3998:personal-name">A. Transcriber</b>, <b epub:type="z3998:personal-name">B. Transcriber</b>, and <a href="https://www.pgdp.net">The Online Distributed Proofreading Team</a><br/>
 			for<br/>
 			<a href="https://www.gutenberg.org/ebooks/1">Project Gutenberg</a><br/>
@@ -26,14 +26,14 @@
 			<a href="https://archive.org/details/emmaanovelinthr02austgoog">Internet Archive</a>.</p>
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">A Very Nice Painting</i>,<br/>
-			a painting completed in 1900 by<br/>
+			a painting completed in <time>1900</time> by<br/>
 			<a href="https://artist.example.com">Ann Artist</a>.<br/>
 			The cover and title pages feature the<br/>
 			<b epub:type="se:name.visual-art.typeface">League Spartan</b> and <b epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</b><br/>
-			typefaces created in 2014 and 2009 by<br/>
+			typefaces created in <time>2014</time> and <time>2009</time> by<br/>
 			<a href="https://www.theleagueofmoveabletype.com">The League of Moveable Type</a>.</p>
 			<p>The first edition of this ebook was released on<br/>
-			<b>January 1, 1900, 12:00 <abbr class="eoc">a.m.</abbr></b><br/>
+			<b><time datetime="1900-01-01T00:00:00Z">January 1, 1900, 12:00 <abbr class="eoc">a.m.</abbr></time></b><br/>
 			You can check for updates to this ebook, view its revision history, or download it for different ereading systems at<br/>
 			<a href="https://standardebooks.org/ebooks/jane-austen/unknown-novel">standardebooks.org/ebooks/jane-austen/unknown-novel</a>.</p>
 			<p>The volunteer-driven Standard Ebooks project relies on readers like you to submit typos, corrections, and other improvements. Anyone can contribute at <a href="https://standardebooks.org">standardebooks.org</a>.</p>


### PR DESCRIPTION
This defaults years to be within `<time>` tags, which will automatically work for everything published after 1000. It also adjusts `prepare_release` to add the ISO datetime to the colophon “released on” field.

I knocked this together in 20 mins, so if you think it’ll be too much work for not enough value to update the corpus, let’s close it, no harm done 🙂