### PR TITLE
fix: attribute ordering in default templates

### DIFF
--- a/se/data/templates/colophon.xhtml
+++ b/se/data/templates/colophon.xhtml
@@ -9,7 +9,7 @@
 		<section id="colophon" epub:type="colophon">
 			<header>
 				<h2 epub:type="title">Colophon</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">TITLE</i><br/>
 			was published in <time>YEAR</time> by<br/>

--- a/se/data/templates/dramatis-personae.xhtml
+++ b/se/data/templates/dramatis-personae.xhtml
@@ -5,7 +5,7 @@
 		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
 	</head>
-	<body epub:type="frontmatter z3998:fiction z3998:drama">
+	<body epub:type="frontmatter z3998:drama z3998:fiction">
 		<section id="dramatis-personae" epub:type="z3998:dramatis-personae">
 			<h2 epub:type="title">Dramatis Personae</h2>
 			<ul>

--- a/se/data/templates/imprint.xhtml
+++ b/se/data/templates/imprint.xhtml
@@ -9,7 +9,7 @@
 		<section id="imprint" epub:type="imprint">
 			<header>
 				<h2 epub:type="title">Imprint</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p>This ebook is the product of many hours of hard work by volunteers for <a href="https://standardebooks.org/">Standard Ebooks</a>, and builds on the hard work of other literature lovers made possible by the public domain.</p>
 			<p>This particular ebook is based on a transcription from <a href="TRANSCRIPTION_URL">TRANSCRIPTION_SOURCE</a> and on digital scans from <a href="PAGE_SCANS_URL">PAGE_SCANS_SOURCE</a>.</p>

--- a/tests/file_commands/create-draft/test-1/golden/anonymous_beowulf_john-lesslie-hall/src/epub/text/colophon.xhtml
+++ b/tests/file_commands/create-draft/test-1/golden/anonymous_beowulf_john-lesslie-hall/src/epub/text/colophon.xhtml
@@ -9,7 +9,7 @@
 		<section id="colophon" epub:type="colophon">
 			<header>
 				<h2 epub:type="title">Colophon</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">Beowulf</i><br/>
 			was published in <time>YEAR</time>.<br/>

--- a/tests/file_commands/create-draft/test-1/golden/anonymous_beowulf_john-lesslie-hall/src/epub/text/imprint.xhtml
+++ b/tests/file_commands/create-draft/test-1/golden/anonymous_beowulf_john-lesslie-hall/src/epub/text/imprint.xhtml
@@ -9,7 +9,7 @@
 		<section id="imprint" epub:type="imprint">
 			<header>
 				<h2 epub:type="title">Imprint</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p>This ebook is the product of many hours of hard work by volunteers for <a href="https://standardebooks.org/">Standard Ebooks</a>, and builds on the hard work of other literature lovers made possible by the public domain.</p>
 			<p>This particular ebook is based on a transcription from <a href="TRANSCRIPTION_URL">TRANSCRIPTION_SOURCE</a> and on digital scans from <a href="PAGE_SCANS_URL">PAGE_SCANS_SOURCE</a>.</p>

--- a/tests/file_commands/create-draft/test-2/golden/edgar-allan-poe_the-narrative-of-arthur-gordon-pym-of-nantucket/src/epub/text/colophon.xhtml
+++ b/tests/file_commands/create-draft/test-2/golden/edgar-allan-poe_the-narrative-of-arthur-gordon-pym-of-nantucket/src/epub/text/colophon.xhtml
@@ -9,7 +9,7 @@
 		<section id="colophon" epub:type="colophon">
 			<header>
 				<h2 epub:type="title">Colophon</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">The Narrative of Arthur Gordon Pym of Nantucket</i><br/>
 			was published in <time>YEAR</time> by<br/>

--- a/tests/file_commands/create-draft/test-2/golden/edgar-allan-poe_the-narrative-of-arthur-gordon-pym-of-nantucket/src/epub/text/imprint.xhtml
+++ b/tests/file_commands/create-draft/test-2/golden/edgar-allan-poe_the-narrative-of-arthur-gordon-pym-of-nantucket/src/epub/text/imprint.xhtml
@@ -9,7 +9,7 @@
 		<section id="imprint" epub:type="imprint">
 			<header>
 				<h2 epub:type="title">Imprint</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p>This ebook is the product of many hours of hard work by volunteers for <a href="https://standardebooks.org/">Standard Ebooks</a>, and builds on the hard work of other literature lovers made possible by the public domain.</p>
 			<p>This particular ebook is based on a transcription from <a href="TRANSCRIPTION_URL">TRANSCRIPTION_SOURCE</a> and on digital scans from <a href="PAGE_SCANS_URL">PAGE_SCANS_SOURCE</a>.</p>

--- a/tests/file_commands/create-draft/test-3/golden/omar-khayyam_the-rubaiyat-of-omar-khayyam_edward-fitzgerald/src/epub/text/colophon.xhtml
+++ b/tests/file_commands/create-draft/test-3/golden/omar-khayyam_the-rubaiyat-of-omar-khayyam_edward-fitzgerald/src/epub/text/colophon.xhtml
@@ -9,7 +9,7 @@
 		<section id="colophon" epub:type="colophon">
 			<header>
 				<h2 epub:type="title">Colophon</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">The Rubáiyát of Omar Khayyám</i><br/>
 			was published in <time>YEAR</time> by<br/>

--- a/tests/file_commands/create-draft/test-3/golden/omar-khayyam_the-rubaiyat-of-omar-khayyam_edward-fitzgerald/src/epub/text/imprint.xhtml
+++ b/tests/file_commands/create-draft/test-3/golden/omar-khayyam_the-rubaiyat-of-omar-khayyam_edward-fitzgerald/src/epub/text/imprint.xhtml
@@ -9,7 +9,7 @@
 		<section id="imprint" epub:type="imprint">
 			<header>
 				<h2 epub:type="title">Imprint</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p>This ebook is the product of many hours of hard work by volunteers for <a href="https://standardebooks.org/">Standard Ebooks</a>, and builds on the hard work of other literature lovers made possible by the public domain.</p>
 			<p>This particular ebook is based on a transcription from <a href="TRANSCRIPTION_URL">TRANSCRIPTION_SOURCE</a> and on digital scans from <a href="PAGE_SCANS_URL">PAGE_SCANS_SOURCE</a>.</p>

--- a/tests/file_commands/create-draft/test-4/golden/selma-lagerlof_the-story-of-gosta-berling_pauline-bancroft-flach/src/epub/text/colophon.xhtml
+++ b/tests/file_commands/create-draft/test-4/golden/selma-lagerlof_the-story-of-gosta-berling_pauline-bancroft-flach/src/epub/text/colophon.xhtml
@@ -9,7 +9,7 @@
 		<section id="colophon" epub:type="colophon">
 			<header>
 				<h2 epub:type="title">Colophon</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">The Story of Gösta Berling</i><br/>
 			was published in <time>YEAR</time> by<br/>

--- a/tests/file_commands/create-draft/test-4/golden/selma-lagerlof_the-story-of-gosta-berling_pauline-bancroft-flach/src/epub/text/imprint.xhtml
+++ b/tests/file_commands/create-draft/test-4/golden/selma-lagerlof_the-story-of-gosta-berling_pauline-bancroft-flach/src/epub/text/imprint.xhtml
@@ -9,7 +9,7 @@
 		<section id="imprint" epub:type="imprint">
 			<header>
 				<h2 epub:type="title">Imprint</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p>This ebook is the product of many hours of hard work by volunteers for <a href="https://standardebooks.org/">Standard Ebooks</a>, and builds on the hard work of other literature lovers made possible by the public domain.</p>
 			<p>This particular ebook is based on a transcription from <a href="TRANSCRIPTION_URL">TRANSCRIPTION_SOURCE</a> and on digital scans from <a href="PAGE_SCANS_URL">PAGE_SCANS_SOURCE</a>.</p>

--- a/tests/file_commands/create-draft/test-5/golden/william-wordsworth_samuel-taylor-coleridge_lyrical-ballads/src/epub/text/colophon.xhtml
+++ b/tests/file_commands/create-draft/test-5/golden/william-wordsworth_samuel-taylor-coleridge_lyrical-ballads/src/epub/text/colophon.xhtml
@@ -9,7 +9,7 @@
 		<section id="colophon" epub:type="colophon">
 			<header>
 				<h2 epub:type="title">Colophon</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">Lyrical Ballads</i><br/>
 			was published in <time>YEAR</time> by<br/>

--- a/tests/file_commands/create-draft/test-5/golden/william-wordsworth_samuel-taylor-coleridge_lyrical-ballads/src/epub/text/imprint.xhtml
+++ b/tests/file_commands/create-draft/test-5/golden/william-wordsworth_samuel-taylor-coleridge_lyrical-ballads/src/epub/text/imprint.xhtml
@@ -9,7 +9,7 @@
 		<section id="imprint" epub:type="imprint">
 			<header>
 				<h2 epub:type="title">Imprint</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p>This ebook is the product of many hours of hard work by volunteers for <a href="https://standardebooks.org/">Standard Ebooks</a>, and builds on the hard work of other literature lovers made possible by the public domain.</p>
 			<p>This particular ebook is based on a transcription from <a href="TRANSCRIPTION_URL">TRANSCRIPTION_SOURCE</a> and on digital scans from <a href="PAGE_SCANS_URL">PAGE_SCANS_SOURCE</a>.</p>

--- a/tests/file_commands/create-draft/test-6/golden/karl-marx_friedrich-engels_the-communist-manifesto_samuel-moore/src/epub/text/colophon.xhtml
+++ b/tests/file_commands/create-draft/test-6/golden/karl-marx_friedrich-engels_the-communist-manifesto_samuel-moore/src/epub/text/colophon.xhtml
@@ -9,7 +9,7 @@
 		<section id="colophon" epub:type="colophon">
 			<header>
 				<h2 epub:type="title">Colophon</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">The Communist Manifesto</i><br/>
 			was published in <time>YEAR</time> by<br/>

--- a/tests/file_commands/create-draft/test-6/golden/karl-marx_friedrich-engels_the-communist-manifesto_samuel-moore/src/epub/text/imprint.xhtml
+++ b/tests/file_commands/create-draft/test-6/golden/karl-marx_friedrich-engels_the-communist-manifesto_samuel-moore/src/epub/text/imprint.xhtml
@@ -9,7 +9,7 @@
 		<section id="imprint" epub:type="imprint">
 			<header>
 				<h2 epub:type="title">Imprint</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p>This ebook is the product of many hours of hard work by volunteers for <a href="https://standardebooks.org/">Standard Ebooks</a>, and builds on the hard work of other literature lovers made possible by the public domain.</p>
 			<p>This particular ebook is based on a transcription from <a href="TRANSCRIPTION_URL">TRANSCRIPTION_SOURCE</a> and on digital scans from <a href="PAGE_SCANS_URL">PAGE_SCANS_SOURCE</a>.</p>

--- a/tests/file_commands/create-draft/test-7/golden/abu-al-ala-al-maarri_the-luzumiyat_ameen-rihani/src/epub/text/colophon.xhtml
+++ b/tests/file_commands/create-draft/test-7/golden/abu-al-ala-al-maarri_the-luzumiyat_ameen-rihani/src/epub/text/colophon.xhtml
@@ -9,7 +9,7 @@
 		<section id="colophon" epub:type="colophon">
 			<header>
 				<h2 epub:type="title">Colophon</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">The Luzumiyat</i><br/>
 			was published in <time>YEAR</time> by<br/>

--- a/tests/file_commands/create-draft/test-7/golden/abu-al-ala-al-maarri_the-luzumiyat_ameen-rihani/src/epub/text/imprint.xhtml
+++ b/tests/file_commands/create-draft/test-7/golden/abu-al-ala-al-maarri_the-luzumiyat_ameen-rihani/src/epub/text/imprint.xhtml
@@ -9,7 +9,7 @@
 		<section id="imprint" epub:type="imprint">
 			<header>
 				<h2 epub:type="title">Imprint</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p>This ebook is the product of many hours of hard work by volunteers for <a href="https://standardebooks.org/">Standard Ebooks</a>, and builds on the hard work of other literature lovers made possible by the public domain.</p>
 			<p>This particular ebook is based on a transcription from <a href="TRANSCRIPTION_URL">TRANSCRIPTION_SOURCE</a> and on digital scans from <a href="PAGE_SCANS_URL">PAGE_SCANS_SOURCE</a>.</p>

--- a/tests/file_commands/create-draft/test-8/golden/hans-jakob-christoffel-von-grimmelshausen_the-adventurous-simplicissimus_alfred-thomas-scrope-goodrick/src/epub/text/colophon.xhtml
+++ b/tests/file_commands/create-draft/test-8/golden/hans-jakob-christoffel-von-grimmelshausen_the-adventurous-simplicissimus_alfred-thomas-scrope-goodrick/src/epub/text/colophon.xhtml
@@ -9,7 +9,7 @@
 		<section id="colophon" epub:type="colophon">
 			<header>
 				<h2 epub:type="title">Colophon</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">The Adventurous Simplicissimus</i><br/>
 			was published in <time>YEAR</time> by<br/>

--- a/tests/file_commands/create-draft/test-8/golden/hans-jakob-christoffel-von-grimmelshausen_the-adventurous-simplicissimus_alfred-thomas-scrope-goodrick/src/epub/text/imprint.xhtml
+++ b/tests/file_commands/create-draft/test-8/golden/hans-jakob-christoffel-von-grimmelshausen_the-adventurous-simplicissimus_alfred-thomas-scrope-goodrick/src/epub/text/imprint.xhtml
@@ -9,7 +9,7 @@
 		<section id="imprint" epub:type="imprint">
 			<header>
 				<h2 epub:type="title">Imprint</h2>
-				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
+				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="se:image.color-depth.black-on-transparent z3998:publisher-logo"/>
 			</header>
 			<p>This ebook is the product of many hours of hard work by volunteers for <a href="https://standardebooks.org/">Standard Ebooks</a>, and builds on the hard work of other literature lovers made possible by the public domain.</p>
 			<p>This particular ebook is based on a transcription from <a href="TRANSCRIPTION_URL">TRANSCRIPTION_SOURCE</a> and on digital scans from <a href="PAGE_SCANS_URL">PAGE_SCANS_SOURCE</a>.</p>


### PR DESCRIPTION
Attributes are alphabetically ordered starting from 3.0.4, so this saves a clean step.