### PR TITLE
add-file: Add chapter, book and part options

### DIFF
--- a/se/commands/add_file.py
+++ b/se/commands/add_file.py
@@ -49,7 +49,7 @@ def add_file(plain_output: bool) -> int: # pylint: disable=unused-argument
 	Entry point for `se add-file`.
 	"""
 
-	file_types = ["dedication", "dramatis-personae", "endnotes", "epigraph", "glossary", "halftitlepage", "ignore", "loi"]
+	file_types = ["chapter", "dedication", "dramatis-personae", "endnotes", "epigraph", "glossary", "halftitlepage", "ignore", "loi", "part"]
 
 	parser = argparse.ArgumentParser(description="Add a Standard Ebooks template file and any accompanying CSS.", prog="[command]se[/] [subcommand]add-file[/]", formatter_class=SeHelpFormatter)
 	parser.add_argument("-f", "--force", dest="force", action="store_true", help="Overwrite any existing files.")
@@ -69,6 +69,13 @@ def add_file(plain_output: bool) -> int: # pylint: disable=unused-argument
 
 		try:
 			match args.file_type:
+				case "chapter":
+					dest_path = se_epub.content_path / "text/chapter-.xhtml"
+
+					_copy_file("chapter-template-add-file.xhtml", dest_path, args.force)
+
+					_replace_languague(dest_path, se_epub.language)
+
 				case "dedication":
 					dest_path = se_epub.content_path / "text/dedication.xhtml"
 
@@ -147,6 +154,13 @@ def add_file(plain_output: bool) -> int: # pylint: disable=unused-argument
 					dest_path = se_epub.content_path / "text/loi.xhtml"
 
 					_copy_file("loi.xhtml", dest_path, args.force)
+
+					_replace_languague(dest_path, se_epub.language)
+
+				case "part":
+					dest_path = se_epub.content_path / "text/part-.xhtml"
+
+					_copy_file("part-template.xhtml", dest_path, args.force)
 
 					_replace_languague(dest_path, se_epub.language)
 

--- a/se/completions/bash/se
+++ b/se/completions/bash/se
@@ -111,7 +111,7 @@ _se(){
 		case "${COMP_WORDS[1]}" in
 			add-file)
 				_se_compgen_words "-f --force -h --help" "${cur}"
-				_se_compgen_words "dedication dramatis-personae endnotes epigraph glossary halftitlepage ignore loi" "${cur}"
+				_se_compgen_words "chapter dedication dramatis-personae endnotes epigraph glossary halftitlepage ignore loi part" "${cur}"
 				_se_compgen_dirs ".*" "${cur}"
 				;;
 			british2american)

--- a/se/completions/fish/se.fish
+++ b/se/completions/fish/se.fish
@@ -31,7 +31,7 @@ complete -c se -n "__fish_se_no_subcommand" -s v -l version -x -d "Print version
 complete -c se -n "__fish_se_no_subcommand" -a add-file -d "Add a Standard Ebooks template file and any accompanying CSS."
 complete -c se -A -n "__fish_seen_subcommand_from add-file" -s f -l force -x -d "Overwrite any existing files."
 complete -c se -A -n "__fish_seen_subcommand_from add-file" -s h -l help -x -d "Show this help message and exit."
-complete -c se -A -n "__fish_seen_subcommand_from add-file" -a "dedication dramatis-personae endnotes epigraph glossary halftitlepage ignore loi" -d "The type of file to add."
+complete -c se -A -n "__fish_seen_subcommand_from add-file" -a "chapter dedication dramatis-personae endnotes epigraph glossary halftitlepage ignore loi part" -d "The type of file to add."
 
 complete -c se -n "__fish_se_no_subcommand" -a british2american -d "Try to convert British quote style to American quote style. Quotes must already be typogrified using `se` `typogrify`. This script isn’t perfect; proofreading is required, especially near closing quotes near to em-dashes."
 complete -c se -A -n "__fish_seen_subcommand_from british2american" -s f -l force -x -d "Force conversion of quote style."

--- a/se/completions/zsh/_se
+++ b/se/completions/zsh/_se
@@ -78,7 +78,7 @@ case $state in
 				_arguments -s \
 					{-f,--force}'[Overwrite any existing files.]' \
 					{-h,--help}'[Show this help message and exit.]' \
-					'1:The type of file to add.:(dedication dramatis-personae endnotes epigraph glossary halftitlepage ignore loi)' \
+					'1:The type of file to add.:(chapter dedication dramatis-personae endnotes epigraph glossary halftitlepage ignore loi part)' \
 					'*:A Standard Ebooks source directory.:_directories'
 				;;
 			british2american)

--- a/se/data/templates/chapter-template-add-file.xhtml
+++ b/se/data/templates/chapter-template-add-file.xhtml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="LANG">
+	<head>
+		<title>TITLE</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="bodymatter z3998:fiction">
+		<section id="chapter-1" epub:type="chapter">
+			<h2 epub:type="title">TITLE</h2>
+			<p>TEXT</p>
+		</section>
+	</body>
+</html>

--- a/se/data/templates/part-template.xhtml
+++ b/se/data/templates/part-template.xhtml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="LANG">
+	<head>
+		<title>Part I</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="bodymatter z3998:fiction">
+		<section id="part-1" epub:type="part">
+			<h3>
+				<span epub:type="se:label">Part</span>
+				<span epub:type="z3998:ordinal z3998:roman">I</span>
+			</h3>
+		</section>
+	</body>
+</html>


### PR DESCRIPTION
After reviewing the manual, especially [7.1.5.1](https://standardebooks.org/manual/1.9.0/single-page#7.1.5.1), it seemed to make most sense to add both `book` and `part` alongside `chapter`. I know that it varies quite a lot which `epub:type` is associated with `book`: it can be division, part, or even chapter; but the templates are always going to need to be edited further by the producer anyway, so I don't think this undermines the utility of being able to quickly generate the basic skeleton with the `add-file` command.

If you don't think all three of these options are useful, let me know which you want excluded.

Also, contrary to what I said in the issue, it does seem necessary to have a chapter template for this purpose that is distinct from the one used by `split-file`. Let me know if you disagree about that, or anything else here, and I'll make the necessary changes.

I also noticed a typo in a function name in `add-file.py`: `_replace_languague` should be `_replace_language`. It doesn't affect any functionality because the typo appears throughout. I'll wait until this is merged or closed to fix that in a separate PR.

resolves #1006