### PR TITLE
Use EPUB Core media types for binary files

### DIFF
--- a/se/se_epub.py
+++ b/se/se_epub.py
@@ -1722,20 +1722,45 @@ class SeEpub:
 			mime_type = None
 			properties: list[str] = []
 
-			if file_path.suffix == ".css":
-				mime_type="text/css"
+			# Add core media types: https://www.w3.org/TR/epub/#sec-core-media-types
+			if file_path.suffix == ".gif":
+				mime_type = "image/gif"
 
-			if file_path.suffix in (".ttf", ".otf", ".woff", ".woff2"):
-				mime_type="application/vnd.ms-opentype"
-
-			if file_path.suffix == ".svg":
-				mime_type = "image/svg+xml"
+			if file_path.suffix == ".jpg":
+				mime_type = "image/jpeg"
 
 			if file_path.suffix == ".png":
 				mime_type = "image/png"
 
-			if file_path.suffix == ".jpg":
-				mime_type = "image/jpeg"
+			if file_path.suffix == ".svg":
+				mime_type = "image/svg+xml"
+
+			if file_path.suffix == ".webp":
+				mime_type = "image/webp"
+
+			if file_path.suffix == ".mp3":
+				mime_type = "audio/mpeg"
+
+			if file_path.suffix == ".mp4":
+				mime_type = "audio/mp4"
+
+			if file_path.suffix == ".ogg":
+				mime_type = "audio/ogg; codecs=opus"
+
+			if file_path.suffix == ".css":
+				mime_type="text/css"
+
+			if file_path.suffix == ".ttf":
+				mime_type="application/font-sfnt"
+
+			if file_path.suffix == ".otf":
+				mime_type="application/vnd.ms-opentype"
+
+			if file_path.suffix == ".woff":
+				mime_type="font/woff"
+
+			if file_path.suffix == ".woff2":
+				mime_type="font/woff2"
 
 			if file_path.stem == "cover":
 				properties.append("cover-image")

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -106,7 +106,8 @@ SE_SEMANTIC_VOCABULARY = ["bridgehead", "collection", "compass", "compound", "di
 
 SE_GENRES = ["Adventure", "Autobiography", "Biography", "Children’s", "Comedy", "Drama", "Fantasy", "Fiction", "Horror", "Memoir", "Mystery", "Nonfiction", "Philosophy", "Poetry", "Satire", "Science Fiction", "Shorts", "Spirituality", "Tragedy", "Travel"]
 IGNORED_CLASSES = ["continued", "dl2", "dl3", "elision", "eoc", "full-page", "together", "telegram"]
-BINARY_EXTENSIONS = [".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".png", ".epub", ".xcf", ".otf", ".jp2"]
+BINARY_IMAGE_EXTENSIONS = [".bmp", ".gif", ".jp2", ".jpg", ".jpeg", ".png", ".tif", ".tiff", ".webp", ".xcf"]
+BINARY_OTHER_EXTENSIONS = [".mp3", ".mp4", ".ogg", ".ttf", ".otf", ".woff", ".woff2", ".epub"]
 IGNORED_FILENAMES = ["colophon.xhtml", "titlepage.xhtml", "imprint.xhtml", "uncopyright.xhtml", "toc.xhtml", "loi.xhtml"]
 SPECIAL_FILES = ["colophon", "endnotes", "imprint", "loi"]
 
@@ -3987,9 +3988,11 @@ def lint(self: 'SeEpub', skip_lint_ignore: bool, allowed_messages: list[str] | N
 			if "-0" in file_path.name:
 				messages.append(LintMessage("f-009", "Illegal leading [text]0[/] in filename.", se.MESSAGE_TYPE_ERROR, file_path))
 
-			if file_path.suffix in BINARY_EXTENSIONS or file_path.name == "core.css":
-				if file_path.suffix in (".jpg", ".jpeg", ".tif", ".tiff", ".png"):
-					messages += _lint_image_checks(self, file_path)
+			if file_path.suffix in BINARY_IMAGE_EXTENSIONS:
+				messages += _lint_image_checks(self, file_path)
+				continue
+
+			if file_path.suffix in BINARY_OTHER_EXTENSIONS or file_path.name == "core.css":
 				continue
 
 			# Read the file and start doing some serious checks!

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -11,6 +11,9 @@ import subprocess
 from pathlib import Path
 import pytest
 
+BINARY_IMAGE_EXTENSIONS = [".bmp", ".gif", ".jp2", ".jpg", ".jpeg", ".png", ".tif", ".tiff", ".webp", ".xcf"]
+BINARY_OTHER_EXTENSIONS = [".mp3", ".mp4", ".ogg", ".ttf", ".otf", ".woff", ".woff2", ".epub"]
+
 def fail_test(message: str) -> None:
 	"""
 	Fail a test with a clean message and without pytest showing helper internals.
@@ -265,10 +268,10 @@ def build_is_golden(build_dir: Path, extract_dir: Path, golden_dir: Path, update
 			# Extract files are checked as normal, i.e. for equality.
 			extract_same = list(set(extract_files).intersection(golden_extract_files))
 			for file in extract_same:
-				# Image files are not UTF-8, and a dump is not useful, so let filecmp handle them.
-				if file.suffix in (".bmp", ".jpg", ".png", ".tif"):
+				# Image and font files are not UTF-8, and a dump is not useful, so let filecmp handle them.
+				if file.suffix in BINARY_IMAGE_EXTENSIONS or file.suffix in BINARY_OTHER_EXTENSIONS:
 					if not filecmp.cmp(extract_dir / file, golden_extract_dir / file):
-						fail_test(f"Extract image file mismatch.{_format_test_context(test_context)}\n\nFile: {file}")
+						fail_test(f"Extract image or font file mismatch.{_format_test_context(test_context)}\n\nFile: {file}")
 				else:
 					with open(golden_extract_dir / file, encoding="utf-8") as gfile:
 						golden_text = gfile.read()
@@ -343,10 +346,10 @@ def files_are_golden(command: str, in_dir: Path, results_dir: Path, golden_dir: 
 
 		# files in both are compared for equality
 		for file in results_same:
-			# image files aren't utf-8, and a dump isn't useful, so let filecmp handle them
-			if file.suffix in (".bmp", ".jpg", ".png", ".tif"):
+			# image or font files aren't utf-8, and a dump isn't useful, so let filecmp handle them
+			if file.suffix in BINARY_IMAGE_EXTENSIONS or file.suffix in BINARY_OTHER_EXTENSIONS:
 				if not filecmp.cmp(results_dir / file, golden_dir / file):
-					fail_test(f"Results image file mismatch.{_format_test_context(test_context)}\n\nFile: {file}")
+					fail_test(f"Results image or font file mismatch.{_format_test_context(test_context)}\n\nFile: {file}")
 			else:
 				with open(golden_dir / file, encoding="utf-8") as gfile:
 					golden_text = gfile.read()


### PR DESCRIPTION
This updates the toolset to handle correctly the file types stipulated at https://www.w3.org/TR/epub/#sec-core-media-types, with the exception of scripts, legacy NCX files, and SMIL files.

For testing I’ve chucked in [Google Tofu](https://github.com/googlefonts/tofu) as it’s very small, but happy to amend that if you’d like.