### PR TITLE
Add ignore file to add-file command

### DIFF
--- a/se/commands/add_file.py
+++ b/se/commands/add_file.py
@@ -49,7 +49,7 @@ def add_file(plain_output: bool) -> int:
 	Entry point for `se add-file`.
 	"""
 
-	file_types = ["dedication", "endnotes", "epigraph", "glossary", "halftitlepage"]
+	file_types = ["dedication", "endnotes", "epigraph", "glossary", "halftitlepage", "ignore"]
 
 	parser = argparse.ArgumentParser(description="Add an SE template file and any accompanying CSS.")
 	parser.add_argument("-f", "--force", dest="force", action="store_true", help="overwrite any existing files")
@@ -128,6 +128,12 @@ def add_file(plain_output: bool) -> int:
 						file.seek(0)
 						file.write(xhtml)
 						file.truncate()
+
+				case "ignore":
+					dest_path = se_epub.path / "se-lint-ignore.xml"
+
+					_copy_file("se-lint-ignore.xml", dest_path, args.force)
+
 
 		except se.SeException as ex:
 			se.print_error(ex, plain_output=plain_output)

--- a/se/data/templates/se-lint-ignore.xml
+++ b/se/data/templates/se-lint-ignore.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<se-lint-ignore>
+	<file path="">
+		<ignore>
+			<code></code>
+			<reason></reason>
+		</ignore>
+	</file>
+</se-lint-ignore>


### PR DESCRIPTION
This is another file I keep a copy of in my local template directory.

I wasn't sure if you wanted the full file name as the option when it was a compound, so I just went with "ignore." Obviously easy to change if you want the full se-lint-ignore.