### PR TITLE
Reproducible epub builds

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -1569,6 +1569,15 @@ def generate_colophon_timestamp(timestamp: datetime) -> str:
 
 	return formatted_timestamp
 
+def generate_epoch_timestamp(timestamp: datetime) -> str:
+	"""
+	Given a `datetime` in UTC, generate a Unix epoch timestamp (seconds since 1970-01-01T00:00:00Z) as an integer string.
+	"""
+
+	formatted_timestamp = str(int(timestamp.timestamp()))
+
+	return formatted_timestamp
+
 def _get_flattened_children(node: EasyXmlElement, allow_header: bool) -> list[EasyXmlElement]:
 	"""
 	Helper function for `find_unexpected_ids()`.

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -195,6 +195,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 					file.truncate()
 
 		# Update the release date in the metadata and colophon.
+		last_updated = None
 		if self.last_commit:
 			for file_path in work_compatible_epub_dir.glob("**/*.xhtml"):
 				dom = self.get_dom(file_path)
@@ -227,7 +228,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 
 		# Output the pure epub3 file.
 		if not check_only:
-			se.epub.write_epub(work_compatible_epub_dir, output_dir / advanced_epub_output_filename)
+			se.epub.write_epub(work_compatible_epub_dir, output_dir / advanced_epub_output_filename, last_updated)
 
 		# Now add compatibility fixes for older ereaders.
 
@@ -802,7 +803,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 			for file_path in work_kepub_dir.glob("**/*.opf"):
 				se.formatting.format_xml_file(file_path)
 
-			se.epub.write_epub(work_kepub_dir, output_dir / kobo_output_filename)
+			se.epub.write_epub(work_kepub_dir, output_dir / kobo_output_filename, last_updated)
 
 		# Now work on more compatibility fixes.
 
@@ -1157,7 +1158,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 
 		# Write the compatible epub.
 		if not check_only:
-			se.epub.write_epub(work_compatible_epub_dir, output_dir / compatible_epub_output_filename)
+			se.epub.write_epub(work_compatible_epub_dir, output_dir / compatible_epub_output_filename, last_updated)
 
 		# Run checks, if specified.
 		build_messages = []
@@ -1435,7 +1436,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 					core_css_file.write("\n\n" + compatibility_css_file.read())
 
 			# Build an epub file we can send to Calibre.
-			se.epub.write_epub(work_compatible_epub_dir, work_dir / compatible_epub_output_filename)
+			se.epub.write_epub(work_compatible_epub_dir, work_dir / compatible_epub_output_filename, last_updated)
 
 			# Generate the Kindle file.
 			# We place it in the work directory because later we have to update the asin, and the `mobi.update_asin()` function will write to the final output directory.

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
 		"psutil==7.0.0",
 		"pyphen==0.17.2",
 		"regex==2024.11.6",
+		"repro_zipfile==0.4.0",
 		"requests==2.32.4",
 		"rich==14.0.0",
 		"roman==5.0",


### PR DESCRIPTION
Resolves #867 for all epub variants.

All epub builds (standard, advanced, and kobo/kepub) are now reproducible.
Kindle azw3 builds are not yet reproducible since the Calibre epub->azw3 conversion is not reproducible.

Example reproducible build from the following command sequence:
```
git clone https://github.com/standardebooks/edgar-allan-poe_poetry.git

se build --kobo edgar-allan-poe_poetry
mv edgar-allan-poe_poetry_advanced.epub edgar-allan-poe_poetry_advanced_build1.epub
mv edgar-allan-poe_poetry.epub          edgar-allan-poe_poetry_build1.epub
mv edgar-allan-poe_poetry.kepub.epub    edgar-allan-poe_poetry_build1.kepub.epub

sleep 5

se build --kobo edgar-allan-poe_poetry
mv edgar-allan-poe_poetry_advanced.epub edgar-allan-poe_poetry_advanced_build2.epub
mv edgar-allan-poe_poetry.epub          edgar-allan-poe_poetry_build2.epub
mv edgar-allan-poe_poetry.kepub.epub    edgar-allan-poe_poetry_build2.kepub.epub

sha256sum edgar-allan-poe_poetry_advanced_build?.epub
echo ""
sha256sum edgar-allan-poe_poetry_build?.epub
echo ""
sha256sum edgar-allan-poe_poetry_build?.kepub.epub
```
produces the following output, showing the reproducible epub builds:
```
8c55426baa52bf22cee7b98a8f69819a1783eb4efd07af9c6fb42e19cee52e5d  edgar-allan-poe_poetry_advanced_build1.epub
8c55426baa52bf22cee7b98a8f69819a1783eb4efd07af9c6fb42e19cee52e5d  edgar-allan-poe_poetry_advanced_build2.epub

214d943e14a5304b0507cb33716656cad568fd387e4f719f075fd3195439a84f  edgar-allan-poe_poetry_build1.epub
214d943e14a5304b0507cb33716656cad568fd387e4f719f075fd3195439a84f  edgar-allan-poe_poetry_build2.epub

c12ceb0f0ae9aa94c571a7a275ab37558c7a599d16cd351db5cf0c898fc4089a  edgar-allan-poe_poetry_build1.kepub.epub
c12ceb0f0ae9aa94c571a7a275ab37558c7a599d16cd351db5cf0c898fc4089a  edgar-allan-poe_poetry_build2.kepub.epub
```

If no git history is available, `ReproducibleZipFile` date-time still default to the zip file "zero time" of 1980-01-01.
However, in the normal case of there being a git `last_commit`, the `SOURCE_DATE_EPOCH` environment variable gets set during the build so that `ReproducibleZipFile` will use the date-time of that commit.

The following example demonstrates the latest git timestamp (`2025-08-18 16:05:00 -0500` aka `2025-08-18 21:05:00 UTC`) being used in the `ReproducibleZipFile` for the epub.

```
cd edgar-allan-poe_poetry
git log -1
commit 701ecf552ddf10681fdefb4434147104c1dc0d91 (HEAD -> master, origin/master, origin/HEAD)
Author: Alex Cabal <alex@standardebooks.org>
Date:   2025-08-18 16:05:00 -0500

    Update metadata boilerplate
```

```
unzip -l edgar-allan-poe_poetry_build1.epub
Archive:  edgar-allan-poe_poetry_build1.epub
  Length      Date    Time    Name
---------  ---------- -----   ----
       20  08-18-2025 21:05   mimetype
      247  08-18-2025 21:05   META-INF/container.xml
        0  08-18-2025 21:05   META-INF/
        0  08-18-2025 21:05   epub/
    11581  08-18-2025 21:05   epub/content.opf
        0  08-18-2025 21:05   epub/css/
     6347  08-18-2025 21:05   epub/css/core.css
     2086  08-18-2025 21:05   epub/css/local.css
     2027  08-18-2025 21:05   epub/css/se.css
        0  08-18-2025 21:05   epub/images/
   552983  08-18-2025 21:05   epub/images/cover.jpg
    21867  08-18-2025 21:05   epub/images/logo.png
    33169  08-18-2025 21:05   epub/images/titlepage.png
     7854  08-18-2025 21:05   epub/onix.xml
        0  08-18-2025 21:05   epub/text/
     3038  08-18-2025 21:05   epub/text/colophon.xhtml
    39542  08-18-2025 21:05   epub/text/endnotes.xhtml
     2398  08-18-2025 21:05   epub/text/imprint.xhtml
   179879  08-18-2025 21:05   epub/text/poetry.xhtml
      806  08-18-2025 21:05   epub/text/titlepage.xhtml
     3009  08-18-2025 21:05   epub/text/uncopyright.xhtml
    14498  08-18-2025 21:05   epub/toc.ncx
     8381  08-18-2025 21:05   epub/toc.xhtml
---------                     -------
   889732                     23 files
```