### PR TITLE
typogrify: Have smartypants return unicode characters rather than HTM entities

### DIFF
--- a/se/typography.py
+++ b/se/typography.py
@@ -82,11 +82,9 @@ def typogrify(xhtml: str, smart_quotes: bool = True) -> str:
 		# When we encounter an actual `rsquo`, it's 99% correct as-is.
 		xhtml = xhtml.replace("’", "!#se:rsquo#!")
 
-		xhtml = smartypants.smartypants(xhtml) # `attr.u` *should* output unicode characters instead of HTML entities, but it doesn't work.
-
-		# Convert entities again.
-		xhtml = html.unescape(xhtml) # This converts HTML entities to unicode.
-		xhtml = regex.sub(r"&(?![#\p{Lowercase_Letter}]+;)", "&amp;", xhtml) # Oops! `html.unescape()` also unescapes plain ampersands...
+		# Have smartypants return unicode characters rather than HTML entities
+		attrs = smartypants.Attr.default | smartypants.Attr.u
+		xhtml = smartypants.smartypants(xhtml, attrs)
 
 	# Replace no-break hyphen with regular hyphen.
 	# We don't do this anymore and leave this check to `se find-unusual-characters`.


### PR DESCRIPTION
This has been on my round tuit list for years, and I finally had (took) some time to look at it. It turns out that any attributes you want added to the default handling have to be `and`ed with the default attributes (Attr.default), otherwise you end up with _only_ the attribute you specified. IOW, _just_ specifying Attr.u ends up with smartypants doing nothing, because all of the other options are turned off by setting attrs to Attr.u. No, this isn't well-documented. :)

I also confirmed (in the smartypants code and by experimentation) that the only entities it's replacing are the ones it uses—a short list of en/em dashes, left/right single/double quotes, and ellipsis—so, e.g., `&amp;`s are left alone.

Also, just as an FYI, smartypants handles backtick as left-quote, so the replacement at the top of `if smart_quotes` block isn't really needed.

smartypants has a new maintainer as of this year, so I may do some testing with the "em dash followed by open quotes" issue and if I can figure out an easy way to fix it in their code, submit a PR. (If you know/remember the specific circumstances of when that problem happens, that would be helpful, otherwise I'll just try several things to try to get it to happen.)