### PR TITLE
words: Remove farfetched and tight-lipped, add farfetchedness

### DIFF
--- a/se/data/words
+++ b/se/data/words
@@ -30922,7 +30922,7 @@ farer
 fares
 farewell
 farewells
-farfetched
+farfetchedness
 farina
 farinaceous
 faring
@@ -39817,6 +39817,7 @@ horsemen
 horsemint
 horsemints
 horseplay
+horsepond
 horsepower
 horseradish
 horseradishes
@@ -50397,6 +50398,8 @@ mendicants
 mendicity
 mending
 mends
+menfolk
+menfolks
 menhaden
 menhadens
 menhir
@@ -82851,7 +82854,6 @@ tightens
 tighter
 tightest
 tightfisted
-tightlipped
 tightly
 tightness
 tightrope
@@ -90999,6 +91001,8 @@ wombat
 wombats
 wombs
 women
+womenfolk
+womenfolks
 wonder
 wondered
 wonderful


### PR DESCRIPTION
The former are in M-W as hyphenated, the latter without hyphen. They're both in the corpus, farfetched far more frequently. I'll fix them if/when this is merged.