### PR TITLE
Add bondslave(s) to hyphenation word list

### DIFF
--- a/se/data/words
+++ b/se/data/words
@@ -9546,6 +9546,8 @@ bondmaids
 bondman
 bondmen
 bonds
+bondslave
+bondslaves
 bondsman
 bondsmen
 bondswoman


### PR DESCRIPTION
This is in M-W unabridged. I don't know you feel about that for hyphenation purposes. It is a word, if an uncommon one, so I thought we would want to correct bond-slave to bondslave.

There are a few occurrences of bond-slave(s) in the corpus; I'll correct them if this is accepted.