### PR TITLE
build(deps): Use oxipng-pybind for PNG Compression

### DIFF
--- a/se/images.py
+++ b/se/images.py
@@ -16,7 +16,7 @@ import regex
 from PIL import Image, ImageFont, ImageMath, PngImagePlugin, UnidentifiedImageError
 from PIL.Image import Image as Image_type # Separate import to satisfy type checking.
 from lxml import etree
-from oxipng import optimize # type: ignore Error in built-in type stub. # pylint: disable=no-name-in-module
+from oxipng import optimize
 
 import se
 import se.formatting

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
 		"pillow==12.2.0",
 		"psutil==7.2.2",
 		"pyphen==0.17.2",
-		"pyoxipng==9.1.1",
+		"oxipng-pybind==10.1.1.post1",
 		"regex==2026.2.28",
 		"repro_zipfile==0.4.1",
 		"requests==2.33.0",

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -4,10 +4,12 @@ Test internal SE programming functions
 
 from pathlib import Path
 
+from PIL import Image, ImageDraw
 import regex
 
 from se.se_epub_generate_toc import add_landmark, TocItem
 import se.easy_xml
+import se.images
 from se.se_epub_lint import SourceFile
 
 
@@ -53,6 +55,33 @@ def test_inner_text():
 	p = dom.xpath("//p")[0]
 
 	assert p.inner_text() == "a <b \tΑ c\nd"
+
+def test_optimize_png(tmp_path: Path):
+	"""
+	Verify the oxipng binding optimizes a PNG file in place without changing the image.
+	"""
+	image_path = tmp_path / "test.png"
+	image = Image.new("RGBA", (32, 32), (0, 0, 0, 0))
+	draw = ImageDraw.Draw(image)
+	draw.rectangle((4, 4, 18, 18), fill=(255, 0, 0, 255))
+	draw.ellipse((12, 12, 28, 28), fill=(0, 0, 255, 255))
+	image.save(image_path, compress_level=0)
+	original_size = image_path.stat().st_size
+
+	with Image.open(image_path) as original_image:
+		original_image.load()
+		original_pixels = original_image.convert("RGBA").tobytes()
+
+	se.images.optimize_png(image_path)
+
+	with Image.open(image_path) as optimized_image:
+		optimized_image.load()
+
+		assert optimized_image.format == "PNG"
+		assert optimized_image.size == (32, 32)
+		assert optimized_image.convert("RGBA").tobytes() == original_pixels
+
+	assert image_path.stat().st_size < original_size
 
 def test_line_numbers_no_comments():
 	"""


### PR DESCRIPTION
Replace pyoxipng with oxipng-pybind, which follows Rust oxipng v10+. 
Add se.images.optimize_png() unit test.

```
pyright se/images.py tests/test_internals.py: 0 errors
pylint se/images.py tests/test_internals.py: 10/10, exit 0
pytest tests/test_internals.py: 11 passed
```

Closes #969 