### PR TITLE
Update kindleunpack vendor code

### DIFF
--- a/se/vendor/kindleunpack/imghdr.py
+++ b/se/vendor/kindleunpack/imghdr.py
@@ -1,0 +1,225 @@
+"""Recognize image file formats based on their first few bytes."""
+
+# Python software and documentation are licensed under the
+# Python Software Foundation License Version 2.
+
+# Starting with Python 3.8.6, examples, recipes, and other code in
+# the documentation are dual licensed under the PSF License Version 2
+# and the Zero-Clause BSD license.
+
+# Some software incorporated into Python is under different licenses.
+# The licenses are listed with code falling under that license.
+
+# PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+# --------------------------------------------
+
+# 1. This LICENSE AGREEMENT is between the Python Software Foundation
+# ("PSF"), and the Individual or Organization ("Licensee") accessing and
+# otherwise using this software ("Python") in source or binary form and
+# its associated documentation.
+
+# 2. Subject to the terms and conditions of this License Agreement, PSF hereby
+# grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+# analyze, test, perform and/or display publicly, prepare derivative works,
+# distribute, and otherwise use Python alone or in any derivative version,
+# provided, however, that PSF's License Agreement and PSF's notice of copyright,
+# i.e., "Copyright (c) 2001 Python Software Foundation; All Rights Reserved"
+# are retained in Python alone or in any derivative version prepared by Licensee.
+
+# 3. In the event Licensee prepares a derivative work that is based on
+# or incorporates Python or any part thereof, and wants to make
+# the derivative work available to others as provided herein, then
+# Licensee hereby agrees to include in any such work a brief summary of
+# the changes made to Python.
+
+# 4. PSF is making Python available to Licensee on an "AS IS"
+# basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+# IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+# DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+# FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+# INFRINGE ANY THIRD PARTY RIGHTS.
+
+# 5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+# FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+# A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+# OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+# 6. This License Agreement will automatically terminate upon a material
+# breach of its terms and conditions.
+
+# 7. Nothing in this License Agreement shall be deemed to create any
+# relationship of agency, partnership, or joint venture between PSF and
+# Licensee.  This License Agreement does not grant permission to use PSF
+# trademarks or trade name in a trademark sense to endorse or promote
+# products or services of Licensee, or any third party.
+
+# 8. By copying, installing or otherwise using Python, Licensee
+# agrees to be bound by the terms and conditions of this License
+# Agreement.
+
+from os import PathLike
+
+__all__ = ["what"]
+
+#-------------------------#
+# Recognize image headers #
+#-------------------------#
+
+def what(file, h=None):
+    f = None
+    try:
+        if h is None:
+            if isinstance(file, (str, PathLike)):
+                f = open(file, 'rb')
+                h = f.read(32)
+            else:
+                location = file.tell()
+                h = file.read(32)
+                file.seek(location)
+        for tf in tests:
+            res = tf(h, f)
+            if res:
+                return res
+    finally:
+        if f: f.close()
+    return None
+
+
+#---------------------------------#
+# Subroutines per image file type #
+#---------------------------------#
+
+tests = []
+
+def test_jpeg(h, f):
+    """JPEG data in JFIF or Exif format"""
+    if h[6:10] in (b'JFIF', b'Exif'):
+        return 'jpeg'
+
+tests.append(test_jpeg)
+
+def test_png(h, f):
+    if h.startswith(b'\211PNG\r\n\032\n'):
+        return 'png'
+
+tests.append(test_png)
+
+def test_gif(h, f):
+    """GIF ('87 and '89 variants)"""
+    if h[:6] in (b'GIF87a', b'GIF89a'):
+        return 'gif'
+
+tests.append(test_gif)
+
+def test_tiff(h, f):
+    """TIFF (can be in Motorola or Intel byte order)"""
+    if h[:2] in (b'MM', b'II'):
+        return 'tiff'
+
+tests.append(test_tiff)
+
+def test_rgb(h, f):
+    """SGI image library"""
+    if h.startswith(b'\001\332'):
+        return 'rgb'
+
+tests.append(test_rgb)
+
+def test_pbm(h, f):
+    """PBM (portable bitmap)"""
+    if len(h) >= 3 and \
+        h[0] == ord(b'P') and h[1] in b'14' and h[2] in b' \t\n\r':
+        return 'pbm'
+
+tests.append(test_pbm)
+
+def test_pgm(h, f):
+    """PGM (portable graymap)"""
+    if len(h) >= 3 and \
+        h[0] == ord(b'P') and h[1] in b'25' and h[2] in b' \t\n\r':
+        return 'pgm'
+
+tests.append(test_pgm)
+
+def test_ppm(h, f):
+    """PPM (portable pixmap)"""
+    if len(h) >= 3 and \
+        h[0] == ord(b'P') and h[1] in b'36' and h[2] in b' \t\n\r':
+        return 'ppm'
+
+tests.append(test_ppm)
+
+def test_rast(h, f):
+    """Sun raster file"""
+    if h.startswith(b'\x59\xA6\x6A\x95'):
+        return 'rast'
+
+tests.append(test_rast)
+
+def test_xbm(h, f):
+    """X bitmap (X10 or X11)"""
+    if h.startswith(b'#define '):
+        return 'xbm'
+
+tests.append(test_xbm)
+
+def test_bmp(h, f):
+    if h.startswith(b'BM'):
+        return 'bmp'
+
+tests.append(test_bmp)
+
+def test_webp(h, f):
+    if h.startswith(b'RIFF') and h[8:12] == b'WEBP':
+        return 'webp'
+
+tests.append(test_webp)
+
+def test_exr(h, f):
+    if h.startswith(b'\x76\x2f\x31\x01'):
+        return 'exr'
+
+tests.append(test_exr)
+
+#--------------------#
+# Small test program #
+#--------------------#
+
+def test():
+    import sys
+    recursive = 0
+    if sys.argv[1:] and sys.argv[1] == '-r':
+        del sys.argv[1:2]
+        recursive = 1
+    try:
+        if sys.argv[1:]:
+            testall(sys.argv[1:], recursive, 1)
+        else:
+            testall(['.'], recursive, 1)
+    except KeyboardInterrupt:
+        sys.stderr.write('\n[Interrupted]\n')
+        sys.exit(1)
+
+def testall(list, recursive, toplevel):
+    import sys
+    import os
+    for filename in list:
+        if os.path.isdir(filename):
+            print(filename + '/:', end=' ')
+            if recursive or toplevel:
+                print('recursing down:')
+                import glob
+                names = glob.glob(os.path.join(glob.escape(filename), '*'))
+                testall(names, recursive, 0)
+            else:
+                print('*** directory (use -r) ***')
+        else:
+            print(filename + ':', end=' ')
+            sys.stdout.flush()
+            try:
+                print(what(filename))
+            except OSError:
+                print('*** not found ***')
+
+if __name__ == '__main__':
+    test()

--- a/se/vendor/kindleunpack/mobi_cover.py
+++ b/se/vendor/kindleunpack/mobi_cover.py
@@ -8,7 +8,7 @@ from .compatibility_utils import unicode_str
 
 from .unipath import pathof
 import os
-import imghdr
+from . import imghdr
 
 import struct
 # note:  struct pack, unpack, unpack_from all require bytestring format

--- a/se/vendor/kindleunpack/mobi_dict.py
+++ b/se/vendor/kindleunpack/mobi_dict.py
@@ -22,6 +22,12 @@ import struct
 from .mobi_index import getVariableWidthValue, readTagSection, getTagMap
 from .mobi_utils import toHex
 
+#python 3.9 dropped support for array tostring()
+def convert_to_bytes(ar):
+    if PY2:
+        return ar.tostring()
+    return ar.tobytes()
+
 DEBUG_DICT = False
 
 class InflectionData(object):
@@ -374,4 +380,4 @@ class dictSupport(object):
             else:
                 print("Error: Inflection rule mode %x is not implemented" % abyte)
                 return None
-        return utf8_str(byteArray.tostring())
+        return utf8_str(convert_to_bytes(byteArray))

--- a/se/vendor/kindleunpack/mobi_header.py
+++ b/se/vendor/kindleunpack/mobi_header.py
@@ -52,80 +52,115 @@ def dump_contexth(cpage, extheader):
     if extheader == b'':
         return
     id_map_strings = {
-        1 : 'Drm Server Id (1)',
-        2 : 'Drm Commerce Id (2)',
-        3 : 'Drm Ebookbase Book Id(3)',
-        100 : 'Creator_(100)',
-        101 : 'Publisher_(101)',
-        102 : 'Imprint_(102)',
-        103 : 'Description_(103)',
-        104 : 'ISBN_(104)',
-        105 : 'Subject_(105)',
-        106 : 'Published_(106)',
-        107 : 'Review_(107)',
-        108 : 'Contributor_(108)',
-        109 : 'Rights_(109)',
-        110 : 'SubjectCode_(110)',
-        111 : 'Type_(111)',
-        112 : 'Source_(112)',
-        113 : 'ASIN_(113)',
-        114 : 'versionNumber_(114)',
-        117 : 'Adult_(117)',
-        118 : 'Price_(118)',
-        119 : 'Currency_(119)',
-        122 : 'fixed-layout_(122)',
-        123 : 'book-type_(123)',
-        124 : 'orientation-lock_(124)',
-        126 : 'original-resolution_(126)',
-        127 : 'zero-gutter_(127)',
-        128 : 'zero-margin_(128)',
-        129 : 'K8_Masthead/Cover_Image_(129)',
-        132 : 'RegionMagnification_(132)',
-        200 : 'DictShortName_(200)',
-        501 : 'cdeType_(501)',
-        502 : 'last_update_time_(502)',
-        503 : 'Updated_Title_(503)',
-        504 : 'ASIN_(504)',
-        508 : 'Unknown_Title_Furigana?_(508)',
-        517 : 'Unknown_Creator_Furigana?_(517)',
-        522 : 'Unknown_Publisher_Furigana?_(522)',
-        524 : 'Language_(524)',
-        525 : 'primary-writing-mode_(525)',
-        526 : 'Unknown_(526)',
-        527 : 'page-progression-direction_(527)',
-        528 : 'override-kindle-fonts_(528)',
-        529 : 'kindlegen_Source-Target_(529)',
-        529 : 'Unknown_(529)',
-        534 : 'Input_Source_Type_(534)',
-        535 : 'Kindlegen_BuildRev_Number_(535)',
-        536 : 'Container_Info_(536)',  # CONT_Header is 0, Ends with CONTAINER_BOUNDARY (or Asset_Type?)
-        538 : 'Container_Resolution_(538)',
-        539 : 'Container_Mimetype_(539)',
-        542 : 'Unknown_but_changes_with_file_name_only_(542)',
-        543 : 'Container_id_(543)',  # FONT_CONTAINER, BW_CONTAINER, HD_CONTAINER
-        544 : 'Unknown_(544)',
+        1 : 'Drm Server Id',
+        2 : 'Drm Commerce Id',
+        3 : 'Drm Ebookbase Book Id',
+        4 : 'Drm Ebookbase Dep Id',
+        100 : 'Creator',
+        101 : 'Publisher',
+        102 : 'Imprint',
+        103 : 'Description',
+        104 : 'ISBN',
+        105 : 'Subject',
+        106 : 'Published',
+        107 : 'Review',
+        108 : 'Contributor',
+        109 : 'Rights',
+        110 : 'SubjectCode',
+        111 : 'Type',
+        112 : 'Source',
+        113 : 'ASIN',
+        # 114 : 'versionNumber',
+        117 : 'Adult',
+        118 : 'Retail-Price',
+        119 : 'Retail-Currency',
+        120 : 'TSC',
+        122 : 'fixed-layout',
+        123 : 'book-type',
+        124 : 'orientation-lock',
+        126 : 'original-resolution',
+        127 : 'zero-gutter',
+        128 : 'zero-margin',
+        129 : 'MetadataResourceURI',
+        132 : 'RegionMagnification',
+        150 : 'LendingEnabled',
+        200 : 'DictShortName',
+        501 : 'cdeType',
+        502 : 'last_update_time',
+        503 : 'Updated_Title',
+        504 : 'CDEContentKey',
+        505 : 'AmazonContentReference',
+        506 : 'Title-Language',
+        507 : 'Title-Display-Direction',
+        508 : 'Title-Pronunciation',
+        509 : 'Title-Collation',
+        510 : 'Secondary-Title',
+        511 : 'Secondary-Title-Language',
+        512 : 'Secondary-Title-Direction',
+        513 : 'Secondary-Title-Pronunciation',
+        514 : 'Secondary-Title-Collation',
+        515 : 'Author-Language',
+        516 : 'Author-Display-Direction',
+        517 : 'Author-Pronunciation',
+        518 : 'Author-Collation',
+        519 : 'Author-Type',
+        520 : 'Publisher-Language',
+        521 : 'Publisher-Display-Direction',
+        522 : 'Publisher-Pronunciation',
+        523 : 'Publisher-Collation',
+        524 : 'Content-Language-Tag',
+        525 : 'primary-writing-mode',
+        526 : 'NCX-Ingested-By-Software',
+        527 : 'page-progression-direction',
+        528 : 'override-kindle-fonts',
+        529 : 'Compression-Upgraded',
+        530 : 'Soft-Hyphens-In-Content',
+        531 : 'Dictionary_In_Langague',
+        532 : 'Dictionary_Out_Language',
+        533 : 'Font_Converted',
+        534 : 'Amazon_Creator_Info',
+        535 : 'Creator-Build-Tag',
+        536 : 'HD-Media-Containers-Info',  # CONT_Header is 0, Ends with CONTAINER_BOUNDARY (or Asset_Type?)
+        538 : 'Resource-Container-Fidelity',
+        539 : 'HD-Container-Mimetype',
+        540 : 'Sample-For_Special-Purpose',
+        541 : 'Kindletool-Operation-Information',
+        542 : 'Container_Id',
+        543 : 'Asset-Type',  # FONT_CONTAINER, BW_CONTAINER, HD_CONTAINER
+        544 : 'Unknown_544',
     }
     id_map_values = {
-        115 : 'sample_(115)',
-        116 : 'StartOffset_(116)',
-        121 : 'K8(121)_Boundary_Section_(121)',
-        125 : 'K8_Count_of_Resources_Fonts_Images_(125)',
-        131 : 'K8_Unidentified_Count_(131)',
-        201 : 'CoverOffset_(201)',
-        202 : 'ThumbOffset_(202)',
-        203 : 'Fake_Cover_(203)',
-        204 : 'Creator_Software_(204)',
-        205 : 'Creator_Major_Version_(205)',
-        206 : 'Creator_Minor_Version_(206)',
-        207 : 'Creator_Build_Number_(207)',
-        401 : 'Clipping_Limit_(401)',
-        402 : 'Publisher_Limit_(402)',
-        404 : 'Text_to_Speech_Disabled_(404)',
+        114 : 'versionNumber',
+        115 : 'sample',
+        116 : 'StartOffset',
+        121 : 'Mobi8-Boundary-Section',
+        125 : 'Embedded-Record-Count',
+        130 : 'Offline-Sample',
+        131 : 'Metadata-Record-Offset',
+        201 : 'CoverOffset',
+        202 : 'ThumbOffset',
+        203 : 'HasFakeCover',
+        204 : 'Creator-Software',
+        205 : 'Creator-Major-Version',
+        206 : 'Creator-Minor-Version',
+        207 : 'Creator-Build-Number',
+        401 : 'Clipping-Limit',
+        402 : 'Publisher-Limit',
+        404 : 'Text-to-Speech-Disabled',
+        406 : 'Rental-Expiration-Time',
     }
     id_map_hexstrings = {
-        208 : 'Watermark_(208_in_hex)',
-        209 : 'Tamper_Proof_Keys_(209_in_hex)',
-        300 : 'Font_Signature_(300_in_hex)',
+        208 : 'Watermark_(hex)',
+        209 : 'Tamper-Proof-Keys_(hex)',
+        300 : 'Font-Signature_(hex)',
+        403 : 'Unknown_(403)_(hex)',
+        405 : 'Ownership-Type_(hex)',
+        407 : 'Unknown_(407)_(hex)',
+        420 : 'Multimedia-Content-Reference_(hex)',
+        450 : 'Locations_Match_(hex)',
+        451 : 'Full-Story-Length_(hex)',
+        452 : 'Sample-Start_Location_(hex)',
+        453 : 'Sample-End-Location_(hex)',
     }
     _length, num_items = struct.unpack(b'>LL', extheader[4:12])
     extheader = extheader[12:]
@@ -135,7 +170,7 @@ def dump_contexth(cpage, extheader):
         content = extheader[pos + 8: pos + size]
         if id in id_map_strings:
             name = id_map_strings[id]
-            print('\n    Key: "%s"\n        Value: "%s"' % (name, content.decode(codec)))
+            print('\n    Key: "%s"\n        Value: "%s"' % (name, content.decode(codec, errors='replace')))
         elif id in id_map_values:
             name = id_map_values[id]
             if size == 9:
@@ -354,6 +389,7 @@ class MobiHeader:
         1 : 'Drm Server Id',
         2 : 'Drm Commerce Id',
         3 : 'Drm Ebookbase Book Id',
+        4 : 'Drm Ebookbase Dep Id',
         100 : 'Creator',
         101 : 'Publisher',
         102 : 'Imprint',
@@ -368,71 +404,97 @@ class MobiHeader:
         111 : 'Type',
         112 : 'Source',
         113 : 'ASIN',
-        114 : 'versionNumber',
+        # 114 : 'versionNumber',
         117 : 'Adult',
-        118 : 'Price',
-        119 : 'Currency',
+        118 : 'Retail-Price',
+        119 : 'Retail-Currency',
+        120 : 'TSC',
         122 : 'fixed-layout',
         123 : 'book-type',
         124 : 'orientation-lock',
         126 : 'original-resolution',
         127 : 'zero-gutter',
         128 : 'zero-margin',
-        129 : 'K8(129)_Masthead/Cover_Image',
+        129 : 'MetadataResourceURI',
         132 : 'RegionMagnification',
+        150 : 'LendingEnabled',
         200 : 'DictShortName',
         501 : 'cdeType',
         502 : 'last_update_time',
         503 : 'Updated_Title',
-        504 : 'ASIN_504',
-        508 : 'Unknown_508',
-        517 : 'Unknown_517',
-        522 : 'Unknown_522',
-        524 : 'Language_524',
+        504 : 'CDEContentKey',
+        505 : 'AmazonContentReference',
+        506 : 'Title-Language',
+        507 : 'Title-Display-Direction',
+        508 : 'Title-Pronunciation',
+        509 : 'Title-Collation',
+        510 : 'Secondary-Title',
+        511 : 'Secondary-Title-Language',
+        512 : 'Secondary-Title-Direction',
+        513 : 'Secondary-Title-Pronunciation',
+        514 : 'Secondary-Title-Collation',
+        515 : 'Author-Language',
+        516 : 'Author-Display-Direction',
+        517 : 'Author-Pronunciation',
+        518 : 'Author-Collation',
+        519 : 'Author-Type',
+        520 : 'Publisher-Language',
+        521 : 'Publisher-Display-Direction',
+        522 : 'Publisher-Pronunciation',
+        523 : 'Publisher-Collation',
+        524 : 'Content-Language-Tag',
         525 : 'primary-writing-mode',
+        526 : 'NCX-Ingested-By-Software',
         527 : 'page-progression-direction',
         528 : 'override-kindle-fonts',
-        529 : 'kindlegen_Source-Target',
-        534 : 'kindlegen_Input_Source_Type',
-        535 : 'kindlegen_BuildRev_Number',
-        536 : 'Container_Info',  # CONT_Header is 0, Ends with CONTAINER_BOUNDARY (or Asset_Type?)
-        538 : 'Container_Resolution',
-        539 : 'Container_Mimetype',
-        542 : 'Unknown_but_changes_with_file_name_only_542',
-        543 : 'Container_id',  # FONT_CONTAINER, BW_CONTAINER, HD_CONTAINER
+        529 : 'Compression-Upgraded',
+        530 : 'Soft-Hyphens-In-Content',
+        531 : 'Dictionary_In_Langague',
+        532 : 'Dictionary_Out_Language',
+        533 : 'Font_Converted',
+        534 : 'Amazon_Creator_Info',
+        535 : 'Creator-Build-Tag',
+        536 : 'HD-Media-Containers-Info',  # CONT_Header is 0, Ends with CONTAINER_BOUNDARY (or Asset_Type?)
+        538 : 'Resource-Container-Fidelity',
+        539 : 'HD-Container-Mimetype',
+        540 : 'Sample-For_Special-Purpose',
+        541 : 'Kindletool-Operation-Information',
+        542 : 'Container_Id',
+        543 : 'Asset-Type',  # FONT_CONTAINER, BW_CONTAINER, HD_CONTAINER
         544 : 'Unknown_544',
-
     }
     id_map_values = {
+        114 : 'versionNumber',
         115 : 'sample',
         116 : 'StartOffset',
-        121 : 'K8(121)_Boundary_Section',
-        125 : 'K8(125)_Count_of_Resources_Fonts_Images',
-        131 : 'K8(131)_Unidentified_Count',
+        121 : 'Mobi8-Boundary-Section',
+        125 : 'Embedded-Record-Count',
+        130 : 'Offline-Sample',
+        131 : 'Metadata-Record-Offset',
         201 : 'CoverOffset',
         202 : 'ThumbOffset',
-        203 : 'Has Fake Cover',
-        204 : 'Creator Software',
-        205 : 'Creator Major Version',
-        206 : 'Creator Minor Version',
-        207 : 'Creator Build Number',
-        401 : 'Clipping Limit',
-        402 : 'Publisher Limit',
-        404 : 'Text to Speech Disabled',
-        406 : 'Rental_Indicator',
+        203 : 'HasFakeCover',
+        204 : 'Creator-Software',
+        205 : 'Creator-Major-Version',
+        206 : 'Creator-Minor-Version',
+        207 : 'Creator-Build-Number',
+        401 : 'Clipping-Limit',
+        402 : 'Publisher-Limit',
+        404 : 'Text-to-Speech-Disabled',
+        406 : 'Rental-Expiration-Time',
     }
     id_map_hexstrings = {
-        208 : 'Watermark (hex)',
-        209 : 'Tamper Proof Keys (hex)',
-        300 : 'Font Signature (hex)',
-        403 : 'Unknown_(403) (hex)',
-        405 : 'Unknown_(405) (hex)',
-        407 : 'Unknown_(407) (hex)',
-        450 : 'Unknown_(450) (hex)',
-        451 : 'Unknown_(451) (hex)',
-        452 : 'Unknown_(452) (hex)',
-        453 : 'Unknown_(453) (hex)',
-
+        208 : 'Watermark_(hex)',
+        209 : 'Tamper-Proof-Keys_(hex)',
+        300 : 'Font-Signature_(hex)',
+        403 : 'Unknown_(403)_(hex)',
+        405 : 'Ownership-Type_(hex)',
+        407 : 'Unknown_(407)_(hex)',
+        420 : 'Multimedia-Content-Reference_(hex)',
+        450 : 'Locations_Match_(hex)',
+        451 : 'Full-Story-Length_(hex)',
+        452 : 'Sample-Start_Location_(hex)',
+        453 : 'Sample-End-Location_(hex)',
     }
 
     def __init__(self, sect, sectNumber):
@@ -451,7 +513,7 @@ class MobiHeader:
         self.records, = struct.unpack_from(b'>H', self.header, 0x8)
 
         # set defaults in case this is a PalmDOC
-        self.title = self.sect.palmname.decode('latin-1')
+        self.title = self.sect.palmname.decode('latin-1', errors='replace')
         self.length = len(self.header)-16
         self.type = 3
         self.codepage = 1252
@@ -509,7 +571,7 @@ class MobiHeader:
         # title
         toff, tlen = struct.unpack(b'>II', self.header[0x54:0x5c])
         tend = toff + tlen
-        self.title=self.header[toff:tend].decode(self.codec)
+        self.title=self.header[toff:tend].decode(self.codec, errors='replace')
 
         exth_flag, = struct.unpack(b'>L', self.header[0x80:0x84])
         self.hasExth = exth_flag & 0x40
@@ -601,14 +663,14 @@ class MobiHeader:
             return
         num_items, = struct.unpack(b'>L', self.exth[8:12])
         pos = 12
-        print("Key Size Decription                     Value")
+        print("Key Size Description                    Value")
         for _ in range(num_items):
             id, size = struct.unpack(b'>LL', self.exth[pos:pos+8])
             contentsize = size-8
             content = self.exth[pos + 8: pos + size]
             if id in MobiHeader.id_map_strings:
                 exth_name = MobiHeader.id_map_strings[id]
-                print('{0: >3d} {1: >4d} {2: <30s} {3:s}'.format(id, contentsize, exth_name, content.decode(codec)))
+                print('{0: >3d} {1: >4d} {2: <30s} {3:s}'.format(id, contentsize, exth_name, content.decode(codec, errors='replace')))
             elif id in MobiHeader.id_map_values:
                 exth_name = MobiHeader.id_map_values[id]
                 if size == 9:
@@ -664,9 +726,9 @@ class MobiHeader:
         if title_offset == 0:
             title_offset = len(self.header)
             title_length = 0
-            self.title = self.sect.palmname.decode('latin-1')
+            self.title = self.sect.palmname.decode('latin-1', errors='replace')
         else:
-            self.title = self.header[title_offset:title_offset+title_length].decode(self.codec)
+            self.title = self.header[title_offset:title_offset+title_length].decode(self.codec, errors='replace')
             # title record always padded with two nul bytes and then padded with nuls to next 4 byte boundary
             title_length = ((title_length+2+3)>>2)<<2
 
@@ -815,7 +877,7 @@ class MobiHeader:
                 content = extheader[pos + 8: pos + size]
                 if id in MobiHeader.id_map_strings:
                     name = MobiHeader.id_map_strings[id]
-                    addValue(name, content.decode(codec))
+                    addValue(name, content.decode(codec, errors='replace'))
                 elif id in MobiHeader.id_map_values:
                     name = MobiHeader.id_map_values[id]
                     if size == 9:

--- a/se/vendor/kindleunpack/mobi_html.py
+++ b/se/vendor/kindleunpack/mobi_html.py
@@ -109,9 +109,10 @@ class HTMLProcessor:
 
 class XHTMLK8Processor:
 
-    def __init__(self, rscnames, k8proc):
+    def __init__(self, rscnames, k8proc, viewport=None):
         self.rscnames = rscnames
         self.k8proc = k8proc
+        self.viewport = viewport
         self.used = {}
 
     def buildXHTML(self):
@@ -213,6 +214,7 @@ class XHTMLK8Processor:
         url_img_index_pattern = re.compile(br'''[('"]kindle:embed:([0-9|A-V]+)\?mime=image/[^\)]*["')]''', re.IGNORECASE)
         font_index_pattern = re.compile(br'''[('"]kindle:embed:([0-9|A-V]+)["')]''', re.IGNORECASE)
         url_css_index_pattern = re.compile(br'''kindle:flow:([0-9|A-V]+)\?mime=text/css[^\)]*''', re.IGNORECASE)
+        url_svg_image_pattern = re.compile(br'''kindle:flow:([0-9|A-V]+)\?mime=image/svg\+xml[^\)]*''', re.IGNORECASE)
 
         for i in range(1, self.k8proc.getNumberOfFlows()):
             [ftype, format, dir, filename] = self.k8proc.getFlowInfo(i)
@@ -273,6 +275,14 @@ class XHTMLK8Processor:
                     [typ, fmt, pdir, fnm] = self.k8proc.getFlowInfo(num)
                     replacement = b'"../' + utf8_str(pdir) + b'/' + utf8_str(fnm) + b'"'
                     tag = url_css_index_pattern.sub(replacement, tag, 1)
+                    self.used[fnm] = 'used'
+
+                # process links to svg images
+                for m in url_svg_image_pattern.finditer(tag):
+                    num = fromBase32(m.group(1))
+                    [typ, fmt, pdir, fnm] = self.k8proc.getFlowInfo(num)
+                    replacement = b'"../' + utf8_str(pdir) + b'/' + utf8_str(fnm) + b'"'
+                    tag = url_svg_image_pattern.sub(replacement, tag, 1)
                     self.used[fnm] = 'used'
 
                 srcpieces[j] = tag
@@ -423,6 +433,19 @@ class XHTMLK8Processor:
             part = b"".join(srcpieces)
             # store away modified version
             parts[i] = part
+
+        # handle injection viewport meta data if needed in each xhtml file
+        if self.viewport:
+            injected_meta = b'<meta name="viewport" content="' + utf8_str(self.viewport) + b'"/>\n'
+            viewport_pattern = re.compile(br'''<meta\s[^>]*name\s*=\s*["'][^"'>]*viewport["'][^>]*>''', re.IGNORECASE)
+            for i in range(len(parts)):
+                part = parts[i]
+                # only inject if a viewport meta item does not already exist in that part
+                if not viewport_pattern.search(part):
+                    endheadpos = part.find(b'</head>')
+                    if endheadpos >= 0:
+                        part = part[0:endheadpos] + injected_meta + part[endheadpos:]
+                parts[i] = part
 
         self.k8proc.setFlows(flows)
         self.k8proc.setParts(parts)

--- a/se/vendor/kindleunpack/mobi_k8proc.py
+++ b/se/vendor/kindleunpack/mobi_k8proc.py
@@ -180,9 +180,11 @@ class K8Processor:
         fragptr = 0
         baseptr = 0
         cnt = 0
+        filename = 'part%04d.xhtml' % cnt
         for [skelnum, skelname, fragcnt, skelpos, skellen] in self.skeltbl:
             baseptr = skelpos + skellen
             skeleton = text[skelpos: baseptr]
+            aidtext = "0"
             for i in range(fragcnt):
                 [insertpos, idtext, filenum, seqnum, startpos, length] = self.fragtbl[fragptr]
                 aidtext = idtext[12:-2]

--- a/se/vendor/kindleunpack/mobi_k8resc.py
+++ b/se/vendor/kindleunpack/mobi_k8resc.py
@@ -60,7 +60,10 @@ class K8RESCProcessor(object):
         if self.resc_length != resc_size:
             print("Warning: RESC section length({:d}bytes) does not match its size({:d}bytes).".format(self.resc_length, resc_size))
         # now parse RESC after converting it to unicode from utf-8
-        self.resc = unicode_str(data[start_pos:start_pos+self.resc_length])
+        try:
+            self.resc = unicode_str(data[start_pos:start_pos+self.resc_length])
+        except UnicodeDecodeError:
+            self.resc = unicode_str(data[start_pos:start_pos+self.resc_length], enc='latin-1')
         self.parseData()
 
     def prepend_to_spine(self, key, idref, linear, properties):

--- a/se/vendor/kindleunpack/mobi_nav.py
+++ b/se/vendor/kindleunpack/mobi_nav.py
@@ -156,11 +156,13 @@ class NAVProcessor(object):
         nav_header = ''
         nav_header += '<?xml version="1.0" encoding="utf-8"?>\n<!DOCTYPE html>'
         nav_header += '<html xmlns="http://www.w3.org/1999/xhtml"'
-        nav_header += ' xmlns:epub="http://www.idpf.org/2011/epub"'
+        nav_header += ' xmlns:epub="http://www.idpf.org/2007/ops"'
         nav_header += ' lang="{0:s}" xml:lang="{0:s}">\n'.format(lang)
         nav_header += '<head>\n<title>{:s}</title>\n'.format(title)
+        nav_header += '<meta charset="UTF-8" />\n'
         nav_header += '<style type="text/css">\n'
         nav_header += 'nav#landmarks { display:none; }\n'
+        nav_header += 'ol { list-style-type: none; }'
         nav_header += '</style>\n</head>\n<body>\n'
         nav_footer = '</body>\n</html>\n'
 

--- a/se/vendor/kindleunpack/mobi_ncx.py
+++ b/se/vendor/kindleunpack/mobi_ncx.py
@@ -6,11 +6,14 @@ from __future__ import unicode_literals, division, absolute_import, print_functi
 
 import os
 from .unipath import pathof
+from .compatibility_utils import unescapeit
 
 
 import re
 # note: re requites the pattern to be the exact same type as the data to be searched in python3
 # but u"" is not allowed for the pattern itself only b""
+
+from xml.sax.saxutils import escape as xmlescape
 
 from .mobi_utils import toBase32
 from .mobi_index import MobiIndex
@@ -73,11 +76,11 @@ class ncxExtract:
                             fieldvalue = 'kindle:pos:fid:%s:off:%s' % (pos_fid, pos_off)
                         tmp[fieldname] = fieldvalue
                         if tag == 3:
-                            toctext = ctoc_text.get(fieldvalue, 'Unknown Text')
+                            toctext = ctoc_text.get(fieldvalue, b'Unknown Text')
                             toctext = toctext.decode(self.mh.codec)
                             tmp['text'] = toctext
                         if tag == 5:
-                            kindtext = ctoc_text.get(fieldvalue, 'Unknown Kind')
+                            kindtext = ctoc_text.get(fieldvalue, b'Unknown Kind')
                             kindtext = kindtext.decode(self.mh.codec)
                             tmp['kind'] = kindtext
                 indx_data.append(tmp)
@@ -151,7 +154,7 @@ class ncxExtract:
                 num += 1
                 link = '%s#filepos%d' % (htmlfile, e['pos'])
                 tagid = 'np_%d' % num
-                entry = ncx_entry % (tagid, num, e['text'], link)
+                entry = ncx_entry % (tagid, num, xmlescape(unescapeit(e['text'])), link)
                 entry = re.sub(re.compile('^', re.M), indent, entry, 0)
                 xml += entry + '\n'
                 # recurs
@@ -164,7 +167,7 @@ class ncxExtract:
             return xml, max_lvl, num
 
         body, max_lvl, num = recursINDX()
-        header = ncx_header % (lang, ident, max_lvl + 1, title)
+        header = ncx_header % (lang, ident, max_lvl + 1, xmlescape(unescapeit(title)))
         ncx =  header + body + ncx_footer
         if not len(indx_data) == num:
             print("Warning: different number of entries in NCX", len(indx_data), num)
@@ -242,7 +245,7 @@ class ncxExtract:
                 else:
                     link = 'Text/%s#%s' % (htmlfile, desttag)
                 tagid = 'np_%d' % num
-                entry = ncx_entry % (tagid, num, e['text'], link)
+                entry = ncx_entry % (tagid, num, xmlescape(unescapeit(e['text'])), link)
                 entry = re.sub(re.compile('^', re.M), indent, entry, 0)
                 xml += entry + '\n'
                 # recurs
@@ -255,7 +258,7 @@ class ncxExtract:
             return xml, max_lvl, num
 
         body, max_lvl, num = recursINDX()
-        header = ncx_header % (lang, ident, max_lvl + 1, title)
+        header = ncx_header % (lang, ident, max_lvl + 1, xmlescape(unescapeit(title)))
         ncx =  header + body + ncx_footer
         if not len(indx_data) == num:
             print("Warning: different number of entries in NCX", len(indx_data), num)

--- a/se/vendor/kindleunpack/mobi_utils.py
+++ b/se/vendor/kindleunpack/mobi_utils.py
@@ -38,8 +38,8 @@ def getLanguage(langID, sublangID):
             26 : {0 : 'hr', 3 : 'sr'},  # Croatian, Serbian
              5 : {0 : 'cs'},  # Czech
              6 : {0 : 'da'},  # Danish
-            19 : {1 : 'nl' , 2 : 'nl-be'},  # Dutch / Flemish,  Dutch (Belgium)
-             9 : {1 : 'en' , 3 : 'en-au' , 40 : 'en-bz' , 4 : 'en-ca' , 6 : 'en-ie' , 8 : 'en-jm' , 5 : 'en-nz' , 13 : 'en-ph' ,
+            19 : {0: 'nl', 1 : 'nl' , 2 : 'nl-be'},  # Dutch / Flemish,  Dutch (Belgium)
+             9 : {0: 'en', 1 : 'en' , 3 : 'en-au' , 10 : 'en-bz' , 4 : 'en-ca' , 6 : 'en-ie' , 8 : 'en-jm' , 5 : 'en-nz' , 13 : 'en-ph' ,
                   7 : 'en-za' , 11 : 'en-tt' , 2 : 'en-gb', 1 : 'en-us' , 12 : 'en-zw'},
              # English,  English (Australia),  English (Belize),  English (Canada),
              # English (Ireland),  English (Jamaica),  English (New Zealand),  English
@@ -49,10 +49,10 @@ def getLanguage(langID, sublangID):
             56 : {0 : 'fo'},  # Faroese
             41 : {0 : 'fa'},  # Farsi / Persian
             11 : {0 : 'fi'},  # Finnish
-            12 : {1 : 'fr' , 2 : 'fr-be' , 3 : 'fr-ca' , 5 : 'fr-lu' , 6 : 'fr-mc' , 4 : 'fr-ch'},
+            12 : {0 : 'fr', 1 : 'fr' , 2 : 'fr-be' , 3 : 'fr-ca' , 5 : 'fr-lu' , 6 : 'fr-mc' , 4 : 'fr-ch'},
             # French,  French (Belgium),  French (Canada),  French (Luxembourg),  French (Monaco),  French (Switzerland)
             55 : {0 : 'ka'},  # Georgian
-             7 : {1 : 'de' , 3 : 'de-at' , 5 : 'de-li' , 4 : 'de-lu' , 2 : 'de-ch'},
+             7 : {0 : 'de', 1 : 'de' , 3 : 'de-at' , 5 : 'de-li' , 4 : 'de-lu' , 2 : 'de-ch'},
              # German,  German (Austria),  German (Liechtenstein),  German (Luxembourg),  German (Switzerland)
              8 : {0 : 'el'},  # Greek, Modern (1453-)
             71 : {0 : 'gu'},  # Gujarati
@@ -61,7 +61,7 @@ def getLanguage(langID, sublangID):
             14 : {0 : 'hu'},  # Hungarian
             15 : {0 : 'is'},  # Icelandic
             33 : {0 : 'id'},  # Indonesian
-            16 : {1 : 'it' , 2 : 'it-ch'},  # Italian,  Italian (Switzerland)
+            16 : {0 : 'it', 1 : 'it' , 2 : 'it-ch'},  # Italian,  Italian (Switzerland)
             17 : {0 : 'ja'},  # Japanese
             75 : {0 : 'kn'},  # Kannada
             63 : {0 : 'kk'},  # Kazakh
@@ -78,7 +78,7 @@ def getLanguage(langID, sublangID):
             20 : {0 : 'no'},  # Norwegian
             72 : {0 : 'or'},  # Oriya
             21 : {0 : 'pl'},  # Polish
-            22 : {2 : 'pt' , 1 : 'pt-br'},  # Portuguese,  Portuguese (Brazil)
+            22 : {0 : 'pt', 2 : 'pt' , 1 : 'pt-br'},  # Portuguese,  Portuguese (Brazil)
             70 : {0 : 'pa'},  # Punjabi
             23 : {0 : 'rm'},  # "Rhaeto-Romanic" (IANA: Romansh)
             24 : {0 : 'ro'},  # Romanian
@@ -94,9 +94,9 @@ def getLanguage(langID, sublangID):
             # Lower Sorbian = 'dsb'
             # Upper Sorbian = 'hsb'
             # Sorbian Languages = 'wen'
-            10 : {0 : 'es' , 4 : 'es' , 44 : 'es-ar' , 64 : 'es-bo' , 52 : 'es-cl' , 36 : 'es-co' , 20 : 'es-cr' , 28 : 'es-do' ,
-                  48 : 'es-ec' , 68 : 'es-sv' , 16 : 'es-gt' , 72 : 'es-hn' , 8 : 'es-mx' , 76 : 'es-ni' , 24 : 'es-pa' ,
-                  60 : 'es-py' , 40 : 'es-pe' , 80 : 'es-pr' , 56 : 'es-uy' , 32 : 'es-ve'},
+            10 : {0 : 'es' , 1 : 'es' , 11 : 'es-ar' , 16 : 'es-bo' , 13 : 'es-cl' , 9 : 'es-co' , 5 : 'es-cr' , 7 : 'es-do' ,
+                  12 : 'es-ec' , 17 : 'es-sv' , 4 : 'es-gt' , 18 : 'es-hn' , 2 : 'es-mx' , 19 : 'es-ni' , 6 : 'es-pa' ,
+                  15 : 'es-py' , 10 : 'es-pe' , 20 : 'es-pr' , 14 : 'es-uy' , 8 : 'es-ve'},
             # Spanish,  Spanish (Mobipocket bug?),  Spanish (Argentina),  Spanish
             # (Bolivia),  Spanish (Chile),  Spanish (Colombia),  Spanish (Costa Rica),
             # Spanish (Dominican Republic),  Spanish (Ecuador),  Spanish (El
@@ -107,7 +107,7 @@ def getLanguage(langID, sublangID):
             # "Sutu" is another name for "Southern Sotho"?
             # IANA code for "Southern Sotho" is 'st'
             65 : {0 : 'sw'},  # Swahili
-            29 : {0 : 'sv' , 1 : 'sv' , 8 : 'sv-fi'},  # Swedish,  Swedish (Finland)
+            29 : {0 : 'sv' , 1 : 'sv' , 2 : 'sv-fi'},  # Swedish,  Swedish (Finland)
             73 : {0 : 'ta'},  # Tamil
             68 : {0 : 'tt'},  # Tatar
             74 : {0 : 'te'},  # Telugu
@@ -117,12 +117,18 @@ def getLanguage(langID, sublangID):
             31 : {0 : 'tr'},  # Turkish
             34 : {0 : 'uk'},  # Ukrainian
             32 : {0 : 'ur'},  # Urdu
-            67 : {2 : 'uz'},  # Uzbek
+            67 : {0 : 'uz', 1 : 'uz'},  # Uzbek
             42 : {0 : 'vi'},  # Vietnamese
             52 : {0 : 'xh'},  # Xhosa
             53 : {0 : 'zu'},  # Zulu
     }
-    return mobilangdict.get(int(langID), {0 : 'en'}).get(int(sublangID), 'en')
+    lang = "en"
+    if langID in mobilangdict:
+        subdict = mobilangdict[langID]
+        lang = subdict[0]
+        if sublangID in subdict:
+            lang = subdict[sublangID]
+    return lang
 
 
 def toHex(byteList):

--- a/se/vendor/kindleunpack/mobiml2xhtml.py
+++ b/se/vendor/kindleunpack/mobiml2xhtml.py
@@ -8,6 +8,8 @@
 Convert from Mobi ML to XHTML
 '''
 
+from __future__ import division, absolute_import, print_function
+
 import os
 import sys
 import re
@@ -37,7 +39,7 @@ class MobiMLConverter(object):
         self.tag_css_rule_cnt = 0
         self.path = []
         self.filename = filename
-        self.wipml = open(self.filename, 'rb').read()
+        self.wipml = open(self.filename, 'r').read()
         self.pos = 0
         self.opfname = self.filename.rsplit('.',1)[0] + '.opf'
         self.opos = 0
@@ -108,7 +110,7 @@ class MobiMLConverter(object):
         if tname == '!doctype':
             tname = '!DOCTYPE'
         # special cases
-        if tname in SPECIAL_HANDLING_TAGS.keys():
+        if tname in SPECIAL_HANDLING_TAGS:
             ttype, backstep = SPECIAL_HANDLING_TAGS[tname]
             tattr['special'] = s[p:backstep]
         if ttype is None:
@@ -177,7 +179,7 @@ class MobiMLConverter(object):
                 ttype, tname, tattr = self.parsetag(tag)
 
                 # If we run into a DTD or xml declarations inside the body ... bail.
-                if tname in SPECIAL_HANDLING_TAGS.keys() and tname != 'comment' and body_done:
+                if tname in SPECIAL_HANDLING_TAGS and tname != 'comment' and body_done:
                     htmlstr += '\n</body></html>'
                     break
 
@@ -200,7 +202,7 @@ class MobiMLConverter(object):
 
                 # Get rid of font tags that only have a color attribute.
                 if tname == 'font' and ttype in ('begin', 'single', 'single_ext'):
-                    if 'color' in tattr.keys() and len(tattr.keys()) == 1:
+                    if 'color' in tattr and len(tattr) == 1:
                         tname = 'removeme:{0}'.format(tname)
                         tattr = None
 
@@ -241,7 +243,7 @@ class MobiMLConverter(object):
                     self.path.append(tname)
                 elif ttype == 'end':
                     if tname != self.path[-1]:
-                        print ('improper nesting: ', self.path, tname, ttype)
+                        print('improper nesting: ', self.path, tname, ttype)
                         if tname not in self.path:
                             # handle case of end tag with no beginning by injecting empty begin tag
                             taginfo = ('begin', tname, None)
@@ -315,16 +317,16 @@ class MobiMLConverter(object):
             return ''
         if ttype == 'end':
             return '</%s>' % tname
-        if ttype in SPECIAL_HANDLING_TYPES and tattr is not None and 'special' in tattr.keys():
+        if ttype in SPECIAL_HANDLING_TYPES and tattr is not None and 'special' in tattr:
             info = tattr['special']
             if ttype == 'comment':
-                return '<%s %s-->' % tname, info
+                return '<%s %s-->' % (tname, info)
             else:
-                return '<%s %s>' % tname, info
+                return '<%s %s>' % (tname, info)
         res = []
         res.append('<%s' % tname)
         if tattr is not None:
-            for key in tattr.keys():
+            for key in tattr:
                 res.append(' %s="%s"' % (key, tattr[key]))
         if ttype == 'single':
             res.append('/>')
@@ -372,16 +374,16 @@ class MobiMLConverter(object):
         if tname in ('country-region', 'place', 'placetype', 'placename',
                 'state', 'city', 'street', 'address', 'content'):
             tname = 'div' if tname == 'content' else 'span'
-            for key in tattr.keys():
+            for key in tattr:
                 tattr.pop(key)
 
         # handle general case of style, height, width, bgcolor in any tag
-        if 'style' in tattr.keys():
+        if 'style' in tattr:
             style = tattr.pop('style').strip()
             if style:
                 styles.append(style)
 
-        if 'align' in tattr.keys():
+        if 'align' in tattr:
             align = tattr.pop('align').strip()
             if align:
                 if tname in ('table', 'td', 'tr'):
@@ -389,7 +391,7 @@ class MobiMLConverter(object):
                 else:
                     styles.append('text-align: %s' % align)
 
-        if 'height' in tattr.keys():
+        if 'height' in tattr:
             height = tattr.pop('height').strip()
             if height and '<' not in height and '>' not in height and re.search(r'\d+', height):
                 if tname in ('table', 'td', 'tr'):
@@ -399,7 +401,7 @@ class MobiMLConverter(object):
                 else:
                     styles.append('margin-top: %s' % self.ensure_unit(height))
 
-        if 'width' in tattr.keys():
+        if 'width' in tattr:
             width = tattr.pop('width').strip()
             if width and re.search(r'\d+', width):
                 if tname in ('table', 'td', 'tr'):
@@ -411,7 +413,7 @@ class MobiMLConverter(object):
                     if width.startswith('-'):
                         styles.append('margin-left: %s' % self.ensure_unit(width[1:]))
 
-        if 'bgcolor' in tattr.keys():
+        if 'bgcolor' in tattr:
             # no proprietary html allowed
             if tname == 'div':
                 del tattr['bgcolor']
@@ -421,7 +423,7 @@ class MobiMLConverter(object):
             tname = 'span'
             if ttype in ('begin', 'single', 'single_ext'):
                 # move the face attribute to css font-family
-                if 'face' in tattr.keys():
+                if 'face' in tattr:
                     face = tattr.pop('face').strip()
                     styles.append('font-family: "%s"' % face)
 
@@ -429,12 +431,12 @@ class MobiMLConverter(object):
                     # them to css. The following will work for 'flat' font tags, but nested font tags
                     # will cause things to go wonky. Need to revert to the parent font tag's size
                     # when a closing tag is encountered.
-                if 'size' in tattr.keys():
+                if 'size' in tattr:
                     sz = tattr.pop('size').strip().lower()
                     try:
                         float(sz)
                     except ValueError:
-                        if sz in size_map.keys():
+                        if sz in size_map:
                             sz = size_map[sz]
                     else:
                         if sz.startswith('-') or sz.startswith('+'):
@@ -509,8 +511,8 @@ def main(argv=sys.argv):
         print('Processing ...')
         htmlstr, css, cssname = mlc.processml()
         outname = infile.rsplit('.',1)[0] + '_converted.html'
-        file(outname, 'wb').write(htmlstr)
-        file(cssname, 'wb').write(css)
+        open(outname, 'w').write(htmlstr)
+        open(cssname, 'w').write(css)
         print('Completed')
         print('XHTML version of book can be found at: ' + outname)
 

--- a/se/vendor/kindleunpack/unpack_structure.py
+++ b/se/vendor/kindleunpack/unpack_structure.py
@@ -160,6 +160,7 @@ xmlns:enc="http://www.w3.org/2001/04/xmlenc#" xmlns:deenc="http://ns.adobe.com/d
         with open(pathof(fileout),'wb') as f:
             f.write(mimetype)
         nzinfo = ZipInfo('mimetype', compress_type=zipfile.ZIP_STORED)
+        nzinfo.external_attr = 0o600 << 16 # make this a normal file
         self.outzip.writestr(nzinfo, mimetype)
         self.zipUpDir(self.outzip,self.k8dir,'META-INF')
         self.zipUpDir(self.outzip,self.k8dir,'OEBPS')


### PR DESCRIPTION
The kindleunpack vendor module uses the previously builtin module imghdr. The imghdr module was deprecated in python 3.11 and removed in 3.13. kindleunpack was subsequently updated to inline the imghdr code; SE therefore needs to update kindleunpack to be compatible with python 3.13.