### PR TITLE
Remove springtide(s) that was recently added.

### DIFF
--- a/se/data/words
+++ b/se/data/words
@@ -77100,8 +77100,6 @@ springlike
 springs
 springtail
 springtails
-springtide
-springtides
 springtime
 springy
 sprinkle


### PR DESCRIPTION
Merriam-Webster does have springtide (meaning springtime), but it also has spring tide (meaning tides at full/new moons), and all or almost all of the usages of spring-tide in the corpus is the latter. Thus, removing the dash automatically is the wrong thing to do.