### PR TITLE
Improve british2american command

### DIFF
--- a/tests/draft_commands/british2american/test-1/golden/b2a.xhtml
+++ b/tests/draft_commands/british2american/test-1/golden/b2a.xhtml
@@ -8,7 +8,66 @@
 	<body epub:type="bodymatter z3998:fiction">
 		<section id="chapter-1" epub:type="chapter">
 			<h2 epub:type="title">A Dreary Story</h2>
-			<p>“That ‘thing’ sounds great,” he said.</p>
+			<!-- single quoted society with no dialog -->
+			<p>Very few of them do stay to see the church, though the rector, the Rev. Thomas J. S. Chillingford, has not only written a short history of it but has also published this history as a pamphlet: Reprinted from the “Transactions of the Bristol and Gloucestershire Archaeological Society”; and any visitor who appreciates an extraordinarily fine rood-screen when he sees one (to say nothing of two possible leper-windows on the north side) cannot fail to obtain a copy of this pamphlet.</p>
+			<!-- simple quotes, but with two on wrong side of punctuation -->
+			<p>“Na Jim!” returned Mr. Oakroyd. This “Na,” which must once have been “Now,” is the recognized salutation in Bruddersford, and the fact that it sounds more like a word of caution than a word of greeting is by no means surprising. You have to be careful in Bruddersford.</p>
+			<!-- single dialog quote with numerous dialect within -->
+			<p>“Ah thowt t’United’d ’a’ made rings rahnd ’em,” Jim remarked.</p>
+			<!-- single outer quote with dialect within, including immediately prior to punctuation -->
+			<p>“Middlin’, middlin’,” said Mr. Oakroyd, with the air of one determined to give nothing away.</p>
+			<!-- multiple dialog quotes, with closing quote dialect within -->
+			<p>“Ay, so I see,” returned her husband dryly. “I wish I’d been here. Ther seems to ha’ been a bit of a party like.”</p>
+			<!-- outer and inner dialog quotes, both with dialect -->
+			<p>Neither, it appeared, had Mrs. Buttershaw. “I seen ’im o’ Wednesday,” she said severely, “standing outside a picture place⁠—I think it were t’Plazzer⁠—and yer’d have thought ’e owned it. ‘That’s Mr. Oakroyd’s lad,’ I ses to Joe, but Joe didn’t know him. Joe knows nobody, and bin in a shop for thirty year! Nay, I nivver seen such a man. ‘Yer won’t know me next,’ I tell him. But when I showed ’im your lad, Joe ses, ‘Well, if that’s Jess Oakroyd’s lad, ’e’s nowt like his father. ’E looks a bit of a swankpot.’ ‘Nay, Joe,’ I ses, ‘yer know nowt about t’lad.’ But I knew what ’e meant. ’E doesn’t like to see these lads all toffed up, doesn’t Joe. Where’s your Leonard workin’ now? Is ’e still in t’ hair cutting?”</p>
+			<!-- more outer and inner dialog quotes with dialect -->
+			<p>“Winks. Just winks.” And Purton produced three of them too, very slow and solemn affairs, to show her how it was done, and then stared at her while she tried hard not to giggle. “Mr. Medworth, ’e says ‘Goin’ at ninety’ and then one of ’em winks, and Mr. Medworth says ‘Ninety-five’ and looks at another of ’em, gets a wink and ’as it up to a hundred. ‘And five’ says the chap with a beard, and then they starts winkin’ again, and then it’s winked right up to one ’undred and forty pounds. ’E’s done well, ’as that thar sideboard.”</p>
+			<!-- quotes on either side of an em-dash aside -->
+			<p>“Well, I wouldn’t say that because I’m never surprised, never,” Mr. Medworth said, very judicially. “But we’ve been lucky today, very lucky. Some keen men here, real competition. And”⁠—here he lowered his voice and hid his teeth⁠—“it was lucky you took my advice about the walnut pieces and left them in. Worth far more to these fellows than they are to you. All a fashion!”</p>
+			<!-- outer and inner dialog, on wrong side of punctuation, outer ending in an em-dash -->
+			<p>“Two pounds and tips galore!” cried Mrs. Oakroyd. “It’ll be four pound ten, sometimes five pound, ’e tells me, in a good week, wi’ regular customers coming in, wool men and travellers and suchlike. ‘Well,’ I tells him, ‘if it is, it’s better money than your poor father ever brought home, and you only fower-and-twenty.’ Nay, I were that surprised! When I seen ’im walk in wi’ Albert Tuggridge, middle o’ t’afternoon, you could ha’ knocked me down wi’ a feather⁠—”</p>
+			<!-- closing quote preceded by em-dash and followed by whitespace -->
+			<p>“They do say, Miss⁠—” Mrs. Purton began, and then stopped, holding, as it were the smoking bomb in her hand. Miss Trant smiled at her. “Well, what are they saying now? Don’t frighten me, Mrs. Purton.”</p>
+			<!-- em-dash aside consisting of quoted phrase -->
+			<p>There were few wedding presents. The boys had subscribed a shilling each and had bought at a shop in Llandudno a silver-plated teapot, coyly suggestive of <i>art nouveau</i>. The Doctor gave them a cheque for twenty-five pounds. Mr. Prendergast gave Grimes a walking stick⁠—“because he was always borrowing mine”⁠—and Dingy, rather generously, two photograph frames, a calendar, and a tray of Benares brassware. Paul was the best man.</p>
+			<!-- outer and inner quotes, reversed quote on dialect, quotes on either side of punctuation-->
+			<p>“Not this time. They couldn’t get a proper charge against me. ‘Six months for loitering with intent.’ They’d been watching me for weeks, but I wasn’t going to let them have a chance this time. Now six months is a very decent little sentence, if you take my meaning. One picks up with old friends, and you like it all the more when you comes out. I never minds six months. What’s more, I’m known here, so I always gets made ‘landing-cleaner.’ I expect you’ve seen my hand often enough coming round with the grub. The warders know me, see, so they always keeps the job open for me if they hears I’m coming back. If you’re nice to ’em the first two or three times you’re ’ere, they’ll probably do the same for you.”</p>
+			<!-- reverse quotes on decade -->
+			<p>The explanation of this rather striking contrast is simple enough. At the time of the cotton famine in the ’sixties Llanabba House was the property of a prosperous Lancashire millowner.</p>
+			<!-- a still-unformatted poem with numerous quotes -->
+			<p class="poem">“<i>O God, our help in ages past,</i>” sang Paul.<br/>
+			“<i>Where’s Prendergast today?</i>”<br/>
+			“<i>What, ain’t you ’eard? ’e’s been done in.</i>”<br/>
+			“<i>And our eternal home.</i>”<br/></p>
+			<p class="poem">“<i>Old Prendy went to see a chap<br/>
+			What said he’d seen a ghost;<br/>
+			Well, he was dippy, and he’d got<br/>
+			A mallet and a saw.</i>’<br/></p>
+			<p class="poem">“<i>Who let the madman have the things?</i>”<br/>
+			“<i>The Governor, who d’you think?<br/>
+			He asked to be a carpenter,<br/>
+			He sawed off Prendy’s head.</i><br/></p>
+			<p class="poem">“<i>A pal of mine what lives next door,<br/>
+			’E ’eard it “appening;<br/>
+			The warder must ’ave ’eard it too,<br/>
+			’E didn’t interfere.</i>’<br/></p>
+			<p class="poem">“<i>Time, like an ever-rolling stream,<br/>
+			Bears all its sons away.”<br/>
+			“Poor Prendy “ollered fit to kill<br/>
+			For nearly ’alf an hour.</i><br/></p>
+			<p class="poem">“<i>Damned lucky it was Prendergast,<br/>
+			Might ’ave been you or me!<br/>
+			The warder says⁠—and I agree⁠—<br/>
+			It serves the Governor right.</i>’<br/></p>
+			<p class="poem">“<i>Amen.</i>”<br/></p>
+			<!-- outer quote with reverse quoted dialect within -->
+			<p>“False pretences and impersonation, sir. There’s five charges against him in different parts of the country, mostly at hotels. He represents himself as a rich man, stays there for some time living like a lord, cashes a big cheque and then goes off. Calls ’isself Sir Solomon Philbrick. Funny thing is, I think he really believes his tale ’isself. I’ve come across several cases like that one time or another. There was a bloke in Somerset what thought ’e was Bishop of Bath and Wells and confirmed a whole lot of kids⁠—very reverent, too.”</p>
+			<!-- outer and inner with no ending outer ending quote and reversed dialect -->
+			<p>“ ‘Did you try pulling out ’is teeth and sending them to his pa?’ I asks.</p>
+			<!-- multiple quotes with multiple reverse quote dialects within -->
+			<p>“This ’ere’s your pal,” he said; “this ’ere’s the path you’ve got to walk on. Neither of you is to touch the other or any part of ’is clothing. Nothing is to be passed from one to the other. You are to keep at a distance of one yard and talk of ’istory, philosophy or kindred subjects. When I rings the bell you stops talking, see? Your pace is to be neither quicker nor slower than average walking-pace. Them’s the Governor’s instructions, and Gawd ’elp yer if yer does anything wrong. Now walk.”</p>
+			<!-- dialog quote with false positive reverse dialog within (the 'is' is real) -->
+			<p>“That,” said Dr. Fagan with some disgust, ’is my daughter.”</p>
 		</section>
 	</body>
 </html>

--- a/tests/draft_commands/british2american/test-1/in/b2a.xhtml
+++ b/tests/draft_commands/british2american/test-1/in/b2a.xhtml
@@ -8,7 +8,66 @@
 	<body epub:type="bodymatter z3998:fiction">
 		<section id="chapter-1" epub:type="chapter">
 			<h2 epub:type="title">A Dreary Story</h2>
-			<p>‘That “thing” sounds great,’ he said.</p>
+			<!-- single quoted society with no dialog -->
+			<p>Very few of them do stay to see the church, though the rector, the Rev. Thomas J. S. Chillingford, has not only written a short history of it but has also published this history as a pamphlet: Reprinted from the ‘Transactions of the Bristol and Gloucestershire Archaeological Society’; and any visitor who appreciates an extraordinarily fine rood-screen when he sees one (to say nothing of two possible leper-windows on the north side) cannot fail to obtain a copy of this pamphlet.</p>
+			<!-- simple quotes, but with two on wrong side of punctuation -->
+			<p>‘Na Jim!’ returned Mr. Oakroyd. This ‘Na’, which must once have been ‘Now’, is the recognized salutation in Bruddersford, and the fact that it sounds more like a word of caution than a word of greeting is by no means surprising. You have to be careful in Bruddersford.</p>
+			<!-- single dialog quote with numerous dialect within -->
+			<p>‘Ah thowt t’United’d ’a’ made rings rahnd ’em,’ Jim remarked.</p>
+			<!-- single outer quote with dialect within, including immediately prior to punctuation -->
+			<p>‘Middlin’, middlin’,’ said Mr. Oakroyd, with the air of one determined to give nothing away.</p>
+			<!-- multiple dialog quotes, with closing quote dialect within -->
+			<p>‘Ay, so I see,’ returned her husband dryly. ‘I wish I’d been here. Ther seems to ha’ been a bit of a party like.’</p>
+			<!-- outer and inner dialog quotes, both with dialect -->
+			<p>Neither, it appeared, had Mrs. Buttershaw. ‘I seen ’im o’ Wednesday,’ she said severely, ‘standing outside a picture place⁠—I think it were t’Plazzer⁠—and yer’d have thought ’e owned it. “That’s Mr. Oakroyd’s lad,” I ses to Joe, but Joe didn’t know him. Joe knows nobody, and bin in a shop for thirty year! Nay, I nivver seen such a man. “Yer won’t know me next,” I tell him. But when I showed ’im your lad, Joe ses, “Well, if that’s Jess Oakroyd’s lad, ’e’s nowt like his father. ’E looks a bit of a swankpot.” “Nay, Joe,” I ses, “yer know nowt about t’lad.” But I knew what ’e meant. ’E doesn’t like to see these lads all toffed up, doesn’t Joe. Where’s your Leonard workin’ now? Is ’e still in t’ hair cutting?’</p>
+			<!-- more outer and inner dialog quotes with dialect -->
+			<p>‘Winks. Just winks.’ And Purton produced three of them too, very slow and solemn affairs, to show her how it was done, and then stared at her while she tried hard not to giggle. ‘Mr. Medworth, ’e says “Goin’ at ninety” and then one of ’em winks, and Mr. Medworth says “Ninety-five” and looks at another of ’em, gets a wink and ’as it up to a hundred. “And five” says the chap with a beard, and then they starts winkin’ again, and then it’s winked right up to one ’undred and forty pounds. ’E’s done well, ’as that thar sideboard.’</p>
+			<!-- quotes on either side of an em-dash aside -->
+			<p>‘Well, I wouldn’t say that because I’m never surprised, never,’ Mr. Medworth said, very judicially. ‘But we’ve been lucky today, very lucky. Some keen men here, real competition. And’⁠—here he lowered his voice and hid his teeth⁠—‘it was lucky you took my advice about the walnut pieces and left them in. Worth far more to these fellows than they are to you. All a fashion!’</p>
+			<!-- outer and inner dialog, on wrong side of punctuation, outer ending in an em-dash -->
+			<p>‘Two pounds and tips galore!’ cried Mrs. Oakroyd. ‘It’ll be four pound ten, sometimes five pound, ’e tells me, in a good week, wi’ regular customers coming in, wool men and travellers and suchlike. “Well,” I tells him, “if it is, it’s better money than your poor father ever brought home, and you only fower-and-twenty”. Nay, I were that surprised! When I seen ’im walk in wi’ Albert Tuggridge, middle o’ t’afternoon, you could ha’ knocked me down wi’ a feather⁠—’</p>
+			<!-- closing quote preceded by em-dash and followed by whitespace -->
+			<p>‘They do say, Miss⁠—’ Mrs. Purton began, and then stopped, holding, as it were the smoking bomb in her hand. Miss Trant smiled at her. ‘Well, what are they saying now? Don’t frighten me, Mrs. Purton.’</p>
+			<!-- em-dash aside consisting of quoted phrase -->
+			<p>There were few wedding presents. The boys had subscribed a shilling each and had bought at a shop in Llandudno a silver-plated teapot, coyly suggestive of <i>art nouveau</i>. The Doctor gave them a cheque for twenty-five pounds. Mr. Prendergast gave Grimes a walking stick⁠—‘because he was always borrowing mine’⁠—and Dingy, rather generously, two photograph frames, a calendar, and a tray of Benares brassware. Paul was the best man.</p>
+			<!-- outer and inner quotes, reversed quote on dialect, quotes on either side of punctuation-->
+			<p>‘Not this time. They couldn’t get a proper charge against me. “Six months for loitering with intent.” They’d been watching me for weeks, but I wasn’t going to let them have a chance this time. Now six months is a very decent little sentence, if you take my meaning. One picks up with old friends, and you like it all the more when you comes out. I never minds six months. What’s more, I’m known here, so I always gets made “landing-cleaner”. I expect you’ve seen my hand often enough coming round with the grub. The warders know me, see, so they always keeps the job open for me if they hears I’m coming back. If you’re nice to ’em the first two or three times you’re ‘ere, they’ll probably do the same for you.’</p>
+			<!-- reverse quotes on decade -->
+			<p>The explanation of this rather striking contrast is simple enough. At the time of the cotton famine in the ‘sixties Llanabba House was the property of a prosperous Lancashire millowner.</p>
+			<!-- a still-unformatted poem with numerous quotes -->
+			<p class="poem">‘<i>O God, our help in ages past,</i>’ sang Paul.<br/>
+			‘<i>Where’s Prendergast today?</i>’<br/>
+			‘<i>What, ain’t you ‘eard? ’e’s been done in.</i>’<br/>
+			‘<i>And our eternal home.</i>’<br/></p>
+			<p class="poem">‘<i>Old Prendy went to see a chap<br/>
+			What said he’d seen a ghost;<br/>
+			Well, he was dippy, and he’d got<br/>
+			A mallet and a saw.</i>’<br/></p>
+			<p class="poem">‘<i>Who let the madman have the things?</i>’<br/>
+			‘<i>The Governor, who d’you think?<br/>
+			He asked to be a carpenter,<br/>
+			He sawed off Prendy’s head.</i><br/></p>
+			<p class="poem">‘<i>A pal of mine what lives next door,<br/>
+			’E ‘eard it ‘appening;<br/>
+			The warder must ’ave ‘eard it too,<br/>
+			’E didn’t interfere.</i>’<br/></p>
+			<p class="poem">‘<i>Time, like an ever-rolling stream,<br/>
+			Bears all its sons away.’<br/>
+			‘Poor Prendy ‘ollered fit to kill<br/>
+			For nearly ‘alf an hour.</i><br/></p>
+			<p class="poem">‘<i>Damned lucky it was Prendergast,<br/>
+			Might ’ave been you or me!<br/>
+			The warder says⁠—and I agree⁠—<br/>
+			It serves the Governor right.</i>’<br/></p>
+			<p class="poem">‘<i>Amen.</i>’<br/></p>
+			<!-- outer quote with reverse quoted dialect within -->
+			<p>‘False pretences and impersonation, sir. There’s five charges against him in different parts of the country, mostly at hotels. He represents himself as a rich man, stays there for some time living like a lord, cashes a big cheque and then goes off. Calls ‘isself Sir Solomon Philbrick. Funny thing is, I think he really believes his tale ‘isself. I’ve come across several cases like that one time or another. There was a bloke in Somerset what thought ’e was Bishop of Bath and Wells and confirmed a whole lot of kids⁠—very reverent, too.’</p>
+			<!-- outer and inner with no ending outer ending quote and reversed dialect -->
+			<p>‘ “Did you try pulling out ‘is teeth and sending them to his pa?” I asks.</p>
+			<!-- multiple quotes with multiple reverse quote dialects within -->
+			<p>‘This ‘ere’s your pal,’ he said; ‘this ‘ere’s the path you’ve got to walk on. Neither of you is to touch the other or any part of ‘is clothing. Nothing is to be passed from one to the other. You are to keep at a distance of one yard and talk of ‘istory, philosophy or kindred subjects. When I rings the bell you stops talking, see? Your pace is to be neither quicker nor slower than average walking-pace. Them’s the Governor’s instructions, and Gawd ‘elp yer if yer does anything wrong. Now walk.’</p>
+			<!-- dialog quote with false positive reverse dialog within (the 'is' is real) -->
+			<p>‘That,’ said Dr. Fagan with some disgust, ‘is my daughter.’</p>
 		</section>
 	</body>
 </html>


### PR DESCRIPTION
Here's the code and test. I assembled the test file from real paragraphs in _Decline and Fall_ and _Good Companions_. I also included at least one instance where b2a doesn't do the right thing, so we have an example if we figure out a way to improve it in the future.

I've attached a file that shows differences in processing the test file with the old command vs the new one. As previously, it includes color codes so should be viewed with `less -R`.

A couple of notes:
1. The existing tests for consecutive quotes was testing for a word-joiner and thin-space, rather than our currently used hairspace. I don't know if that's what we used to do or what, but I updated it to look for the hairspace (and made it optional, in case they hadn't run typogrify yet).
2. In the test for dialect with the wrong opening quote (open rather than closed), I included is and at, on the theory that, although they are real words, they're more likely to be dialect (‘is ‘at fell off) immediately after a quote rather than the real words. This will definitely cause some false positives (I included one in the test), so it's a matter of whether it's right more often than its wrong. If you feel like it's more likely that one or both will be "normally" used, then it's easy enough to remove those two words.
3. I added copious comments so it was clear what was happening at each step and why, and added an overall overview to the function comments.
[b2adiff.txt](https://github.com/user-attachments/files/18383667/b2adiff.txt)

