### PR TITLE
Add a number of words to hyphenation word list

### DIFF
--- a/se/data/words
+++ b/se/data/words
@@ -7796,6 +7796,8 @@ bellow
 bellowed
 bellowing
 bellows
+bellpull
+bellpulls
 bells
 bellwether
 bellwethers
@@ -9105,6 +9107,7 @@ bloodlines
 bloodlust
 bloodmobile
 bloodmobiles
+bloodred
 bloodroot
 bloodroots
 bloods
@@ -12620,6 +12623,10 @@ carditis
 carditises
 cardoon
 cardoons
+cardplayer
+cardplayers
+cardroom
+cardrooms
 cards
 cardsharp
 cardsharper
@@ -14255,6 +14262,7 @@ cherries
 cherry
 cherrystone
 cherrystones
+cherrywood
 chert
 cherty
 cherub
@@ -31994,6 +32002,7 @@ firs
 first
 firstborn
 firstborns
+firstfruits
 firsthand
 firstly
 firsts
@@ -51161,6 +51170,8 @@ millerite
 millerites
 millers
 millet
+millhouse
+millhouses
 milliampere
 milliamperes
 milliard
@@ -58581,6 +58592,8 @@ pasteboard
 pasted
 pastel
 pastels
+pastepot
+pastepots
 pastern
 pasterns
 pastes
@@ -58622,6 +58635,8 @@ pastorships
 pastrami
 pastries
 pastry
+pastrycook
+pastrycooks
 pasts
 pasturage
 pasture
@@ -61155,6 +61170,8 @@ playable
 playact
 playacted
 playacting
+playactor
+playactors
 playacts
 playback
 playbacks
@@ -62247,6 +62264,8 @@ postbag
 postbags
 postbox
 postboxes
+postboy
+postboys
 postcard
 postcards
 postcode
@@ -62273,6 +62292,7 @@ postfixes
 postglacial
 postgraduate
 postgraduates
+posthaste
 posthole
 postholes
 posthumous
@@ -65705,6 +65725,7 @@ raglans
 ragout
 ragouts
 ragpicker
+ragpickers
 rags
 ragtag
 ragtags
@@ -70727,6 +70748,10 @@ sandpipers
 sandpit
 sandpits
 sands
+sansculotte
+sansculottish
+sansculottism
+sansculottes
 sandstone
 sandstones
 sandstorm
@@ -73541,6 +73566,8 @@ shopaholic
 shopaholics
 shopfront
 shopfronts
+shopgirl
+shopgirls
 shophar
 shophars
 shopkeeper
@@ -74082,6 +74109,7 @@ silkier
 silkiest
 silkily
 silkiness
+silklined
 silks
 silkscreen
 silkscreens
@@ -78530,6 +78558,8 @@ streams
 street
 streetcar
 streetcars
+streetlamp
+streetlamps
 streetlight
 streetlights
 streets
@@ -84127,6 +84157,8 @@ transvestites
 transvestitism
 transvestitisms
 trap
+trapdoor
+trapdoors
 trapes
 trapeze
 trapezes
@@ -89699,6 +89731,8 @@ wastefully
 wastefulness
 wasteland
 wastelands
+wastepaper
+wastepapers
 waster
 wasters
 wastes
@@ -91114,6 +91148,8 @@ worker
 workers
 workforce
 workforces
+workgirl
+workgirls
 workhorse
 workhorses
 workhouse


### PR DESCRIPTION
Since I've found quite a few recently (from reviews and/or my stuff), I went through all of the dashed words in the Balzac I'm working on right now, and checked them all. This is the result.

Cardroom, millhouse, pastepot, pastrycook, playactor, silklined, and workgirl are in unabridged. Streetlamp is redirected to streetlight, but in the definition it says "called also streetlamp." The rest are in the main dictionary.

Yes, I'll work on updating the corpus, but it's going to take a while. Maybe two whiles. :)

bellpull
bellpulls
bloodred
cardplayer
cardplayers
cardroom
cardrooms
cherrywood
firstfruits
millhouse
millhouses
pastepot
pastepots
pastrycook
pastrycooks
playactor
playactors
postboy
postboys
posthaste
ragpickers
sansculotte
sansculottish
sansculottism
sansculottes
shopgirl
shopgirls
silklined
streetlamp
streetlamps
trapdoor
trapdoors
wastepaper
wastepapers
workgirl
workgirls