### PR TITLE
modernize-spelling: (over/dis)burthen -> (over/dis)burden

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -166,7 +166,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b([Bb])rand([\- ])new\b", r"\1rand\2new", xhtml)		# bran new -> brand new
 	xhtml = regex.sub(r"\b([Bb])rief case", r"\1riefcase", xhtml)			# brief case -> briefcase
 	xhtml = regex.sub(r"\b([Bb])rusk(ly|ness)?\b", r"\1rusque\2", xhtml)		# brusk(ly|ness) -> brusque(ly|ness)
-	xhtml = regex.sub(r"\b([Bb])urthen", r"\1urden", xhtml)				# burthen -> burden
+	xhtml = regex.sub(r"([Bb])urthen", r"\1urden", xhtml)				# (over/dis)burthen -> (over/dis)burden
 	xhtml = regex.sub(r"([Bb])ye?-and-([Bb])ye?\b", r"\1y-and-\2y", xhtml)		# by-and-bye, bye-and-by -> by-and-by (Note, may be capitalized in a song title)
 	xhtml = regex.sub(r"\b([Bb])y-by\b", r"\1ye-bye", xhtml)			# by-by -> bye-bye
 	xhtml = regex.sub(r"\b([Bb])ye?[\- ]the[\- ]bye?\b", r"\1y the by", xhtml)	# by-the-bye -> by the by


### PR DESCRIPTION
We were previously only copying with burthen -> burden.

Sorry for two PRs in quick succession, but this feels more obvious than https://github.com/standardebooks/tools/pull/948.

This is in the corpus in:
- anthony-trollope_can-you-forgive-her
- anthony-trollope_orley-farm
- edgar-allan-poe_short-fiction
- george-eliot_middlemarch
- h-p-lovecraft_short-fiction
- henry-fielding_the-history-of-tom-jones-a-foundling
- john-henry-newman_verses-on-various-occasions
- ludovico-ariosto_orlando-furioso_william-stewart-rose
- r-h-tawney_religion-and-the-rise-of-capitalism
- william-shakespeare_henry-vi-part-ii
- william-shakespeare_king-lear
