### PR TITLE
words: Add plainclothes

### DIFF
--- a/se/data/words
+++ b/se/data/words
@@ -61001,6 +61001,7 @@ plaid
 plaids
 plain
 plainchant
+plainclothes
 plainclothesman
 plainclothesmen
 plainer


### PR DESCRIPTION
The hyphenated adjectival form `plain-clothes` occurs a lot in the corpus, but M-W has this adjective listed unhyphenated (Definition 1): https://www.merriam-webster.com/dictionary/plainclothes#dictionary-entry-1