### PR TITLE
clean: preserve pre whitespace

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -521,6 +521,10 @@ def _indent_children(elem, level, one_space, indentations, has_child_tails=False
 
 	# Recursively indent all children.
 	for child in elem:
+		# Pre elements preserve whitespace
+		if child.tag == "{http://www.w3.org/1999/xhtml}pre":
+			break
+
 		if len(child) > 0:
 			if has_child_tails:
 				next_level = level


### PR DESCRIPTION
We obviously don’t want any `pre` elements in production SE books, but dropping whitespace formatting at step 7 of the step-by-step guide makes things much more difficult later in the production process.