### PR TITLE
Fix epubcheck subject errors in content.opf

### DIFF
--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -554,8 +554,8 @@ def _create_draft(args: Namespace, plain_output: bool):
 					subject_node = se.easy_xml.EasyXmlElement(element)
 					subject_node.set_attr("id", f"subject-{i}")
 					subject_node.set_text(subject)
-					authority_node = se.easy_xml.EasyXmlElement(f"<meta property=\"authority\" refines=\"subject-{i}\">LCHS</meta>")
-					term_node = se.easy_xml.EasyXmlElement(f"<meta property=\"term\" refines=\"subject-{i}\">{loc_id}</meta>")
+					authority_node = se.easy_xml.EasyXmlElement(f"<meta property=\"authority\" refines=\"#subject-{i}\">LCHS</meta>")
+					term_node = se.easy_xml.EasyXmlElement(f"<meta property=\"term\" refines=\"#subject-{i}\">{loc_id}</meta>")
 
 					for node in epub.metadata_dom.xpath("//meta[@property='se:subject'][1]"):
 						node.insert_before(subject_node)


### PR DESCRIPTION
I couldn’t work out why epubcheck was failing on a new production, turns out that there was some fallout from https://github.com/standardebooks/tools/commit/caca7c7d71447b341859fb49a3d0bed1dba12319. This fixes two seperate issues:

1. `dc:contributor` was being written out as `dc:subject` for transcribers.
2. Subject refinements were missing the required IDREF `#`, causing them to not be linked.

Fixing these makes the build run without error.