### PR TITLE
Add a missed time block in translated productions’ colophons

### DIFF
--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -909,7 +909,7 @@ def _create_draft(args: Namespace, plain_output: bool):
 				colophon_xhtml = colophon_xhtml.replace("<a href=\"AUTHOR_WIKI_URL\">AUTHOR</a>", contributor_string)
 
 			if translators:
-				translator_block = f"It was translated from ORIGINAL_LANGUAGE in TRANSLATION_YEAR by<br/>\n\t\t\t{_generate_contributor_string(translators, True)}.</p>"
+				translator_block = f"It was translated from ORIGINAL_LANGUAGE in <time>TRANSLATION_YEAR</time> by<br/>\n\t\t\t{_generate_contributor_string(translators, True)}.</p>"
 				colophon_xhtml = colophon_xhtml.replace("</p>\n\t\t\t<p>This ebook was produced for<br/>", f"<br/>\n\t\t\t{translator_block}\n\t\t\t<p>This ebook was produced for<br/>")
 
 			if args.pg_id:


### PR DESCRIPTION
Noticed this when spinning up a new project with a translated text.