### PR TITLE
build: fix Kobo build on links with &amp; entities

### DIFF
--- a/se/easy_xml.py
+++ b/se/easy_xml.py
@@ -97,6 +97,9 @@ class EasyXmlElement:
 				for namespace, identifier in self.namespaces.items():
 					short_name = short_name.replace(f"{{{identifier}}}", f"{namespace}:")
 
+				# Reinstate potentially necessary entities that LXML has stripped
+				value = value.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+
 				attrs += f" {short_name}=\"{value}\""
 
 		tag_name: str = str(self.lxml_element.tag)


### PR DESCRIPTION
Calling items on an etree.Element converts entities to characters. This is fine for most things, but ampersands are used in query strings and cause the Kobo build to fail with XML errors. This adds them back in before writing the string out. I’ve included angle brackets too as they’re the other potential characters we don’t want stripped.

We don’t typically have query string links in our books so we haven’t seen it before, but it turned up in a white label production.