### PR TITLE
Add filepath to error when extracting non ebooks

### DIFF
--- a/se/commands/extract_ebook.py
+++ b/se/commands/extract_ebook.py
@@ -100,7 +100,7 @@ def extract_ebook(plain_output: bool) -> int:
 			with zipfile.ZipFile(target, "r") as file:
 				file.extractall(extracted_path)
 		else:
-			se.print_error("File doesn’t look like an epub, mobi, or azw3 file.")
+			se.print_error(f"File doesn’t look like an epub, mobi, or azw3: [path][link=file://{target}]{target}[/][/].", plain_output=plain_output)
 			return se.InvalidFileException.code
 
 		if args.verbose:


### PR DESCRIPTION
Ran into this when trying to bulk extract a bunch of `.epub`s which made it harder to track down the broken files.