### PR TITLE
recompose-epub: Add --image-files flag. Fixes #827

### DIFF
--- a/se/commands/recompose_epub.py
+++ b/se/commands/recompose_epub.py
@@ -18,12 +18,13 @@ def recompose_epub(plain_output: bool) -> int:
 	parser.add_argument("-o", "--output", metavar="FILE", type=str, default="", help="a file to write output to instead of printing to standard output")
 	parser.add_argument("-x", "--xhtml", action="store_true", help="output XHTML instead of HTML5")
 	parser.add_argument("-e", "--extra-css-file", metavar="FILE", type=str, default=None, help="the path to an additional CSS file to include after any CSS files in the epub")
+	parser.add_argument("-i", "--image-files", action="store_true", help="leave image src attributes as relative URLs instead of inlining as data: URIs")
 	parser.add_argument("directory", metavar="DIRECTORY", help="a Standard Ebooks source directory")
 	args = parser.parse_args()
 
 	try:
 		se_epub = SeEpub(args.directory)
-		recomposed_epub = se_epub.recompose(args.xhtml, Path(args.extra_css_file) if args.extra_css_file else None)
+		recomposed_epub = se_epub.recompose(args.xhtml, Path(args.extra_css_file) if args.extra_css_file else None, args.image_files)
 
 		if args.output:
 			with open(args.output, "w", encoding="utf-8") as file:

--- a/se/completions/bash/se
+++ b/se/completions/bash/se
@@ -124,7 +124,7 @@ _se(){
 					COMPREPLY+=($(compgen -f -X ".*"))
 					return 0
 				fi
-				COMPREPLY+=($(compgen -W "-h --help -o= --output= -x --xhtml -e --extra-css-file" -- "${cur}"))
+				COMPREPLY+=($(compgen -W "-h --help -o= --output= -x --xhtml -e --extra-css-file -i --image-files" -- "${cur}"))
 				COMPREPLY+=($(compgen -d -X ".*" -- "${cur}"))
 				;;
 			renumber-endnotes)

--- a/se/completions/fish/se.fish
+++ b/se/completions/fish/se.fish
@@ -141,6 +141,7 @@ complete -c se -A -n "__fish_seen_subcommand_from recompose-epub" -s h -l help -
 complete -c se -A -n "__fish_seen_subcommand_from recompose-epub" -s o -l output -d "a file to write output to instead of printing to standard output"
 complete -c se -A -n "__fish_seen_subcommand_from recompose-epub" -s x -l xhtml -d "output XHTML instead of HTML5"
 complete -c se -A -n "__fish_seen_subcommand_from recompose-epub" -s e -l extra-css-file -d "the path to an additional CSS file to include after any CSS files in the epub"
+complete -c se -A -n "__fish_seen_subcommand_from recompose-epub" -s i -l image-files -d "leave image src attributes as relative URLs instead of inlining as data: URIs"
 
 complete -c se -n "__fish_se_no_subcommand" -a renumber-endnotes -d "Renumber all endnotes and noterefs sequentially from the beginning, taking care to match noterefs and endnotes if possible."
 complete -c se -A -n "__fish_seen_subcommand_from renumber-endnotes" -s h -l help -x -d "show this help message and exit"

--- a/se/completions/zsh/_se
+++ b/se/completions/zsh/_se
@@ -229,7 +229,8 @@ case $state in
 					{-o,--output}'=[a file to write output to instead of printing to standard output]: :_files' \
 					'*: :_files -g \*.xhtml' \
 					{-x,--xhtml}'[output XHTML instead of HTML5]' \
-					{-e,--extra-css-file}'=[the path to an additional CSS file to include after any CSS files in the epub]: :_files'
+					{-e,--extra-css-file}'=[the path to an additional CSS file to include after any CSS files in the epub]: :_files' \
+					{-i,--image-files}'[leave image src attributes as relative URLs instead of inlining as data: URIs]'
 				;;
 			renumber-endnotes)
 				_arguments -s \


### PR DESCRIPTION
See #827 for motivation and context.

After running with the new `--image-files` (`-i`) flag, all I had to do was replace `src="../images` with `src="./images` and zip up the HTML output plus the `images` folder to build this Gutenberg-compatible version: https://ebookmaker.pglaf.org/cache/20250511164828/ (link expires in 3 days).