### PR TITLE
build: Tweak Kobo span CSS replacement

### DIFF
--- a/se/se_epub_build.py
+++ b/se/se_epub_build.py
@@ -1165,8 +1165,7 @@ def _build_kobo_process_css(file_path: Path) -> None:
 		processed_css = css
 
 		# Retarget `span` selectors at SE `<span>`s (i.e. not `koboSpan`s) only.
-		# Ignore `span` followed by a colon (this would be a CSS property like `column-span`).
-		processed_css = regex.sub(r"""(?<=\s)span(?=[^\w:])""", r"""span.se""", processed_css)
+		processed_css = regex.sub(r"""(?<=\s)span(?=.*[,{]\n)""", r"""span.se""", processed_css)
 
 		if processed_css != css:
 			file.seek(0)


### PR DESCRIPTION
I recently encountered an issue with this logic where it is not picking up `span`s with pseudo-classes (e.g. `span:first-child`):

```
.dl2 span:first-child{
	vertical-align: 100%;
}
```

The reason is that when I first implemented this code, I excluded `span` followed by a colon because of the existence of the `column-span` property. But that property isn't actually an issue because of the lookbehind for a whitespace character.

In my research, I realized that there is another edge case, which is that `span` is used as a keyword for [grid layouts](https://www.w3.org/TR/css-grid-1/#common-uses-numeric). Our existing logic doesn't handle this edge case, but I wonder if that is a moot point given that we don't really use grid layouts.