### PR TITLE
Ignore .eggs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 /build
 /dist
 /*.egg-info
+/.eggs
 /.pytest_cache
 /.vscode
 /todo


### PR DESCRIPTION
I’ve been manually ignoring this for years, but it occurred that it could be automatically ignored. I’m not sure why no-one else has mentioned this so far. Some artefact of how this works on Mac?