### PR TITLE
Change: BuildMessage.build now cleans more characters disallowed in filenames, when generating a filename from dc:identifier.

### DIFF
--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -145,7 +145,10 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 
 		asin = sha1(identifier.encode("utf-8")).hexdigest()
 
-		identifier = identifier.replace("https://standardebooks.org/ebooks/", "").replace("/", "_")
+		identifier = identifier.replace("https://standardebooks.org/ebooks/", "")
+		pieces = identifier.split("/")
+		safe_pieces = [se.formatting.make_url_safe(piece) for piece in pieces]
+		identifier = "_".join(safe_pieces)
 	except Exception as ex:
 		raise se.InvalidSeEbookException(f"Missing [xml]<dc:identifier>[/] element in [path][link=file://{self.metadata_file_path}]{self.metadata_file_path}[/][/].") from ex
 


### PR DESCRIPTION
The filename generation now safely cleans more unsafe characters (ex. `"`, `#`, `!` etc.) from possible identifiers.

Addresses #844.