### PR TITLE
semanticate: Correct handling of optional period on imperial units, allow singular lb

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -183,7 +183,7 @@ def semanticate(xhtml: str) -> str:
 	xhtml = regex.sub(r"([0-9]+)\s*([cmk][mgl])\b", fr"\1{se.NO_BREAK_SPACE}<abbr>\2</abbr>", xhtml)
 
 	# Add abbreviations around Imperial measurements.
-	xhtml = regex.sub(r"(?<![\$£0-9,])([0-9½¼⅙⅚⅛⅜⅝⅞]+)\s*(ft|yd|mi|pt|qt|gal|oz|lbs)\.?\b", fr"\1{se.NO_BREAK_SPACE}<abbr>\2.</abbr>", xhtml)
+	xhtml = regex.sub(r"(?<![\$£0-9,])([0-9½¼⅙⅚⅛⅜⅝⅞]+)\s*(ft|yd|yds|mi|pt|qt|gal|oz|lb|lbs)\.?(\W)", fr"\1{se.NO_BREAK_SPACE}<abbr>\2.</abbr>\3", xhtml)
 
 	# Handle `in.` separately to require a period, because with an optional period there are too many false positives.
 	xhtml = regex.sub(r"(?<![\$£0-9,])([0-9½¼⅙⅚⅛⅜⅝⅞]+)\s*in\.(\b|[\s,:;!?])", fr"\1{se.NO_BREAK_SPACE}<abbr>in.</abbr>\2", xhtml)


### PR DESCRIPTION
Per report from Jason. Since the period isn't required, it matches on the '\b', and since '\b' doesn't consume anything, the period is neither matched nor consumed, and adding a period results in one inside the tag and one outside. Using `\W` instead does consume it if it matches, but still doesn't require it. I'm sure there's some esoteric difference between '\b' and '\W', but it appears to work fine in my playing around with it.

Also, shouldn't we match on singular lb as well as plural? Something that weighs 1 lb 4 oz isn't going to have the `s`. I went ahead and added the singular as well.