### PR TITLE
lint: fix y-006 error message

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -476,7 +476,7 @@ TYPOS
 "y-003", "Possible typo: Paragraph missing ending punctuation."
 "y-004", "Possible typo: Mis-curled quotation mark after dash."
 "y-005", "Possible typo: Question mark or exclamation mark followed by period or comma."
-"y-006", "Possible typo: [text]‘[/] without matching [text]’[/]. Hint: [text]’[/] are used for abbreviations;	commas and periods must go inside quotation marks."
+"y-006", "Possible typo: [text]‘[/] without matching [text]’[/]. Hint: [text]’[/] are used for elisions;	commas and periods must go inside quotation marks."
 "y-007", "Possible typo: [text]‘[/] not within [text]“[/]. Hint: Should [text]‘[/] be replaced with [text]“[/]? Is there a missing closing quote? Is this a nested quote that should be preceded by [text]“[/]? Are quotes in close proximity correctly closed?"
 "y-008", "Possible typo: Dialog interrupted by interjection but with incorrect closing quote."
 "y-009", "Possible typo: Dialog begins with lowercase letter."
@@ -3275,7 +3275,7 @@ def _lint_xhtml_typo_checks(source_file: SourceFile, dom: se.easy_xml.EasyXmlTre
 	# Check for opening `‘` in quote that doesn't appear to have a matching `’`, ignoring contractions/elided words as false matches.
 	typos = dom.xpath("/html/body//text()[re:match(., '“[^‘”]*‘[^“]+?”', 'g')/text()[not(re:test(., '’[^A-Za-z]'))]]")
 	if typos:
-		messages.append(LintMessage("y-006", "Possible typo: [text]‘[/] without matching [text]’[/]. Hint: [text]’[/] are used for abbreviations.", se.MESSAGE_TYPE_WARNING, filename, typos))
+		messages.append(LintMessage("y-006", "Possible typo: [text]‘[/] without matching [text]’[/]. Hint: [text]’[/] are used for elisions.", se.MESSAGE_TYPE_WARNING, filename, typos))
 
 	# Try to find top-level `lsquo;` for example, `<p>“Bah!” he said to the ‘minister.’</p>`.
 	# We can't do this on xpath because we can't iterate over the output of `re:replace()`.

--- a/tests/lint/typos/y-006/golden/y-006-out.txt
+++ b/tests/lint/typos/y-006/golden/y-006-out.txt
@@ -1,4 +1,4 @@
-y-006 [Manual Review] chapter-1.xhtml Possible typo: `‘` without matching `’`. Hint: `’` are used for abbreviations.
+y-006 [Manual Review] chapter-1.xhtml Possible typo: `‘` without matching `’`. Hint: `’` are used for elisions.
  Line 20:       “ ‘Fail literature would have us believe that a minion death is not but a goat.” Extending this logic, a trenchant pull without beggars is truly a actress of decurved baies. Before lists, glues were only owls. “We can assume that any ‘instance of a beaver can be construed as a dentoid grandmother. Those step-brothers are nothing more than wrens.”
  Line 22:       Fail behavior is a support. We know that the technicians could be said to resemble maudlin pisceses. “Their workshop was, in ‘em, a sodden river.” Some jaundiced cares are thought of simply as gears. In ancient times the energy of an egypt becomes a many comic.
  Line 24:       Before lows, illegals were only headlines. Their orange was, in this moment, a reddest alphabet. “To be more ‘pecific, their moon wasn’t, in this moment, a nagging notebook.” Replaces are gladsome tires.


### PR DESCRIPTION
It seems like this error message was supposed to say "elisions" and not "abbreviations."