### PR TITLE
Add a couple of MusicXML lint rules

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -271,6 +271,7 @@ METADATA
 "m-089", "Ignore rule ignores the same line more than once."
 "m-090", "[val]dedication[/] semantic inflection found, but no MARC relator [val]dto[/] (Dedicator)."
 "m-091", "Possibly misspelled MARC relator found."
+"m-092", "MusicXML files found, but no MARC relator [val]mcp[/] (Music copyist)."
 
 SEMANTICS & CONTENT
 "s-001", "Illegal numeric entity."
@@ -4008,6 +4009,10 @@ def lint(self: 'SeEpub', skip_lint_ignore: bool, allowed_messages: list[str] | N
 
 			# Remove comments before we do any further processing.
 			source_file = source_file.sub(regex.compile(r"<!--.+?-->", flags=regex.DOTALL), "")
+
+			# Check for MusicXML associated role
+			if file_path.suffix == ".musicxml" and not self.metadata_dom.xpath("/package/metadata/meta[(@property='role') and text()='mcp']"):
+				messages.append(LintMessage("m-092", "MusicXML files found, but no MARC relator [val]mcp[/] (Music copyist).", se.MESSAGE_TYPE_WARNING, file_path))
 
 			# Ignore XML files in `./images/` because we don't care how *source* SVGs/MusicXML are internally formatted.
 			if not file_path.is_relative_to(self.path / "images"):

--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -161,6 +161,7 @@ FILESYSTEM
 "f-001", "Illegal file or directory."
 "f-002", "Missing expected file or directory."
 "f-003", "File doesn’t match template."
+"f-004", "MusicXML files must end in [path].musicxml[/]."
 "f-007", "File not listed in [xml]<spine>[/]."
 "f-008", "Filename is not URL-safe."
 "f-009", "Illegal leading [text]0[/] in filename."
@@ -174,7 +175,6 @@ FILESYSTEM
 "f-018", "Image greater than 4,000,000 pixels square in dimension."
 "f-019", "[path].png[/] file without transparency. Hint: If an image doesn’t have transparency, it should be saved as a [path].jpg[/]."
 UNUSEDvvvvvvvvvvvvvvvvv
-"f-004", ""
 "f-005", ""
 "f-006", ""
 "f-014", ""
@@ -4010,7 +4010,10 @@ def lint(self: 'SeEpub', skip_lint_ignore: bool, allowed_messages: list[str] | N
 			# Remove comments before we do any further processing.
 			source_file = source_file.sub(regex.compile(r"<!--.+?-->", flags=regex.DOTALL), "")
 
-			# Check for MusicXML associated role
+			# Check for potential MusicXML errors
+			if file_path.suffix == ".xml" and source_file.findall("http://www.musicxml.org/dtds/"):
+				messages.append(LintMessage("f-004", "MusicXML files must end in [path].musicxml[/].", se.MESSAGE_TYPE_ERROR, file_path))
+
 			if file_path.suffix == ".musicxml" and not self.metadata_dom.xpath("/package/metadata/meta[(@property='role') and text()='mcp']"):
 				messages.append(LintMessage("m-092", "MusicXML files found, but no MARC relator [val]mcp[/] (Music copyist).", se.MESSAGE_TYPE_WARNING, file_path))
 


### PR DESCRIPTION
MusicXML files need to have a `.musicxml` extension (see https://www.w3.org/2021/06/musicxml40/tutorial/compressed-mxl-files/#file-suffixes-and-media-types), and we should credit the music transcribers with a `mcp` role.

I’ll sweep the corpus for offenders if / when it’s merged.