### PR TITLE
Add whether standardebooks is installed editable to --version output

### DIFF
--- a/se/commands/version.py
+++ b/se/commands/version.py
@@ -3,14 +3,22 @@ This module implements the `se version` command.
 """
 
 import se
+import json
+from importlib.metadata import Distribution
 
 def version() -> int:
 	"""
 	Entry point for `se version`.
 	"""
 
-	# Is distribution an editable install?
-	# Copied from a pip utility function which is not publicly accessible. See <https://stackoverflow.com/questions/42582801/check-whether-a-python-package-has-been-installed-in-editable-egg-link-mode>.
+	# This API is discussed in https://github.com/pypa/setuptools/issues/4186. At some point (python 3.12 or 13?), an origin method was added to Distribution, which allows this to be done without needing json, e.g.
+	# 	pkg_is_editable = Distribution.from_name("standardebooks").origin.dir_info.editable
+	direct_url = Distribution.from_name("standardebooks").read_text("direct_url.json")
+	pkg_is_editable = json.loads(direct_url).get("dir_info", {}).get("editable", False)	
 
-	print(f"{se.VERSION}")
+	se_version = f"{se.VERSION}"
+	if pkg_is_editable:
+		se_version += ", editable"
+
+	print(se_version)
 	return 0


### PR DESCRIPTION
See the comment for information on where this info came from. I took a guess on how you wanted the information displayed; just let me know if you want something different.

I obviously an editable installation, and this returns the correct value. But I don't have a non-editable one, so it needs to be tested on that as well. I don't how (or if) we can add a unit test for this.

mypy is complaining about direct_url, but I don't see how to resolve its complaint.