### PR TITLE
Update installation instructions for Fedora users

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,31 +39,31 @@ sudo ln -s $HOME/.local/pipx/venvs/standardebooks/lib/python3.*/site-packages/se
 ln -s $HOME/.local/pipx/venvs/standardebooks/lib/python3.*/site-packages/se/completions/fish/se $HOME/.config/fish/completions/se.fish
 ```
 
-## Fedora users
+## Fedora 41 users
 
 ```shell
 # Install some pre-flight dependencies.
-sudo dnf install calibre git java-1.8.0-openjdk python3-devel
+sudo dnf install pipx python3.12 python3.12-devel gcc libxslt-devel calibre git java-21-openjdk-headless
 
-# Install pipx.
-python3 -m pip install --user pipx
-python3 -m pipx ensurepath
+# Ensure PATH environment variable is correctly set up for pipx
+pipx ensurepath
 
 # Install the toolset.
-pipx install standardebooks
+pipx install --python=3.12 standardebooks
+pipx inject standardebooks setuptools
 ```
 
 ### Optional: Install shell completions
 
 ```shell
 # Install ZSH completions.
-sudo ln -s $HOME/.local/pipx/venvs/standardebooks/lib/python3.*/site-packages/se/completions/zsh/_se /usr/share/zsh/vendor-completions/_se && hash -rf && compinit
+sudo ln -s $HOME/.local/share/pipx/venvs/standardebooks/lib/python3.*/site-packages/se/completions/zsh/_se /usr/share/zsh/vendor-completions/_se && hash -rf && compinit
 
 # Install Bash completions.
-sudo ln -s $HOME/.local/pipx/venvs/standardebooks/lib/python3.*/site-packages/se/completions/bash/se /usr/share/bash-completion/completions/se
+sudo ln -s $HOME/.local/share/pipx/venvs/standardebooks/lib/python3.*/site-packages/se/completions/bash/se /usr/share/bash-completion/completions/se
 
 # Install Fish completions.
-ln -s $HOME/.local/pipx/venvs/standardebooks/lib/python3.*/site-packages/se/completions/fish/se $HOME/.config/fish/completions/se.fish
+ln -s $HOME/.local/share/pipx/venvs/standardebooks/lib/python3.*/site-packages/se/completions/fish/se $HOME/.config/fish/completions/se.fish
 ```
 
 ## macOS users


### PR DESCRIPTION
Instructions to install the toolset on Fedora have been outdated for a while now. The release of Fedora 41 last week further complicates things.

Fedora 41 ships with Python 3.13.0 by default. The toolset is incompatible with this version since it only supports Python >= 3.8 and <= 3.12. Furthermore, one of the toolset dependencies, Pillow, does not support Python 3.13 and above until [version 10.4.0](https://github.com/python-pillow/Pillow/issues/8075#issuecomment-2199751940)—the toolset strictly requires 10.3.0.

These updated instructions have been tested on three different machines; one is relatively new while the other two are rather old (one of which wasn’t even supposed to be good in the first place!) Some of the dependencies are already satisfied on a fresh Fedora 41 Workstation install but are included for completion’s sake. Instructions were also tested on a fresh minimal install—in which  case more dependencies for the listed packages will be installed but everything works fine in the end.

While pipx can fetch stand-alone Python builds, it should be noted that it only worked on the newer machine. For some reason, the two older computers simply couldn’t run any of the stand-alone builds at all—I spent a whole evening trying to find out why but ended up with nothing. However, installing the `python3.12` and `python3.12-devel` packages from the Fedora repos worked fine and pipx could easily latch onto that version with the `--python 3.12` switch. If anything, it is the recommended method to install different Python versions on Fedora.

(Additionally, the stand-alone builds pipx downloads take about 240M of space each while the official packages only take 43M in total. While storage space is less and less of a problem these days, I’ll take anything I can get. The stand-alone builds also specifically require clang instead of gcc to install the toolset, which is a heavier dependency.)

pipx is now installed with dnf from the Fedora repos (eschewing pip); it is the [recommended](https://github.com/pypa/pipx?tab=readme-ov-file#on-linux) [method](https://developer.fedoraproject.org/tech/languages/python/pypi-installation.html) on Fedora.

Java was bumped from 1.8 to 21, the default LTS version that ships with Fedora. It has also been changed to headless since the toolset doesn’t require any GUI. Unless there are specific incompatibilities that require 1.8, there seems to be little reason to add another version. Also, 1.8 would need to be specifically selected else any Java code would be run by the default implementation, i.e., 21.

`python3 -m pipx ensurepath` was changed to `pipx ensurepath` because it is again [the recommended method when installed as a Fedora package](https://github.com/pypa/pipx?tab=readme-ov-file#on-linux).

Finally, it is necessary to inject the setuptools package into the pipx standardebooks venv else the toolset crashes, complaining about missing pkg_resources module.

Shell completions were slightly updated: it seems that the default directory where pipx stores its data was changed from `~/.local/pipx/` to `~/.local/share/pipx/`. Any new installation will use that updated location.