### PR TITLE
create-draft: Correct 'naive' transcriber sort

### DIFF
--- a/se/commands/create_draft.py
+++ b/se/commands/create_draft.py
@@ -779,7 +779,7 @@ def _create_draft(args: Namespace, plain_output: bool):
 						matches = regex.search(r"^([\p{Letter}]+) ([\p{Letter}]+)$", producer)
 
 						if matches:
-							contributor_file_as_node.set_text( f"{matches[1]}, {matches[2]}")
+							contributor_file_as_node.set_text( f"{matches[2]}, {matches[1]}")
 
 					# Known special cases.
 					if "David Widger" in producer:


### PR DESCRIPTION
As noted on the list, the "naive" sort of the transcribers left the names in the same position rather than reversing them.