### PR TITLE
compare-versions: Safari support

### DIFF
--- a/se/commands/compare_versions.py
+++ b/se/commands/compare_versions.py
@@ -61,15 +61,19 @@ def _screenshot_html_element(browser: 'Browser', filename: Path, output_path: Pa
 		try:
 			browser.driver.find_element("tag name", "html").screenshot(str(output_path)) # pyright: ignore Broken Selenium type hint here.
 		except WebDriverException:
-			# Firefox might throw an exception of the viewport is too large. In that case, fall back to a special function to stich to together viewport-sized screenshots.
-			_screenshot_firefox_full_page(browser, output_path)
+			# Firefox might throw an exception of the viewport is too large. In that case, fall back to a special function to stitch to together viewport-sized screenshots.
+			_screenshot_firefox_or_safari_full_page(browser, output_path)
+
+	# Safari needs to stitch together multiple screenshots to produce a full page image
+	elif browser.type == BrowserType.SAFARI:
+		_screenshot_firefox_or_safari_full_page(browser, output_path)
 
 	else:
 		raise se.MissingDependencyException("Couldn't initialize default web browser.")
 
-def _screenshot_firefox_full_page(browser: 'Browser', output_path: Path) -> None:
+def _screenshot_firefox_or_safari_full_page(browser: 'Browser', output_path: Path) -> None:
 	"""
-	Save a full-page Firefox screenshot by stitching together viewport-sized screenshots.
+	Save a full-page Firefox or Safari screenshot by stitching together viewport-sized screenshots.
 	"""
 
 	get_dimensions_script = """


### PR DESCRIPTION
This works in as much as it loads a browser (not headless of course), screenshots full pages, and diffs them. Safaridriver doesn’t have full page support of course, but the Firefox fallback function works.

Having said that, we have some problems. I had some unexpected hangs on _Goriot_ where it did nothing for minutes on end. But worse, the diffs seem unreliable. E.g. here’s a diff of _Goriot_’s dedication page where I made no change:

<img width="1600" height="1200" alt="An screenshot of a dedication page with a big red blob at the top." src="https://github.com/user-attachments/assets/ad5f1635-d34d-4fb0-907c-5a6c55a69c72" />

For the main file I added a single letter at the end. Safaridriver produced a 76MB PNG for that that appears to be corrupt, or at any rate none of the image editing software I have can edit it.

So I’d say that we specifically don’t want to merge this. But putting it up for consideration anyway.