### PR TITLE
modernize-spelling: hæmorrhage -> haemorrhage

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -586,6 +586,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = xhtml.replace("Cæsar", r"Caesar")
 	xhtml = xhtml.replace("Crœsus", r"Croesus")
 	xhtml = regex.sub(r"\b([Ff])œtus", r"\1oetus", xhtml)
+	xhtml = regex.sub(r"\b([Hh])æmorrhage", r"\1aemorrhage", xhtml)
 	xhtml = regex.sub(r"\b([Hh])yæna", r"\1yena", xhtml)
 	xhtml = regex.sub(r"\b([Ll])arvæ", r"\1arvae", xhtml)
 	xhtml = xhtml.replace("Linnæus", r"Linnaeus")


### PR DESCRIPTION
This is in the corpus in four existing productions, will fix up if merged:

- aleksandr-kuprin_the-duel_george-allen-unwin
- d-h-lawrence_women-in-love
- john-rhode_the-murders-in-praed-street
- sigfrid-siwertz_downstream_e-classen