### PR TITLE
Add a build-svg-titles command

### DIFF
--- a/se/commands/build_svg_titles.py
+++ b/se/commands/build_svg_titles.py
@@ -1,0 +1,76 @@
+"""
+This module implements the `se build-svg-titles` command.
+"""
+
+import argparse
+
+import se
+import se.easy_xml
+from se.se_epub import SeEpub
+
+
+def build_svg_titles(plain_output: bool) -> int:
+	"""
+	Entry point for `se build-svg-titles`.
+	"""
+
+	parser = argparse.ArgumentParser(description="Updates or adds SVG <title> elements based on the alt attributes from the <img> elements.")
+	parser.add_argument("-v", "--verbose", action="store_true", help="increase output verbosity")
+	parser.add_argument("directories", metavar="DIRECTORY", nargs="+", help="a Standard Ebooks source directory")
+	args = parser.parse_args()
+
+	console = se.init_console()
+
+	for directory in args.directories:
+		try:
+			if args.verbose:
+				console.print(se.prep_output(f"Processing [path][link=file://{directory}]{directory}[/][/] ...", plain_output))
+
+			se_epub = SeEpub(directory)
+
+			# Load the `alt` attributes for all illustrations.
+			for filename in se_epub.spine_file_paths:
+				dom = se_epub.get_dom(filename)
+
+				for img in dom.xpath(r"/html/body//img[re:test(@src,'\.svg$')]"):
+					img_src = img.get_attr("src")
+					img_alt = img.get_attr("alt")
+					image_ref = img_src.split("/").pop()
+
+					if not img_alt or image_ref in ("cover.svg", "logo.svg", "titlepage.svg"):
+						continue
+
+					# Update or add the title to the SVG.
+					try:
+						svg_path = se_epub.content_path / "images" / image_ref
+						svg_dom = se_epub.get_dom(svg_path)
+						svg_element = svg_dom.xpath("/svg")[0]
+
+						# Check for existing `<title>` elements in the SVG.
+						title_elements = svg_dom.xpath("/svg/title")
+						if len(title_elements) == 0:
+							# Add a properly indented `<title>` element at the start of the `<svg>`.
+							title_element = se.easy_xml.EasyXmlElement("<title/>")
+							svg_element.prepend(title_element)
+							svg_element.text = "\n\t"
+						else:
+							# Remove any additional `<title>` elements.
+							for title_element in title_elements[1:]:
+								title_element.remove()
+							# Select the first element for updating.
+							title_element = title_elements[0]
+
+						# Update the text in the `<title>` element.
+						title_element.text = img_alt
+
+						with open(svg_path, "w", encoding="utf-8") as file:
+							file.write(svg_dom.to_string())
+
+					except FileNotFoundError:
+						se.print_error(f"Couldn’t open file: [path][link=file://{svg_path}]{svg_path}[/][/].", plain_output=plain_output)
+
+		except se.SeException as ex:
+			se.print_error(ex)
+			return ex.code
+
+	return 0

--- a/tests/stdout_commands/help/test-1/golden/help-test-1-out.txt
+++ b/tests/stdout_commands/help/test-1/golden/help-test-1-out.txt
@@ -7,6 +7,7 @@ build-images
 build-loi
 build-manifest
 build-spine
+build-svg-titles
 build-title
 build-toc
 clean

--- a/tests/stdout_commands/help/test-2/golden/help-test-2-out.txt
+++ b/tests/stdout_commands/help/test-2/golden/help-test-2-out.txt
@@ -3,7 +3,7 @@ usage: se [-h] [-p] [-v] COMMAND [ARGS ...]
 The entry point for the Standard Ebooks toolset.
 
 positional arguments:
-  COMMAND        one of: add-file british2american build build-ids build-images build-loi build-manifest build-spine build-title build-toc clean compare-versions create-draft css-select dec2roman extract-ebook find-mismatched-dashes find-mismatched-diacritics find-unusual-characters help hyphenate interactive-replace lint make-url-safe modernize-spelling prepare-release recompose-epub renumber-endnotes roman2dec semanticate shift-endnotes shift-illustrations split-file titlecase typogrify unicode-names word-count xpath
+  COMMAND        one of: add-file british2american build build-ids build-images build-loi build-manifest build-spine build-svg-titles build-title build-toc clean compare-versions create-draft css-select dec2roman extract-ebook find-mismatched-dashes find-mismatched-diacritics find-unusual-characters help hyphenate interactive-replace lint make-url-safe modernize-spelling prepare-release recompose-epub renumber-endnotes roman2dec semanticate shift-endnotes shift-illustrations split-file titlecase typogrify unicode-names word-count xpath
   ARGS           arguments for the subcommand
 
 options:


### PR DESCRIPTION
This adds a new `se build-svg-titles` command that copies the `alt` text from the XHTML files to the `<title>` elements in the corresponding SVG files. This saves time when adding or updating these descriptions and makes it easier to keep them synchronized.

Would this be useful to add to the tools?

* Copying the descriptions from the `alt` attributes to the SVG files makes the most sense, I think, because you would also have to add `alt` tags for any non-SVG images, so this keeps everything in one place.
* I am not sure if `build-svg-titles` is the ideal name, but it matches the `build-title` command that has a somewhat similar function.
* This command doesn't re-indent the SVG files or correct the `<title>` position (that is for `se clean`), but if you run it on a properly indented file it will still be clean afterwards.