### PR TITLE
Avoid catastrophic bactracking in t-017

### DIFF
--- a/se/se_epub_lint.py
+++ b/se/se_epub_lint.py
@@ -2856,7 +2856,8 @@ def _lint_xhtml_typography_checks(self: 'SeEpub', source_file: SourceFile, dom: 
 
 		# ...and also check for ending punctuation inside `<em>` elements, if it looks like a *part* of a clause instead of a whole clause.
 		# If the `<em>` is preceded by an em dash or quotes, or if there's punctuation and a space before it, then it's presumed to be a whole clause.
-		line_matches = [ (match.strip(), line_num) for (match, line_num) in source_file.findall(r"(?<!.[—“‘>]|[!\.\?…;:]\s)<em>(?:\w+?\s*)+[\.,\!\?;]</em>") if match.islower()]
+		# The `++` is used to avoid catastrophic backtracking (https://github.com/standardebooks/tools/issues/1003)
+		line_matches = [ (match.strip(), line_num) for (match, line_num) in source_file.findall(r"(?<!.[—“‘>]|[!\.\?…;:]\s)<em>(?:\w+?\s*)++[\.,\!\?;]</em>") if match.islower()]
 
 		submessages = LintSubmessage.from_nodes(nodes) + LintSubmessage.from_matches(line_matches)
 		if submessages:

--- a/tests/lint/typography/t-017/golden/t-017-out.txt
+++ b/tests/lint/typography/t-017/golden/t-017-out.txt
@@ -1,0 +1,4 @@
+t-017 [Manual Review] chapter-1.xhtml Ending punctuation inside formatting like bold, small caps, or italics. Hint: Ending punctuation is only allowed within formatting if the phrase is an independent clause.
+ Line 12:       <em>there.</em>
+ Line 13:       <em>rather quickly,</em>
+ Line 15:       <em>wehrmachtnachrichtungenverhindungen.</em>

--- a/tests/lint/typography/t-017/in/src/epub/text/chapter-1.xhtml
+++ b/tests/lint/typography/t-017/in/src/epub/text/chapter-1.xhtml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/" xml:lang="en-GB">
+	<head>
+		<title>I</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="bodymatter z3998:fiction">
+		<section id="chapter-1" epub:type="chapter">
+			<h2 epub:type="z3998:ordinal z3998:roman">I</h2>
+			<!-- invalid -->
+			<p>Hello <em>there.</em></p>
+			<p>He ran <em>rather quickly,</em> then stopped.</p>
+			<!-- this differs from the valid one below because it is all lower-case -->
+			<p>He was Chief of <em>wehrmachtnachrichtungenverhindungen.</em></p>
+			<!-- valid -->
+			<!-- long example to detect performance regressions (https://github.com/standardebooks/tools/issues/1003) -->
+			<p>He was Chief of <em>Wehrmachtnachrichtungenverhindungen</em>.</p>
+		</section>
+	</body>
+</html>


### PR DESCRIPTION
By making the (\w+\s*)+ sub-pattern possessive: There is no reason for the regex engine to backtrack in this pattern if it fails to match, as neither \w nor \s contains any of the subsequent punctuation that this lint is concerned with.

Add a basic test for this lint to prevent regressions here: Without the associated fix, the test never terminates.

Fixes #1003