### PR TITLE
Update installation instructions for Fedora 43

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,17 @@ sudo ln -s $(pipx environment --value PIPX_LOCAL_VENVS)/standardebooks/lib/pytho
 ln -s $(pipx environment --value PIPX_LOCAL_VENVS)/standardebooks/lib/python3.*/site-packages/se/completions/fish/se.fish $HOME/.config/fish/completions/
 ```
 
-## Fedora 41 users
+## Fedora 43 users
 
 ```shell
 # Install some pre-flight dependencies.
-sudo dnf install pipx python3.12 python3.12-devel gcc libxslt-devel calibre git java-21-openjdk-headless
+sudo dnf install pipx python3-devel gcc libxslt-devel calibre git java-25-openjdk-headless
 
 # Ensure `$PATH` environment variable is correctly set up for `pipx`.
 pipx ensurepath
 
 # Install the toolset.
-pipx install --python=3.12 standardebooks
-pipx inject standardebooks setuptools
+pipx install standardebooks
 ```
 
 ### Optional: Install shell completions


### PR DESCRIPTION
Straightforward update. Changes to dependencies reflect the relaxing in Python requirements. OpenJDK 25 is now default on Fedora 43, and the toolset doesn’t seem to require a specific version.

Interestingly enough, it is no longer required to inject `setuptools` into the pipx package for it to work.

Tested on three different computers, including a minimal install.