### PR TITLE
Modernize aërial -> aerial

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -478,7 +478,7 @@ TYPOS
 "y-019”, "Possible typo: [text]”[/] without opening [text]“[/]."
 "y-020”, "Possible typo: consecutive comma-period ([text],.[/])."
 "y-022”, "Possible typo: consecutive quotations without intervening text, e.g. [text]“…” “…”[/]."
-"y-024”, "Possible typo: dash before [text]the/there/is/and/they/when[/] probably should be em-dash."
+"y-024”, "Possible typo: dash before [text]the/there/is/and/or/they/when[/] probably should be em-dash."
 "y-025”, "Possible typo: letter/comma/quote mark/letter with no intervening space."
 "y-026”, "Possible typo: no punctuation before conjunction [text]But/And/For/Nor/Yet/Or[/]."
 "y-027”, "Possible typo: Extra [text]’[/] at end of paragraph."
@@ -3047,9 +3047,9 @@ def _lint_xhtml_typo_checks(filename: Path, dom: se.easy_xml.EasyXmlTree, file_c
 		messages.append(LintMessage("y-022", "Possible typo: consecutive quotations without intervening text, e.g. [text]“…” “…”[/].", se.MESSAGE_TYPE_WARNING, filename, typos))
 
 	# Check for dashes instead of em-dashes
-	typos = [node.to_string() for node in dom.xpath("/html/body//p[re:test(., '\\s[a-z]+-(the|there|is|and|they|when)\\s')]")]
+	typos = [node.to_string() for node in dom.xpath("/html/body//p[re:test(., '\\s[a-z]+-(the|there|is|and|or|they|when)\\s')]")]
 	if typos:
-		messages.append(LintMessage("y-024", "Possible typo: dash before [text]the/there/is/and/they/when[/] probably should be em-dash.", se.MESSAGE_TYPE_WARNING, filename, typos))
+		messages.append(LintMessage("y-024", "Possible typo: dash before [text]the/there/is/and/or/they/when[/] probably should be em-dash.", se.MESSAGE_TYPE_WARNING, filename, typos))
 
 	# Check for letter/comma/quote mark/letter with no intervening space (rdquo is already handled by y-012)
 	typos = [node.to_string() for node in dom.xpath("/html/body//p[re:test(., '[a-z],[“‘’][a-z]', 'i')]")]

--- a/se/spelling.py
+++ b/se/spelling.py
@@ -191,6 +191,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b([Cc])oërc", r"\1oerc", xhtml)				# coërc -> coerc (as in coërcion)
 	xhtml = regex.sub(r"\b([Cc])oëd", r"\1oed", xhtml)				# coëd -> coed (as in coëducation)
 	xhtml = regex.sub(r"\b([Dd])aïs\b", r"\1ais", xhtml)				# daïs -> dais
+	xhtml = regex.sub(r"\b([Aa])ërial", r"\1erial", xhtml)				# aërial -> aerial
 	xhtml = regex.sub(r"\b([Cc])oup[\- ]de[\- ]gr[aâ]ce", r"\1oup de grâce", xhtml)	# coup-de-grace -> coup-de-grâce
 	xhtml = regex.sub(r"\b([Cc])anape", r"\1anapé", xhtml)				# canape -> canapé
 	xhtml = regex.sub(r"\b([Pp])recis\b", r"\1récis", xhtml)			# precis -> précis

--- a/tests/lint/typos/y-024/golden/y-024-out.txt
+++ b/tests/lint/typos/y-024/golden/y-024-out.txt
@@ -1,5 +1,5 @@
 y-024 [Manual Review] chapter-1.xhtml Possible typo: dash before 
-`the/there/is/and/they/when` probably should be em-dash.
+`the/there/is/and/or/they/when` probably should be em-dash.
         <p>The cushion of-the celery becomes a clausal yak.</p>
         <p>A desk sees-there as a patent description.</p>
         <p>An unrhymed leopard without kittens-is truly a twist of hoven 


### PR DESCRIPTION
There‘s an obvious trend in ngrams for this: https://books.google.com/ngrams/graph?content=a%C3%ABrial%2Caerial&year_start=1800&year_end=2022&corpus=en&smoothing=3

Looking at the corpus, 19 productions currently use this; will modernize if this is merged.