### PR TITLE
Modernize naïf -> naive

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -95,31 +95,31 @@ def detect_problem_spellings(xhtml: str) -> list:
 	# language = get_xhtml_language(xhtml)
 	output = []
 
-	if regex.search(r"\bstaid\b", xhtml):
+	if regex.search(r"\bstaid\b", xhtml, flags=regex.I):
 		output.append("“staid” detected. This should be modernized if it is the past tense of “stay,” but not if used as an adjective meaning “sedate or prim.”")
 
-	if regex.search(r"\bcozen\b", xhtml):
+	if regex.search(r"\bcozen\b", xhtml, flags=regex.I):
 		output.append("“cozen” detected. This should be modernized if it means “cousin,” but not if used to mean “to deceive or win over.”")
 
-	if regex.search(r"\bgrown-?up\b", xhtml):
+	if regex.search(r"\bgrown-?up\b", xhtml, flags=regex.I):
 		output.append("“grownup” or “grown-up” detected. Confirm that “grownup” is strictly a noun, and “grown-up” is strictly an adjective.")
 
-	if regex.search(r"\bcommon[\-\s]?sense\b", xhtml):
+	if regex.search(r"\bcommon[\-\s]?sense\b", xhtml, flags=regex.I):
 		output.append("“commonsense” or “common sense” or “common-sense” detected. Confirm that “common sense” and “common-sense” are strictly nouns, and that “commonsense” is strictly an adjective.")
 
-	if regex.search(r"\bmann?ikin\b", xhtml):
+	if regex.search(r"\bmann?ikin\b", xhtml, flags=regex.I):
 		output.append("“mannikin” or “manikin” detected. Confirm that “mannikin” is used in the sense of a small person, and “mannequin” is used in the sense of a dummy or figure.")
 
-	if regex.search(r"\bgripe", xhtml):
+	if regex.search(r"\bgripe", xhtml, flags=regex.I):
 		output.append("“gripe” or “griped” detected. Confirm that “gripe” is used in the sense of illness or complaint, not in the sense of “grip” or “gripped.”")
 
-	if regex.search(r"\bmay[\-\s]?day", xhtml):
+	if regex.search(r"\bmay[\-\s]?day", xhtml, flags=regex.I):
 		output.append("“mayday” or “may day” or “may-day” detected. Confirm that “may day” and “may-day” refer to the day, and that “mayday” is used in the sense of a distress signal.")
 
-	if regex.search(r"\bfree[\-\s]?will", xhtml):
+	if regex.search(r"\bfree[\-\s]?will", xhtml, flags=regex.I):
 		output.append("“freewill” or “free will” or “free-will” detected. Confirm that “free will” and “free-will” are strictly nouns, and that “freewill” is strictly an adjective.")
 
-	if regex.search(r"\bna[iï]f", xhtml):
+	if regex.search(r"\bna[iï]f", xhtml, flags=regex.I):
 		output.append("“naif” or “naïf” detected. Confirm that “naïf” is strictly a noun, and “naive” is strictly an adjective.")
 
 	return output

--- a/se/spelling.py
+++ b/se/spelling.py
@@ -119,6 +119,9 @@ def detect_problem_spellings(xhtml: str) -> list:
 	if regex.search(r"\bfree[\-\s]?will", xhtml):
 		output.append("“freewill” or “free will” or “free-will” detected. Confirm that “free will” and “free-will” are strictly nouns, and that “freewill” is strictly an adjective.")
 
+	if regex.search(r"\bna[iï]f", xhtml):
+		output.append("“naif” or “naïf” detected. Confirm that “naïf” is strictly a noun, and “naive” is strictly an adjective.")
+
 	return output
 
 def modernize_spelling(xhtml: str) -> str:
@@ -170,6 +173,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"([Hh])ypothenuse", r"\1ypotenuse", xhtml)			# hypothenuse -> hypotenuse
 	xhtml = regex.sub(r"[‘’]([Bb])us\b", r"\1us", xhtml)				# ’bus -> bus
 	xhtml = regex.sub(r"([Nn])aïve", r"\1aive", xhtml)				# naïve -> naive
+	xhtml = regex.sub(r"([Nn])aif", r"\1aïf", xhtml)					# naif -> naïf
 	xhtml = regex.sub(r"([Nn])a[ïi]vet[ée]", r"\1aivete", xhtml)			# naïveté -> naivete
 	xhtml = regex.sub(r"&amp;c\.", r"etc.", xhtml)					# &c. -> etc.
 	xhtml = regex.sub(r"([Pp])rot[ée]g[ée]", r"\1rotégé", xhtml)			# protege -> protégé


### PR DESCRIPTION
Also add a warning that naïf as a noun is the correct usage.

I’ve covered the rest of the corpus: the two remaining naïfs are part of French text.