### PR TITLE
modernize-spelling: Bagdad -> Baghdad

### DIFF
--- a/se/spelling.py
+++ b/se/spelling.py
@@ -157,6 +157,7 @@ def modernize_spelling(xhtml: str) -> str:
 	xhtml = regex.sub(r"\b([Aa])ny thing\b", r"\1nything", xhtml)			# any thing -> anything
 	xhtml = regex.sub(r"\b([Aa])ny where\b", r"\1nywhere", xhtml)			# any where -> anywhere
 	xhtml = regex.sub(r"\b([Aa])ukward", r"\1wkward", xhtml)			# aukward -> awkward
+	xhtml = regex.sub(r"Bagdad", r"Baghdad", xhtml)				# Bagdad -> Baghdad
 	xhtml = regex.sub(r"\b([Bb])awble", r"\1auble", xhtml)				# bawble -> bauble
 	xhtml = regex.sub(r"\b([Bb])bee[’']s[ \-]wax\b", r"\1eeswax", xhtml)		# bee’s-wax -> beeswax
 	xhtml = regex.sub(r"\b([Bb])efal(s?)\b", r"\1efall\2", xhtml)			# befal -> befall


### PR DESCRIPTION
This is my first time making any updates to the toolset, so please tell me if I got the idea correctly.

From what I understand, the ```words``` file has words that need to lose the hyphen, correct? Or am I reading the code incorrectly?

I also noticed that some words have different lines for their capitalized and non-capitalized versions; is there a particular reason for that? I'm trying to understand.