### PR TITLE
lint: for duplicate contributor entries to the same domain

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -15,6 +15,7 @@ import os
 from pathlib import Path
 import importlib.resources
 from typing import TYPE_CHECKING, cast
+from urllib.parse import urlsplit
 from unidecode import unidecode
 
 import cssutils
@@ -281,6 +282,7 @@ METADATA
 "m-090", "[val]dedication[/] semantic inflection found, but no MARC relator [val]dto[/] (Dedicator)."
 "m-091", "Possibly misspelled MARC relator found."
 "m-092", "MusicXML files found, but no MARC relator [val]mcp[/] (Music copyist)."
+"m-093", "A single contributor has multiple schema:sameAs URLs to the same site."
 
 SEMANTICS & CONTENT
 "s-001", "Illegal numeric entity."
@@ -1208,6 +1210,38 @@ def _lint_metadata_checks(self: 'SeEpub') -> list[LintMessage]:
 
 	if invalid_marc_relators_nodes:
 		messages.append(LintMessage("m-091", "Possibly misspelled MARC relator found.", se.MESSAGE_TYPE_ERROR, self.metadata_file_path, LintSubmessage.from_node_text(invalid_marc_relators_nodes)))
+
+	# Check for single contributors that have multiple schema:sameAs URLs pointing at the same site
+	nodes = self.metadata_dom.xpath("/package/metadata/link[@rel='schema:sameAs']")
+	same_as_entries: dict[str, list[tuple[str, 'EasyXmlElement']]] = {}
+	# Group entries by role
+	for node in nodes:
+		refines = node.get_attr("refines", False)
+		domain = ''
+		href = node.get_attr("href", False)
+		if href:
+			domain = urlsplit(href).netloc
+
+		if refines and domain:
+			if not refines in same_as_entries:
+				same_as_entries[refines] = []
+			same_as_entries[refines].append((domain, node))
+
+	# Check to see if each group has duplicate domains
+	for _, v in same_as_entries.items():
+		domains: list[str] = []
+		for entry in v:
+			domains.append(entry[0])
+
+		duplicate_domains = {domain for domain in domains if domains.count(domain) > 1}
+
+		invalid_nodes: list['EasyXmlElement'] = []
+		for entry in v:
+			if entry[0] in duplicate_domains:
+				invalid_nodes.append(entry[1])
+
+		if invalid_nodes:
+			messages.append(LintMessage("m-093", "A single contributor has multiple schema:sameAs URLs to the same site.", se.MESSAGE_TYPE_ERROR, self.metadata_file_path, LintSubmessage.from_nodes(invalid_nodes)))
 
 	return messages
 

--- a/tests/lint/metadata/m-093/golden/m-093-out.txt
+++ b/tests/lint/metadata/m-093/golden/m-093-out.txt
@@ -1,0 +1,6 @@
+m-093 [Error] content.opf A single contributor has multiple schema:sameAs URLs to the same site.
+ Line 56:       <link href="https://id.loc.gov/authorities/names/n79032879.html" refines="#author" rel="schema:sameAs"/>
+ Line 57:       <link href="https://id.loc.gov/authorities/names/n79032880.html" refines="#author" rel="schema:sameAs"/>
+m-093 [Error] content.opf A single contributor has multiple schema:sameAs URLs to the same site.
+ Line 61:       <link href="https://en.wikipedia.org/wiki/Georg_Friedrich_Kersting" refines="#artist" rel="schema:sameAs"/>
+ Line 62:       <link href="https://en.wikipedia.org/wiki/Georg_Friedrich_Kersting_Jr." refines="#artist" rel="schema:sameAs"/>

--- a/tests/lint/metadata/m-093/in/src/epub/content.opf
+++ b/tests/lint/metadata/m-093/in/src/epub/content.opf
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" dir="ltr" prefix="rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#" unique-identifier="uid" version="3.0" xml:lang="en-US">
+	<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+		<dc:identifier id="uid">https://standardebooks.org/ebooks/jane-austen/unknown-novel</dc:identifier>
+		<dc:date>1900-01-01T00:00:00Z</dc:date>
+		<meta property="dcterms:modified">1900-01-01T00:00:00Z</meta>
+		<dc:rights>The source text and artwork in this ebook are believed to be in the United States public domain; that is, they are believed to be free of copyright restrictions in the United States. They may still be copyrighted in other countries, so users located outside of the United States must check their local laws before using this ebook. The creators of, and contributors to, this ebook dedicate their contributions to the worldwide public domain via the terms in the [CC0 1.0 Universal Public Domain Dedication](https://creativecommons.org/publicdomain/zero/1.0/).</dc:rights>
+		<meta property="rdf:type">http://schema.org/Book</meta>
+		<dc:publisher id="publisher">Standard Ebooks</dc:publisher>
+		<meta property="file-as" refines="#publisher">Standard Ebooks</meta>
+		<link href="https://standardebooks.org/" refines="#publisher" rel="schema:url"/>
+		<meta property="role" refines="#publisher" scheme="marc:relators">bkd</meta>
+		<meta property="role" refines="#publisher" scheme="marc:relators">mdc</meta>
+		<meta property="role" refines="#publisher" scheme="marc:relators">pbl</meta>
+		<dc:contributor id="type-designer">The League of Moveable Type</dc:contributor>
+		<meta property="file-as" refines="#type-designer">League of Moveable Type, The</meta>
+		<link href="https://www.theleagueofmoveabletype.com/" refines="#type-designer" rel="schema:url"/>
+		<meta property="role" refines="#type-designer" scheme="marc:relators">tyd</meta>
+		<link href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa" rel="dcterms:conformsTo"/>
+		<meta property="a11y:certifiedBy">Standard Ebooks</meta>
+		<meta property="schema:accessMode">textual</meta>
+		<meta property="schema:accessModeSufficient">textual</meta>
+		<meta property="schema:accessibilityFeature">alternativeText</meta>
+		<meta property="schema:accessibilityFeature">displayTransformability</meta>
+		<meta property="schema:accessibilityFeature">readingOrder</meta>
+		<meta property="schema:accessibilityFeature">structuralNavigation</meta>
+		<meta property="schema:accessibilityFeature">tableOfContents</meta>
+		<meta property="schema:accessibilityFeature">unlocked</meta>
+		<meta property="schema:accessibilityHazard">none</meta>
+		<meta property="schema:accessibilitySummary">This publication conforms to WCAG 2.2 Level AA.</meta>
+		<dc:title id="title">Unknown Novel</dc:title>
+		<meta property="file-as" refines="#title">Unknown Novel</meta>
+		<dc:subject id="subject-1">England--Social life and customs--19th century--Fiction</dc:subject>
+		<dc:subject id="subject-2">Sisters -- Fiction</dc:subject>
+		<meta property="authority" refines="#subject-1">LCSH</meta>
+		<meta property="term" refines="#subject-1">sh2008114941</meta>
+		<meta property="authority" refines="#subject-2">LCSH</meta>
+		<meta property="term" refines="#subject-2">sh2008111400</meta>
+		<meta property="schema:genre">Fiction</meta>
+		<dc:abstract>A short test novel for lint testing.</dc:abstract>
+		<dc:description>
+			&lt;p&gt;A short test novel for lint testing.&lt;/p&gt;
+		</dc:description>
+		<dc:language>en-GB</dc:language>
+		<dc:source>https://www.gutenberg.org/ebooks/161</dc:source>
+		<dc:source>https://archive.org/details/bub_gb_RtT0OLKFMHsC</dc:source>
+		<meta property="schema:wordCount">WORD_COUNT</meta>
+		<meta property="schema:educationalLevel">READING_EASE</meta>
+		<link href="https://en.wikipedia.org/wiki/Unknown_Jane_Austen_Novel" rel="schema:sameAs"/>
+		<meta id="vcs-repository" property="schema:workExample">schema:workExample</meta>
+		<meta property="rdf:type" refines="#vcs-repository">http://schema.org/SoftwareSourceCode</meta>
+		<link href="https://github.com/standardebooks/jane-austen_unknown-novel" refines="#vcs-repository" rel="schema:codeRepository"/>
+		<dc:creator id="author">Jane Austen</dc:creator>
+		<meta property="file-as" refines="#author">Austen, Jane</meta>
+		<link href="https://en.wikipedia.org/wiki/Jane_Austen" refines="#author" rel="schema:sameAs"/>
+		<link href="https://id.loc.gov/authorities/names/n79032879.html" refines="#author" rel="schema:sameAs"/>
+		<link href="https://id.loc.gov/authorities/names/n79032880.html" refines="#author" rel="schema:sameAs"/>
+		<meta property="role" refines="#author" scheme="marc:relators">aut</meta>
+		<dc:contributor id="artist">Georg Friedrich Kersting</dc:contributor>
+		<meta property="file-as" refines="#artist">Kersting, Georg Friedrich</meta>
+		<link href="https://en.wikipedia.org/wiki/Georg_Friedrich_Kersting" refines="#artist" rel="schema:sameAs"/>
+		<link href="https://en.wikipedia.org/wiki/Georg_Friedrich_Kersting_Jr." refines="#artist" rel="schema:sameAs"/>
+		<link href="https://id.loc.gov/authorities/names/n83319941.html" refines="#artist" rel="schema:sameAs"/>
+		<meta property="role" refines="#artist" scheme="marc:relators">art</meta>
+		<dc:contributor id="transcriber-1">Anonymous</dc:contributor>
+		<meta property="file-as" refines="#transcriber-1">Anonymous</meta>
+		<meta property="role" refines="#transcriber-1" scheme="marc:relators">trc</meta>
+		<dc:contributor id="producer-1">John Doe</dc:contributor>
+		<meta property="file-as" refines="#producer-1">Doe, John</meta>
+		<meta property="role" refines="#producer-1" scheme="marc:relators">bkp</meta>
+		<meta property="role" refines="#producer-1" scheme="marc:relators">blw</meta>
+		<meta property="role" refines="#producer-1" scheme="marc:relators">cov</meta>
+		<meta property="role" refines="#producer-1" scheme="marc:relators">mrk</meta>
+		<meta property="role" refines="#producer-1" scheme="marc:relators">pfr</meta>
+		<meta property="role" refines="#producer-1" scheme="marc:relators">tyg</meta>
+	</metadata>
+	<manifest>
+		<item href="css/core.css" id="core.css" media-type="text/css"/>
+		<item href="css/local.css" id="local.css" media-type="text/css"/>
+		<item href="css/se.css" id="se.css" media-type="text/css"/>
+		<item href="images/cover.svg" id="cover.svg" media-type="image/svg+xml" properties="cover-image"/>
+		<item href="images/logo.svg" id="logo.svg" media-type="image/svg+xml"/>
+		<item href="images/titlepage.svg" id="titlepage.svg" media-type="image/svg+xml"/>
+		<item href="text/chapter-1.xhtml" id="chapter-1.xhtml" media-type="application/xhtml+xml"/>
+		<item href="text/colophon.xhtml" id="colophon.xhtml" media-type="application/xhtml+xml" properties="svg"/>
+		<item href="text/imprint.xhtml" id="imprint.xhtml" media-type="application/xhtml+xml" properties="svg"/>
+		<item href="text/titlepage.xhtml" id="titlepage.xhtml" media-type="application/xhtml+xml" properties="svg"/>
+		<item href="text/uncopyright.xhtml" id="uncopyright.xhtml" media-type="application/xhtml+xml"/>
+		<item href="toc.xhtml" id="toc.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+	</manifest>
+	<spine>
+		<itemref idref="titlepage.xhtml"/>
+		<itemref idref="imprint.xhtml"/>
+		<itemref idref="chapter-1.xhtml"/>
+		<itemref idref="colophon.xhtml"/>
+		<itemref idref="uncopyright.xhtml"/>
+	</spine>
+</package>


### PR DESCRIPTION
For example, if a contributor has two Wikipedia or NACOAF entries. This typically happens when a new contributor is manually added by copying and pasting an existing contributor’s code, but the rel attribute is left untouched.