### PR TITLE
Add words to hyphenated words list

### DIFF
--- a/se/data/words
+++ b/se/data/words
@@ -19008,6 +19008,8 @@ cosy
 cotangent
 cotangents
 cote
+cotehardie
+cotehardies
 cotenant
 cotenants
 coterie
@@ -49318,6 +49320,8 @@ mantelets
 mantelpiece
 mantelpieces
 mantels
+mantelshelf
+mantelshelves
 mantes
 mantic
 mantilla
@@ -84919,6 +84923,7 @@ tumble
 tumblebug
 tumblebugs
 tumbled
+tumbledown
 tumbler
 tumblers
 tumbles


### PR DESCRIPTION
A few more words run across either in reviews or in my current production, all in M-W.

While adding mantelshelf, I noticed we have both mantelpiece(s) and mantlepiece(s). M-W [says](https://www.merriam-webster.com/dictionary/mantle) (scroll down to the Did You Know?) that mantel and mantle aren't really synonyms, although the latter is sometimes used, "especially in American English," for the former. Ngrams reflects that; mantlepiece is barely above zero, mantelpiece is a couple of order of magnitudes more common. (In English fiction; it's even more pronounced in English in general.)

So, I wonder if we should change mantle-?piece to mantelpiece in spelling.py, and remove mantlepiece(s) from words? There are 45 occurrences of mantlepiece in the corpus that would need to be changed.
Ditto for mantle-?shelf; we have four of those in the corpus, vs. 117 of mantelshelf.

cotehardie(s)
mantelshelf
mantelshelves
tumbledown