### PR TITLE
build: Move isolatable portions to individual functions

### DIFF
--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -1756,7 +1756,6 @@ def build(self, run_epubcheck: bool, check_only: bool, build_kobo: bool, build_k
 			_split_endnote_files(self, work_compatible_epub_dir, endnote_files_to_be_chunked, metadata_dom, toc_relative_path, toc_dom)
 
 		# Remove `<span>` and `<abbr>` from the ToC, which causes broken rendering in iOS 18+. See <https://groups.google.com/g/standardebooks/c/dam7dmBcqW0/m/v4GaBkY7AgAJ>.
-		toc_dom = self.get_dom(work_compatible_epub_dir / "epub" / toc_relative_path)
 		write_toc = False
 		for node in toc_dom.xpath("/html/body//abbr | /html/body//span"):
 			node.unwrap()


### PR DESCRIPTION
Plenty left to do, but this is a start at restructuring se_epub_build.

Like the lint restructure, this moves the big chunks of the mainline function into individual functions, so that the mainline is mostly just calling functions to do the individual things that need to be done.

It successfully builds all epub types—epub3, compatible, kobo, kindle—and handles epub checks and MathML conversion, but has only been tested on a couple of books, and has not been stress/error tested at all. I created this as a draft PR so you can look at it and make any comments as things move along.

The next thing I'm going to do is add documentation to all of the added functions, and then I'll probably start trying to break things.

One question about yesterday's change for to strip the abbr/spans from the ToC—you moved the defining of toc_dom out of the "chunk" code, but then you redefined it again after the chunk code before you removed the abbr/spans. Is there a reason you redefined it? You can see it more easily in the restructured code:

```python3
		# Get the ToC dom for upcoming operations.
		toc_relative_path = metadata_dom.xpath("/package/manifest/item[re:test(@properties, '\\bnav\\b')]/@href", True)
		toc_dom = self.get_dom(work_compatible_epub_dir / "epub" / toc_relative_path)

		# If we have any endnote files with more than 600 endnotes, split them
		if endnote_files_to_be_chunked:
			_split_endnote_files(self, work_compatible_epub_dir, endnote_files_to_be_chunked, toc_relative_path, toc_dom)

		# Remove `<span>` and `<abbr>` from the ToC, which causes broken rendering in iOS 18+. See <https://groups.google.com/g/standardebooks/c/dam7dmBcqW0/m/v4GaBkY7AgAJ>.
		toc_dom = self.get_dom(work_compatible_epub_dir / "epub" / toc_relative_path)
````

Is that second `toc_dom = …` needed? It's identical to the first one, but I'm not sufficiently up to speed on how dom's work and whether the chunking could cause it to need to be redefined.