### PR TITLE
Fix srcset

### DIFF
--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -517,7 +517,6 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 				processed_xhtml = processed_xhtml.replace("〃", "“")
 				processed_xhtml = processed_xhtml.replace(" ", f"{se.NO_BREAK_SPACE}{se.NO_BREAK_SPACE}") # Em-space to two nbsps.
 				processed_xhtml = processed_xhtml.replace("∶", ":")
-				processed_xhtml = processed_xhtml.replace("℅", "c/o")
 
 				# Replace combining vertical line above, used to indicate stressed syllables, with combining acute accent.
 				processed_xhtml = processed_xhtml.replace(fr"{se.COMBINING_VERTICAL_LINE_ABOVE}", fr"{se.COMBINING_ACUTE_ACCENT}")

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -457,7 +457,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 
 				# Add ARIA roles, which are just mostly duplicate attributes to `epub:type`.
 				for role in ARIA_ROLES:
-					# Exclude landmarks because while their semantics indicate what their *links* contain, not what *they themselves are*.
+					# Exclude landmarks because their semantics indicate what their *links* contain, not what *they themselves are*.
 					# Skip elements that already have a `role` attribute, as more than one role will cause Ace to fail.
 					for node in dom.xpath(f"/html//*[not(@role) and not(ancestor-or-self::nav[contains(@epub:type, 'landmarks')]) and re:test(@epub:type, '\\b{role}\\b')]"):
 						# `<article>`s generally aren't allowed ARIA roles, so skip them.

--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -846,7 +846,7 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 				node.set_attr("src", src.replace(".svg", ".png"))
 
 				if not ibooks_srcset_bug_exists:
-					match = regex.search(r"(?<=/)[^/]+(?=\.svg)", src)
+					match = regex.search(r".*?(?=\.svg)", src)
 					filename = match[0] if match else None
 					if filename:
 						node.set_attr("srcset", f"{filename}-2x.png 2x, {filename}.png 1x")


### PR DESCRIPTION
Fixes srcset to include the full image path, and the same comment correction and dup character replacement removal in the aborted footnote PR.