### PR TITLE
m-081

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -249,6 +249,7 @@ METADATA
 "m-077", "MathML found in ebook, but no [attr]schema:accessibilityFeature[/] properties set to [val]MathML[/] and [val]describedMath[/] in metadata."
 "m-078", "MathML found in ebook, but no MathML accessibility [xml]<ProductFormFeatureValue>17</ProductFormFeatureValue>[/] set in ONIX data."
 "m-079", "Ebook looks like a collection, but no [xml]<meta property=\"se:is-a-collection\">true</meta>[/] element in metadata."
+"m-080", "DP link must be exactly [text]The Online Distributed Proofreaders Canada Team[/]."
 
 SEMANTICS & CONTENT
 "s-001", "Illegal numeric entity (like [xhtml]&#913;[/])."

--- a/tests/lint/metadata/m-081/golden/m-081-out.txt
+++ b/tests/lint/metadata/m-081/golden/m-081-out.txt
@@ -1,0 +1,5 @@
+m-081 [Error] colophon.xhtml When published between a range of years, the text 
+must be `published between year1 and year2`.
+        <p><i epub:type="se:name.publication.book">Unknown Novel</i><br/>
+        was published in 1810⁠–⁠1813 by<br/>
+        <a href="https://en.wikipedia.org/wiki/Jane_Austen">Jane Austen</a>.</p>

--- a/tests/lint/metadata/m-081/in/src/epub/text/colophon.xhtml
+++ b/tests/lint/metadata/m-081/in/src/epub/text/colophon.xhtml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-US">
+	<head>
+		<title>Colophon</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/se.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="backmatter">
+		<section id="colophon" epub:type="colophon">
+			<header>
+				<h2 epub:type="title">Colophon</h2>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+			</header>
+			<p><i epub:type="se:name.publication.book">Unknown Novel</i><br/>
+			was published in 1810⁠–⁠1813 by<br/>
+			<a href="https://en.wikipedia.org/wiki/Jane_Austen">Jane Austen</a>.</p>
+			<p>This ebook was produced for<br/>
+			<a href="https://standardebooks.org">Standard Ebooks</a><br/>
+			by<br/>
+			<b>An Anonymous Volunteer</b>,<br/>
+			and is based on a transcription produced in 2010 by<br/>
+			<b class="name">An Anonymous Volunteer</b><br/>
+			for<br/>
+			<a href="https://www.gutenberg.org/ebooks/161">Project Gutenberg</a><br/>
+			and is based on digital scans from the<br/>
+			<a href="https://archive.org/details/bub_gb_RtT0OLKFMHsC">Internet Archive</a>.</p>
+			<p>The cover page is adapted from<br/>
+			<i epub:type="se:name.visual-art.painting">At the Mirror</i>,<br/>
+			a painting completed in 1827 by<br/>
+			<a href="https://en.wikipedia.org/wiki/Georg_Friedrich_Kersting">Georg Friedrich Kersting</a>.<br/>
+			The cover and title pages feature the<br/>
+			<b epub:type="se:name.visual-art.typeface">League Spartan</b> and <b epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</b><br/>
+			typefaces created in 2014 and 2009 by<br/>
+			<a href="https://www.theleagueofmoveabletype.com">The League of Moveable Type</a>.</p>
+			<p>The first edition of this ebook was released on<br/>
+			<b>January 1, 1900, 12:00 <abbr class="eoc">a.m.</abbr></b><br/>
+			You can check for updates to this ebook, view its revision history, or download it for different ereading systems at<br/>
+			<a href="https://standardebooks.org/ebooks/jane-austen/unknown-novel">standardebooks.org/ebooks/jane-austen/unknown-novel</a>.</p>
+			<p>The volunteer-driven Standard Ebooks project relies on readers like you to submit typos, corrections, and other improvements. Anyone can contribute at <a href="https://standardebooks.org">standardebooks.org</a>.</p>
+		</section>
+	</body>
+</html>


### PR DESCRIPTION
The first commit adds m-080 to the list of messages at the top, which I forgot in the last PR. Sorry about that.

m-081 tests that when there's a year range for the published data in the colophon, it's worded as "published between X and Y." Most of ours are worded that way, but we also have a few "published between X–Y" and a few "published in X–Y."

The wording of the message is a bit awkward, but I couldn't think of anything better, and I knew you would. :) Let me know what you want it to say and I'll update the PR.