### PR TITLE
Restrict blocking of table popup to just Apple Books

### DIFF
--- a/se/data/templates/compatibility.css
+++ b/se/data/templates/compatibility.css
@@ -82,12 +82,12 @@ img.mathml{
 
 /* Apple Books will load a pannable zoomable table view when clicked, which is useful unless you’re
    trying to read a piece of drama. */
-[epub|type~="z3998:drama"] table,
-table[epub|type~="z3998:drama"]{
+:root[__ibooks_internal_theme] [epub|type~="z3998:drama"] table,
+:root[__ibooks_internal_theme] table[epub|type~="z3998:drama"]{
 	pointer-events: none;
 }
 
-[epub|type~="z3998:drama"] table a,
-table[epub|type~="z3998:drama"] a{
+:root[__ibooks_internal_theme] [epub|type~="z3998:drama"] table a,
+:root[__ibooks_internal_theme] table[epub|type~="z3998:drama"] a{
 	pointer-events: auto;
 }


### PR DESCRIPTION
This was causing an undesired inability to select text on Kobo. Of course, it turns out that we also can’t select text on Books either, but at least this fixes non-Books scenarios.

I tried a bunch of other CSS to see if I could word around the problem with no luck. I think the next steps would be to experiment with `display: grid` for browsers that support it…