### PR TITLE
Fix `SyntaxWarning: invalid escape sequence`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
 		"roman==5.0",
 		"selenium==4.31.0",
 		"setuptools==78.1.1",
-		"smartypants==2.0.1",
+		"smartypants==2.0.2",
 		"tinycss2==1.4.0",
 		"titlecase==2.4.1",
 		"unidecode==1.3.8"


### PR DESCRIPTION
`se lint` frequently emits

```
[...]/lib/python3.12/site-packages/smartypants.py:271: SyntaxWarning: invalid escape sequence '\S'
  if re.match("\S", prev_token_last_char):
```

This is an upstream bug in smartypants: https://github.com/justinmayer/smartypants.py/pull/21

A fix was included in June 16 release 2.0.2: https://github.com/justinmayer/smartypants.py/issues/25#issuecomment-2980447643

I don't believe it will break anything as this is a minor change, but I of course am not the editor-in-chief! Submitting PR with due deference & respect.