### PR TITLE
typogrify: “Tis -> “ ’Tis

### DIFF
--- a/se/typography.py
+++ b/se/typography.py
@@ -199,10 +199,10 @@ def typogrify(xhtml: str, smart_quotes: bool = True) -> str:
 	xhtml = regex.sub(r"c/o", "℅", xhtml, flags=regex.IGNORECASE)
 
 	# Sort out preceding `rsquo`s for `tis` / `twas` / `twere` / `twont’t`:
-	# 1. If there’s a missing quote (after a space or tag), add it.
+	# 1. If there’s a missing quote (after a space or tag or a left double-quote), add it.
 	# 2. If there’s a right double-quote assumed it should be an open and closing single quote pair.
 	contractions = r"[Tt]is|[Tt]was|[Tt]were|[Tt]won’t"
-	xhtml = regex.sub(fr"([\s>])({ contractions })\b", r"\1’\2", xhtml) # 1.
+	xhtml = regex.sub(fr"([\s>“])({ contractions })\b", r"\1’\2", xhtml) # 1.
 	xhtml = regex.sub(fr"”\b({ contractions })\b", r"‘’\1", xhtml)      # 2.
 
 	# Replace `M‘<letter>` with `Mc<letter>`; use of `lsquo` in this case is a historical case of a "poor man's superscript c". See <https://english.stackexchange.com/questions/543272/why-were-scottish-irish-names-once-rendered-with-apostrophes-instead-of-mac#543329>.

--- a/tests/draft_commands/typogrify/test-1/golden/typogrify.xhtml
+++ b/tests/draft_commands/typogrify/test-1/golden/typogrify.xhtml
@@ -33,6 +33,8 @@
 				<li>“ ’Tis</li>
 				<li>“ ’tis</li>
 				<li>“ ’Tis</li>
+				<li>“ ’tis</li>
+				<li>“ ’Tis</li>
 			</ul>
 			<!-- Remove space between number and fraction -->
 			<ul>

--- a/tests/draft_commands/typogrify/test-1/in/typogrify.xhtml
+++ b/tests/draft_commands/typogrify/test-1/in/typogrify.xhtml
@@ -33,6 +33,8 @@
 				<li>“'Tis</li>
 				<li>“’tis</li>
 				<li>“’Tis</li>
+				<li>“tis</li>
+				<li>“Tis</li>
 			</ul>
 			<!-- Remove space between number and fraction -->
 			<ul>


### PR DESCRIPTION
Teach typogrify about tis etc. directly after an opening left double-quote. It alread knows about tis after a space or after an opening tag.