### PR TITLE
Highlight time elements when proofreading

### DIFF
--- a/se/data/templates/proofreading.css
+++ b/se/data/templates/proofreading.css
@@ -1,6 +1,7 @@
 /* Proofreading CSS */
 [epub|type~="z3998:roman"],
 [lang]:not(html),
-abbr{
+abbr,
+time{
 	background: #C0C0C0;
 }


### PR DESCRIPTION
I didn’t realise the proofreading CSS existed, have been doing this manually in my productions.