### PR TITLE
fix: clean not running on elements after pre

### DIFF
--- a/se/formatting.py
+++ b/se/formatting.py
@@ -522,7 +522,7 @@ def _indent_children(elem: etree.Element, level: int, one_space: str, indentatio
 	for child in elem:
 		# Pre elements preserve whitespace
 		if child.tag == "{http://www.w3.org/1999/xhtml}pre":
-			break
+			continue
 
 		if len(child) > 0:
 			if has_child_tails:


### PR DESCRIPTION
Given the scenario of clean running on a file with elements before and after a `pre` element, the nodes after will currently not be cleaned as we break out of the clean loop when we hit a pre element. We want, instead, to continue the loop after ignoring the `pre` (apart from indentation of the first line).