### PR TITLE
modernize-spelling: lowercase street arab

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -304,7 +304,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b([Hh])iccough", r"\1iccup", xhtml)			# hiccough -> hiccup
 	xhtml = regex.sub(r"\b([Rr])oue(s?)\b", r"\1oué\2", xhtml)			# roue -> roué
 	xhtml = regex.sub(r"\b([Ii])dee fixe\b", r"\1dée fixe\2", xhtml)		# idee fixe -> idée fixe
-	xhtml = regex.sub(r"\b([Ss])treet[\s\-]arab\b", r"\1treet Arab", xhtml)		# street-arab -> street Arab
+	xhtml = regex.sub(r"\b([Ss])treet[\s\-][Aa]rab(s?)\b", r"\1treet arab\2", xhtml)		# street-arab -> street arab
 	xhtml = regex.sub(r"\b[EÉ]migr[eé](?!e)", r"Émigré", xhtml)			# Emigre -> Émigré (but not emigrée, which is French)
 	xhtml = regex.sub(r"\b[eé]migr[eé](?!e)", r"émigré", xhtml)			# emigre -> émigré (but not emigrée, which is French)
 	xhtml = regex.sub(r"\b([Cc])ourtezan", r"\1ourtesan", xhtml)			# courtezan -> courtesan


### PR DESCRIPTION
We still want to drop the hyphen though. It should also work in the plural.

In the corpus there’s “street Arab” with a capital in the following productions that I’ll fix:

- alexandre-dumas_the-count-of-monte-cristo_chapman-and-hall
- arthur-conan-doyle_a-study-in-scarlet
- arthur-conan-doyle_the-memoirs-of-sherlock-holmes
- arthur-conan-doyle_the-sign-of-the-four
- d-h-lawrence_women-in-love
- emile-gaboriau_monsieur-lecoq_laura-e-kendall
- emile-gaboriau_the-slaves-of-paris_charles-scribners-sons
- erskine-childers_the-riddle-of-the-sands
- ethel-voynich_the-gadfly
- fergus-hume_the-mystery-of-a-hansom-cab
- freeman-wills-crofts_the-cask
- honore-de-balzac_father-goriot_ellen-marriage
- honore-de-balzac_shorts-from-scenes-from-private-life_clara-bell_ellen-marriage
- israel-zangwill_the-big-bow-mystery
- jack-london_the-iron-heel
- kate-chopin_short-fiction
- l-m-montgomery_anne-of-green-gables
- marcel-proust_in-search-of-lost-time_c-k-scott-moncrieff
- maurice-leblanc_the-crystal-stopper_alexander-teixeira-de-mattos
- maurice-leblanc_the-secret-tomb_alexander-teixeira-de-mattos
- sigfrid-siwertz_downstream_e-classen
- victor-hugo_les-miserables_isabel-f-hapgood

Fixes https://github.com/standardebooks/tools/issues/771.