### PR TITLE
modernize-spelling: dropt -> dropped

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -202,6 +202,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b([Dd])oat\b", r"\1ote", xhtml)				# doat -> dote
 	xhtml = regex.sub(r"\b([Dd])oat(ed|ing)", r"\1ot\2", xhtml)			# doating -> doting
 	xhtml = regex.sub(r"(?<!up and )(?<!up or )\b([Dd])own stairs\b", r"\1ownstairs", xhtml)		# down stairs -> downstairs, but not "up (or|and) down stairs"
+	xhtml = regex.sub(r"\b([Dd])ropt\b", r"\1ropped", xhtml)			# dropt -> dropped
 	xhtml = regex.sub(r"\b([Dd])ulness", r"\1ullness", xhtml)			# dulness -> dullness
 	xhtml = regex.sub(r"\b([Dd])umbfounder", r"\1umbfound", xhtml)			# dumbfoundered -> dumbfounded
 	xhtml = regex.sub(r"\b([Dd])umfound", r"\1umbfound", xhtml)			# dumfound -> dumbfound


### PR DESCRIPTION
This feels like a reasonably obvious addition based on the ngram: https://books.google.com/ngrams/graph?content=dropt,dropped. It’s found in 55 of our productions so fairly widespread, although a bunch of that is poetry which would be left as is of course.

It’s maybe also worth pointing out that there are occurences of `cropt` (9 matches) and `propt` (7 matches). Also one `dhropt` in a particularly obtuse accent; I think we can leave that as is.