### PR TITLE
Fix wrong click behaviour in Apple Books with drama

### DIFF
--- a/se/data/templates/compatibility.css
+++ b/se/data/templates/compatibility.css
@@ -79,3 +79,15 @@ img.mathml{
 :root[__ibooks_internal_theme] blockquote p:first-child{
 	hanging-punctuation: first last !important;
 }
+
+/* Apple Books will load a pannable zoomable table view when clicked, which is useful unless you’re
+   trying to read a piece of drama. */
+[epub|type~="z3998:drama"] table,
+table[epub|type~="z3998:drama"]{
+	pointer-events: none;
+}
+
+[epub|type~="z3998:drama"] table a,
+table[epub|type~="z3998:drama"] a{
+	pointer-events: auto;
+}


### PR DESCRIPTION
Apple Books has a specific behaviour for tables: if you click on them you get a scannable zoomable popup of the whole table. This is really nice functionality, until you realise that we use tables to lay drama out.

A fix is to block events on drama tables. Obviously we have some links (for example endnotes) inside drama that need to remain clickable, so we unblock for those.

I’ve tested this on Agamemnon: the table click behaviour is blocked, while the endnotes continue to pop up as expected. One change we could make is to make this specific to Apple Books though? Up to you.