### PR TITLE
Skip se-lint-ignore.xml when writing epub file

### DIFF
--- a/se/epub.py
+++ b/se/epub.py
@@ -79,7 +79,7 @@ def write_epub(epub_root_absolute_path: Path, output_absolute_path: Path, last_u
 		epub.write(epub_root_absolute_path / "META-INF" / "container.xml", "META-INF/container.xml", compress_type=zipfile.ZIP_DEFLATED)
 
 		for file_path in sorted(epub_root_absolute_path.glob("**/*")):
-			if file_path.name not in ("mimetype", "container.xml"):
+			if file_path.name not in ("mimetype", "container.xml", "se-lint-ignore.xml"):
 				epub.write(file_path, file_path.relative_to(epub_root_absolute_path), compress_type=zipfile.ZIP_DEFLATED)
 
 	# Unset the timestamp environment variable that was set for ReproducibleZipFile.


### PR DESCRIPTION
It's easy to forget to remove se-lint-ignore.xml file when building epub ZIP container. This change makes sure the used-only-in-editing-workflow file is not included into the epub build meant for reading, and thus saves a manual cleanup step.

(Unless the file is meant to be included in the final epub ZIP container. In that case feel free to close this PR, but then a note about that in the manual might be useful.)