### PR TITLE
Various README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ pipx install --python=3.12 --fetch-missing-python standardebooks
 sudo ln -s $(pipx environment --value PIPX_LOCAL_VENVS)/standardebooks/lib/python3.*/site-packages/se/completions/zsh/_se /usr/share/zsh/vendor-completions/_se && hash -rf && compinit
 
 # Install Bash completions.
-sudo ln -s $(pipx environment --value PIPX_LOCAL_VENVS)/standardebooks/lib/python3.*/site-packages/se/completions/bash/se /usr/share/bash-completion/completions/se
+mkdir -p $HOME/.local/share/bash-completion/completions/
+ln -s $(pipx environment --value PIPX_LOCAL_VENVS)/standardebooks/lib/python3.*/site-packages/se/completions/bash/se $HOME/.local/share/bash-completion/completions/se
 
 # Install Fish completions.
 ln -s $(pipx environment --value PIPX_LOCAL_VENVS)/standardebooks/lib/python3.*/site-packages/se/completions/fish/se.fish $HOME/.config/fish/completions/
@@ -69,8 +70,8 @@ pipx install standardebooks
 sudo ln -s $(pipx environment --value PIPX_LOCAL_VENVS)/standardebooks/lib/python3.*/site-packages/se/completions/zsh/_se /usr/share/zsh/vendor-completions/_se && hash -rf && compinit
 
 # Install Bash completions.
-sudo ln -s $(pipx environment --value PIPX_LOCAL_VENVS)/standardebooks/lib/python3.*/site-packages/se/completions/bash/se /usr/share/bash-completion/completions/se
-
+mkdir -p $HOME/.local/share/bash-completion/completions/
+ln -s $(pipx environment --value PIPX_LOCAL_VENVS)/standardebooks/lib/python3.*/site-packages/se/completions/bash/se $HOME/.local/share/bash-completion/completions/se
 # Install Fish completions.
 ln -s $(pipx environment --value PIPX_LOCAL_VENVS)/standardebooks/lib/python3.*/site-packages/se/completions/fish/se $HOME/.config/fish/completions/se.fish
 ```


### PR DESCRIPTION
Here are some improvements to the README:

* Python requirements now reflect the version number in `setup.py`.
* Backticks are removed from monospaced environments. Because they are already monospaced, this causes the backticks to show, which is probably not the intended behaviour.
* Bash completions now install locally. Since `pipx` installs the toolset for the current user, it makes sense to install completions the same way. `bash-completion` recognises `~/.local/share/bash-completion/completions/` as a valid location, although it doesn’t exist by default. It’s also one fewer `sudo` command, which isn’t a bad thing.